### PR TITLE
fix: unable to delete upstreams if no longer upstream found issue

### DIFF
--- a/internal/store/postgres/job/job_repository.go
+++ b/internal/store/postgres/job/job_repository.go
@@ -489,8 +489,8 @@ func (j JobRepository) ReplaceUpstreams(ctx context.Context, jobsWithUpstreams [
 	}
 
 	var jobFullName []string
-	for _, upstream := range storageJobUpstreams {
-		jobFullName = append(jobFullName, upstream.getJobFullName())
+	for _, jobWithUpstream := range jobsWithUpstreams {
+		jobFullName = append(jobFullName, jobWithUpstream.Job().FullName())
 	}
 
 	if err = j.deleteUpstreams(ctx, tx, jobFullName); err != nil {

--- a/internal/store/postgres/job/job_repository.go
+++ b/internal/store/postgres/job/job_repository.go
@@ -493,7 +493,7 @@ func (j JobRepository) ReplaceUpstreams(ctx context.Context, jobsWithUpstreams [
 		jobFullName = append(jobFullName, jobWithUpstream.Job().FullName())
 	}
 
-	if err = j.deleteUpstreams(ctx, tx, jobFullName); err != nil {
+	if err = j.deleteUpstreamsByJobNames(ctx, tx, jobFullName); err != nil {
 		tx.Rollback(ctx)
 		return err
 	}
@@ -568,7 +568,7 @@ VALUES (
 	return nil
 }
 
-func (JobRepository) deleteUpstreams(ctx context.Context, tx pgx.Tx, jobUpstreams []string) error {
+func (JobRepository) deleteUpstreamsByJobNames(ctx context.Context, tx pgx.Tx, jobUpstreams []string) error {
 	deleteForProjectScope := `DELETE
 FROM job_upstream
 WHERE project_name || '/' || job_name = any ($1);`

--- a/internal/store/postgres/job/job_repository.go
+++ b/internal/store/postgres/job/job_repository.go
@@ -477,10 +477,10 @@ func (j *JobWithUpstream) getJobFullName() string {
 }
 
 func (j JobRepository) ReplaceUpstreams(ctx context.Context, jobsWithUpstreams []*job.WithUpstream) error {
-	var storageJobUpstreams []*JobWithUpstream
+	var jobUpstreams []*JobWithUpstream
 	for _, jobWithUpstreams := range jobsWithUpstreams {
-		upstream := toJobUpstream(jobWithUpstreams)
-		storageJobUpstreams = append(storageJobUpstreams, upstream...)
+		singleJobUpstreams := toJobUpstream(jobWithUpstreams)
+		jobUpstreams = append(jobUpstreams, singleJobUpstreams...)
 	}
 
 	tx, err := j.db.Begin(ctx)
@@ -497,7 +497,7 @@ func (j JobRepository) ReplaceUpstreams(ctx context.Context, jobsWithUpstreams [
 		tx.Rollback(ctx)
 		return err
 	}
-	if err = j.insertUpstreams(ctx, tx, storageJobUpstreams); err != nil {
+	if err = j.insertUpstreams(ctx, tx, jobUpstreams); err != nil {
 		tx.Rollback(ctx)
 		return err
 	}


### PR DESCRIPTION
When a job is updated and it no longer has any upstream, Optimus skipped the deletion of the upstream for the particular job. However, if at least 1 upstream left, the deletion of the rest of the upstream will work.