### PR TITLE
fix: show wrapped error when calling method error

### DIFF
--- a/ext/store/bigquery/client_test.go
+++ b/ext/store/bigquery/client_test.go
@@ -118,7 +118,7 @@ func TestClientProvider(t *testing.T) {
 
 		_, err := provider.Get(ctx, "")
 		assert.NotNil(t, err)
-		assert.EqualError(t, err, "internal error for entity BigqueryStore: failed to read account")
+		assert.EqualError(t, err, "internal error for entity BigqueryStore: failed to read account: unexpected end of JSON input")
 	})
 
 	t.Run("creates a new client with json", func(t *testing.T) {

--- a/ext/store/bigquery/copier_test.go
+++ b/ext/store/bigquery/copier_test.go
@@ -25,7 +25,7 @@ func TestTableCopier(t *testing.T) {
 
 			_, err := copierHandle.Run(ctx)
 			assert.Error(t, err)
-			assert.EqualError(t, err, "internal error for entity BigqueryStore: not able to create copy job")
+			assert.EqualError(t, err, "internal error for entity BigqueryStore: not able to create copy job: error in creating run")
 		})
 		t.Run("return copy job when successful", func(t *testing.T) {
 			bqCopier := new(mockBQCopier)

--- a/ext/store/bigquery/job_test.go
+++ b/ext/store/bigquery/job_test.go
@@ -24,7 +24,7 @@ func TestJob(t *testing.T) {
 
 			err := copyJob.Wait(ctx)
 			assert.Error(t, err)
-			assert.EqualError(t, err, "internal error for entity BigqueryStore: error while wait for bq job")
+			assert.EqualError(t, err, "internal error for entity BigqueryStore: error while wait for bq job: error in wait")
 		})
 		t.Run("return no error when successful", func(t *testing.T) {
 			bqJob := new(mockBQJob)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -125,12 +125,12 @@ func As(err error, target any) bool {
 }
 
 func (e *DomainError) Error() string {
-	subError := ""
-	if errors.Is(e.WrappedErr, &DomainError{}) {
-		subError = ": " + e.WrappedErr.Error()
+	if e.WrappedErr != nil {
+		return fmt.Sprintf("%v for entity %v: %v: %s",
+			e.ErrorType.String(), e.Entity, e.Message, e.WrappedErr.Error())
 	}
-	return fmt.Sprintf("%v for entity %v: %v%s",
-		e.ErrorType.String(), e.Entity, e.Message, subError)
+	return fmt.Sprintf("%v for entity %v: %v",
+		e.ErrorType.String(), e.Entity, e.Message)
 }
 
 func (e *DomainError) Unwrap() error {


### PR DESCRIPTION
This PR is to show the sub-error in a wrapped error, if it exist. This is because at the moment, the sub-error is not shown. And when there's error in production, the actual error message is sometime required.