### PR TITLE
fix: replay issues

### DIFF
--- a/core/scheduler/service/replay_service.go
+++ b/core/scheduler/service/replay_service.go
@@ -43,6 +43,10 @@ func (r ReplayService) CreateReplay(ctx context.Context, tenant tenant.Tenant, j
 		return uuid.Nil, fmt.Errorf("unable to get job details from DB for jobName: %s, project:%s,  error:%w ", jobName, tenant.ProjectName().String(), err)
 	}
 
+	if subjectJob.Job.Tenant.NamespaceName() != tenant.NamespaceName() {
+		return uuid.Nil, fmt.Errorf("job %s does not exist in %s namespace", jobName, tenant.NamespaceName().String())
+	}
+
 	jobCron, err := cron.ParseCronSchedule(subjectJob.Schedule.Interval)
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("encountered unexpected error when parsing job cron interval for job %s: %w", jobName, err)

--- a/core/scheduler/service/replay_worker.go
+++ b/core/scheduler/service/replay_worker.go
@@ -164,7 +164,7 @@ func (w ReplayWorker) processReplayedRequest(ctx context.Context, replayReq *sch
 	}
 
 	updatedReplayMap := identifyUpdatedRunStatus(replayReq.Runs, incomingRuns)
-	updatedRuns := scheduler.JobRunStatusList(incomingRuns).MergeWithUpdatedRuns(updatedReplayMap)
+	updatedRuns := scheduler.JobRunStatusList(replayReq.Runs).MergeWithUpdatedRuns(updatedReplayMap)
 	inProgressRuns := scheduler.JobRunStatusList(updatedRuns).GetSortedRunsByStates([]scheduler.State{scheduler.StateReplayed})
 	failedRuns := scheduler.JobRunStatusList(updatedRuns).GetSortedRunsByStates([]scheduler.State{scheduler.StateFailed})
 

--- a/core/scheduler/service/replay_worker.go
+++ b/core/scheduler/service/replay_worker.go
@@ -141,7 +141,7 @@ func (w ReplayWorker) processPartialReplayedRequest(ctx context.Context, replayR
 		w.l.Info("cleared [%s] [%s] run for replay %s", replayReq.Replay.JobName().String(), toBeReplayedRuns[0].ScheduledAt, replayReq.Replay.ID().String())
 
 		updatedReplayMap[toBeReplayedRuns[0].ScheduledAt] = scheduler.StateReplayed
-		updatedRuns = scheduler.JobRunStatusList(incomingRuns).MergeWithUpdatedRuns(updatedReplayMap)
+		updatedRuns = scheduler.JobRunStatusList(updatedRuns).MergeWithUpdatedRuns(updatedReplayMap)
 	}
 
 	pendingRuns := scheduler.JobRunStatusList(updatedRuns).GetSortedRunsByStates([]scheduler.State{scheduler.StatePending})

--- a/core/scheduler/service/replay_worker_test.go
+++ b/core/scheduler/service/replay_worker_test.go
@@ -35,6 +35,7 @@ func TestReplayWorker(t *testing.T) {
 		EndDate:   endTime,
 	}
 	scheduledTime2 := scheduledTime1.Add(24 * time.Hour)
+	scheduledTime3 := scheduledTime2.Add(24 * time.Hour)
 	executionTime1 := scheduledTime1.Add(-24 * time.Hour)
 	executionTime2 := executionTime1.Add(24 * time.Hour)
 	jobCronStr := "0 12 * * *"
@@ -255,7 +256,7 @@ func TestReplayWorker(t *testing.T) {
 			replayWorker.Process(replayReq)
 		})
 
-		t.Run("should able to process partial replayed request", func(t *testing.T) {
+		t.Run("should able to process partial replayed request with the recent run status is success", func(t *testing.T) {
 			replayRepository := new(ReplayRepository)
 			defer replayRepository.AssertExpectations(t)
 
@@ -276,6 +277,10 @@ func TestReplayWorker(t *testing.T) {
 						ScheduledAt: scheduledTime2,
 						State:       scheduler.StatePending,
 					},
+					{
+						ScheduledAt: scheduledTime3,
+						State:       scheduler.StatePending,
+					},
 				},
 			}
 			updatedRuns1 := []*scheduler.JobRunStatus{
@@ -285,7 +290,11 @@ func TestReplayWorker(t *testing.T) {
 				},
 				{
 					ScheduledAt: scheduledTime2,
-					State:       scheduler.StatePending,
+					State:       scheduler.StateFailed,
+				},
+				{
+					ScheduledAt: scheduledTime3,
+					State:       scheduler.StateFailed,
 				},
 			}
 			updatedRuns2 := []*scheduler.JobRunStatus{
@@ -297,12 +306,80 @@ func TestReplayWorker(t *testing.T) {
 					ScheduledAt: scheduledTime2,
 					State:       scheduler.StateReplayed,
 				},
+				{
+					ScheduledAt: scheduledTime3,
+					State:       scheduler.StatePending,
+				},
 			}
 
 			jobRepository.On("GetJobDetails", mock.Anything, projName, jobAName).Return(jobAWithDetails, nil)
 			sch.On("GetJobRuns", mock.Anything, tnnt, runsCriteriaJobA, jobCron).Return(updatedRuns1, nil).Once()
 			sch.On("Clear", mock.Anything, tnnt, jobAName, scheduledTime2.Add(-24*time.Hour)).Return(nil)
-			replayRepository.On("UpdateReplay", mock.Anything, replayReq.Replay.ID(), scheduler.ReplayStateReplayed, updatedRuns2, "").Return(nil).Once()
+			replayRepository.On("UpdateReplay", mock.Anything, replayReq.Replay.ID(), scheduler.ReplayStatePartialReplayed, updatedRuns2, "").Return(nil).Once()
+
+			replayWorker := service.NewReplayWorker(logger, replayRepository, sch, jobRepository, replayServerConfig)
+			replayWorker.Process(replayReq)
+		})
+		t.Run("should able to process partial replayed request with the recent run status is failed", func(t *testing.T) {
+			replayRepository := new(ReplayRepository)
+			defer replayRepository.AssertExpectations(t)
+
+			sch := new(mockReplayScheduler)
+			defer sch.AssertExpectations(t)
+
+			jobRepository := new(JobRepository)
+			defer jobRepository.AssertExpectations(t)
+
+			replayReq := &scheduler.ReplayWithRun{
+				Replay: scheduler.NewReplay(uuid.New(), jobAName, tnnt, replayConfigParallel, scheduler.ReplayStatePartialReplayed, time.Now()),
+				Runs: []*scheduler.JobRunStatus{
+					{
+						ScheduledAt: scheduledTime1,
+						State:       scheduler.StateReplayed,
+					},
+					{
+						ScheduledAt: scheduledTime2,
+						State:       scheduler.StatePending,
+					},
+					{
+						ScheduledAt: scheduledTime3,
+						State:       scheduler.StatePending,
+					},
+				},
+			}
+			updatedRuns1 := []*scheduler.JobRunStatus{
+				{
+					ScheduledAt: scheduledTime1,
+					State:       scheduler.StateFailed,
+				},
+				{
+					ScheduledAt: scheduledTime2,
+					State:       scheduler.StateFailed,
+				},
+				{
+					ScheduledAt: scheduledTime3,
+					State:       scheduler.StateFailed,
+				},
+			}
+			updatedRuns2 := []*scheduler.JobRunStatus{
+				{
+					ScheduledAt: scheduledTime1,
+					State:       scheduler.StateFailed,
+				},
+				{
+					ScheduledAt: scheduledTime2,
+					State:       scheduler.StateReplayed,
+				},
+				{
+					ScheduledAt: scheduledTime3,
+					State:       scheduler.StatePending,
+				},
+			}
+
+			jobRepository.On("GetJobDetails", mock.Anything, projName, jobAName).Return(jobAWithDetails, nil)
+			sch.On("GetJobRuns", mock.Anything, tnnt, runsCriteriaJobA, jobCron).Return(updatedRuns1, nil).Once()
+			sch.On("Clear", mock.Anything, tnnt, jobAName, scheduledTime2.Add(-24*time.Hour)).Return(nil)
+			replayRepository.On("UpdateReplay", mock.Anything, replayReq.Replay.ID(), scheduler.ReplayStatePartialReplayed, updatedRuns2, "").Return(nil).Once()
 
 			replayWorker := service.NewReplayWorker(logger, replayRepository, sch, jobRepository, replayServerConfig)
 			replayWorker.Process(replayReq)
@@ -326,6 +403,10 @@ func TestReplayWorker(t *testing.T) {
 					},
 					{
 						ScheduledAt: scheduledTime2,
+						State:       scheduler.StatePending,
+					},
+					{
+						ScheduledAt: scheduledTime3,
 						State:       scheduler.StatePending,
 					},
 				},


### PR DESCRIPTION
Issues encountered:
1. Replay request created even though the namespace name is invalid.
2. Replay with sequential & parallel mode has its runs updated with the scheduler's state, even though the runs are not processed yet.