### PR TITLE
Fix: optimus job failure alerts 

### DIFF
--- a/ext/scheduler/airflow/__lib.py
+++ b/ext/scheduler/airflow/__lib.py
@@ -310,16 +310,15 @@ def optimus_notify(context, event_meta):
     if len(failure_message)>0:
         log.info(f'failures: {failure_message}')
     
-    task_instance = {}
-
+    task_instance = context.get('task_instance')
+    
     if event_meta["event_type"] == "TYPE_FAILURE" :
         dag_run = context['dag_run']
         tis = dag_run.get_task_instances()
         for ti in tis:
             if ti.state == "failed":
                 task_instance = ti
-    else :
-        task_instance = context.get('task_instance')
+                break
 
     message = {
         "log_url": task_instance.log_url,

--- a/ext/scheduler/airflow/__lib.py
+++ b/ext/scheduler/airflow/__lib.py
@@ -310,7 +310,17 @@ def optimus_notify(context, event_meta):
     if len(failure_message)>0:
         log.info(f'failures: {failure_message}')
     
-    task_instance = context.get('task_instance')
+    task_instance = {}
+
+    if event_meta["event_type"] == "TYPE_FAILURE" :
+        dag_run = context['dag_run']
+        tis = dag_run.get_task_instances()
+        for ti in tis:
+            if ti.state == "failed":
+                task_instance = ti
+    else :
+        task_instance = context.get('task_instance')
+
     message = {
         "log_url": task_instance.log_url,
         "task_id": task_instance.task_id,

--- a/ext/scheduler/airflow/__lib.py
+++ b/ext/scheduler/airflow/__lib.py
@@ -12,6 +12,7 @@ from airflow.models import (XCOM_RETURN_KEY, Variable, XCom, TaskReschedule )
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.providers.slack.operators.slack import SlackAPIPostOperator
 from airflow.sensors.base import BaseSensorOperator
+from airflow.utils.state import TaskInstanceState
 from croniter import croniter
 from kubernetes.client import models as k8s
 
@@ -316,7 +317,7 @@ def optimus_notify(context, event_meta):
         dag_run = context['dag_run']
         tis = dag_run.get_task_instances()
         for ti in tis:
-            if ti.state == "failed":
+            if ti.state == TaskInstanceState.FAILED:
                 task_instance = ti
                 break
 


### PR DESCRIPTION
Slack Job Failure Alerts should capture the task id of failed tasks 