### PR TITLE
fix : add k8s pod timeout in the operator instead of dag default args

### DIFF
--- a/ext/scheduler/airflow/__lib.py
+++ b/ext/scheduler/airflow/__lib.py
@@ -27,6 +27,7 @@ TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 TIMESTAMP_MS_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 SCHEDULER_ERR_MSG = "scheduler_error"
+STARTUP_TIMEOUT_IN_SECS = int(Variable.get("startup_timeout_in_secs", default_var=2 * 60))
 
 def lookup_non_standard_cron_expression(expr: str) -> str:
     expr_mapping = {
@@ -46,6 +47,7 @@ def lookup_non_standard_cron_expression(expr: str) -> str:
 
 class SuperKubernetesPodOperator(KubernetesPodOperator):
     def __init__(self, *args, **kwargs):
+        kwargs["startup_timeout_seconds"] = STARTUP_TIMEOUT_IN_SECS
         super(SuperKubernetesPodOperator, self).__init__(*args, **kwargs)
         self.do_xcom_push = kwargs.get('do_xcom_push')
         self.namespace = kwargs.get('namespace')

--- a/ext/scheduler/airflow/dag/expected_dag.2.1.py
+++ b/ext/scheduler/airflow/dag/expected_dag.2.1.py
@@ -21,7 +21,6 @@ SENSOR_DEFAULT_TIMEOUT_IN_SECS = int(Variable.get("sensor_timeout_in_secs", defa
 DAG_RETRIES = int(Variable.get("dag_retries", default_var=3))
 DAG_RETRY_DELAY = int(Variable.get("dag_retry_delay_in_secs", default_var=5 * 60))
 DAGRUN_TIMEOUT_IN_SECS = int(Variable.get("dagrun_timeout_in_secs", default_var=3 * 24 * 60 * 60))
-STARTUP_TIMEOUT_IN_SECS = int(Variable.get("startup_timeout_in_secs", default_var=2 * 60))
 POOL_SENSOR = Variable.get("sensor_pool", default_var="default_pool")
 POOL_TASK = Variable.get("task_pool", default_var="default_pool")
 POOL_HOOK = Variable.get("hook_pool", default_var="default_pool")
@@ -37,7 +36,6 @@ default_args = {
     "depends_on_past": True,
     "retries": 2,
     "retry_delay": timedelta(seconds=100),
-    "startup_timeout_seconds": STARTUP_TIMEOUT_IN_SECS,
     "retry_exponential_backoff": True,
     "priority_weight": 2000,
     "start_date": datetime.strptime("2022-11-10T05:02:00", "%Y-%m-%dT%H:%M:%S"),

--- a/ext/scheduler/airflow/dag/expected_dag.2.4.py
+++ b/ext/scheduler/airflow/dag/expected_dag.2.4.py
@@ -21,7 +21,6 @@ SENSOR_DEFAULT_TIMEOUT_IN_SECS = int(Variable.get("sensor_timeout_in_secs", defa
 DAG_RETRIES = int(Variable.get("dag_retries", default_var=3))
 DAG_RETRY_DELAY = int(Variable.get("dag_retry_delay_in_secs", default_var=5 * 60))
 DAGRUN_TIMEOUT_IN_SECS = int(Variable.get("dagrun_timeout_in_secs", default_var=3 * 24 * 60 * 60))
-STARTUP_TIMEOUT_IN_SECS = int(Variable.get("startup_timeout_in_secs", default_var=2 * 60))
 POOL_SENSOR = Variable.get("sensor_pool", default_var="default_pool")
 POOL_TASK = Variable.get("task_pool", default_var="default_pool")
 POOL_HOOK = Variable.get("hook_pool", default_var="default_pool")
@@ -37,7 +36,6 @@ default_args = {
     "depends_on_past": True,
     "retries": 2,
     "retry_delay": timedelta(seconds=100),
-    "startup_timeout_seconds": STARTUP_TIMEOUT_IN_SECS,
     "retry_exponential_backoff": True,
     "priority_weight": 2000,
     "start_date": datetime.strptime("2022-11-10T05:02:00", "%Y-%m-%dT%H:%M:%S"),

--- a/ext/scheduler/airflow/dag/template/dag.2.1.py.tmpl
+++ b/ext/scheduler/airflow/dag/template/dag.2.1.py.tmpl
@@ -22,7 +22,6 @@ SENSOR_DEFAULT_TIMEOUT_IN_SECS = int(Variable.get("sensor_timeout_in_secs", defa
 DAG_RETRIES = int(Variable.get("dag_retries", default_var=3))
 DAG_RETRY_DELAY = int(Variable.get("dag_retry_delay_in_secs", default_var=5 * 60))
 DAGRUN_TIMEOUT_IN_SECS = int(Variable.get("dagrun_timeout_in_secs", default_var=3 * 24 * 60 * 60))
-STARTUP_TIMEOUT_IN_SECS = int(Variable.get("startup_timeout_in_secs", default_var=2 * 60))
 POOL_SENSOR = Variable.get("sensor_pool", default_var="default_pool")
 POOL_TASK = Variable.get("task_pool", default_var="default_pool")
 POOL_HOOK = Variable.get("hook_pool", default_var="default_pool")
@@ -41,7 +40,6 @@ default_args = {
     "depends_on_past": {{ if .JobDetails.Schedule.DependsOnPast }}True{{- else -}}False{{- end -}},
     "retries": {{ if gt .JobDetails.Retry.Count 0 -}} {{.JobDetails.Retry.Count}} {{- else -}} DAG_RETRIES {{- end}},
     "retry_delay": {{ if gt .JobDetails.Retry.Delay 0 -}} timedelta(seconds={{.JobDetails.Retry.Delay}}) {{- else -}} timedelta(seconds=DAG_RETRY_DELAY) {{- end}},
-    "startup_timeout_seconds": STARTUP_TIMEOUT_IN_SECS,
     "retry_exponential_backoff": {{if .JobDetails.Retry.ExponentialBackoff -}}True{{- else -}}False{{- end -}},
     "priority_weight": {{.Priority}},
     "start_date": datetime.strptime({{ .JobDetails.Schedule.StartDate.Format "2006-01-02T15:04:05" | quote }}, "%Y-%m-%dT%H:%M:%S"),

--- a/ext/scheduler/airflow/dag/template/dag.2.4.py.tmpl
+++ b/ext/scheduler/airflow/dag/template/dag.2.4.py.tmpl
@@ -22,7 +22,6 @@ SENSOR_DEFAULT_TIMEOUT_IN_SECS = int(Variable.get("sensor_timeout_in_secs", defa
 DAG_RETRIES = int(Variable.get("dag_retries", default_var=3))
 DAG_RETRY_DELAY = int(Variable.get("dag_retry_delay_in_secs", default_var=5 * 60))
 DAGRUN_TIMEOUT_IN_SECS = int(Variable.get("dagrun_timeout_in_secs", default_var=3 * 24 * 60 * 60))
-STARTUP_TIMEOUT_IN_SECS = int(Variable.get("startup_timeout_in_secs", default_var=2 * 60))
 POOL_SENSOR = Variable.get("sensor_pool", default_var="default_pool")
 POOL_TASK = Variable.get("task_pool", default_var="default_pool")
 POOL_HOOK = Variable.get("hook_pool", default_var="default_pool")
@@ -41,7 +40,6 @@ default_args = {
     "depends_on_past": {{ if .JobDetails.Schedule.DependsOnPast }}True{{- else -}}False{{- end -}},
     "retries": {{ if gt .JobDetails.Retry.Count 0 -}} {{.JobDetails.Retry.Count}} {{- else -}} DAG_RETRIES {{- end}},
     "retry_delay": {{ if gt .JobDetails.Retry.Delay 0 -}} timedelta(seconds={{.JobDetails.Retry.Delay}}) {{- else -}} timedelta(seconds=DAG_RETRY_DELAY) {{- end}},
-    "startup_timeout_seconds": STARTUP_TIMEOUT_IN_SECS,
     "retry_exponential_backoff": {{if .JobDetails.Retry.ExponentialBackoff -}}True{{- else -}}False{{- end -}},
     "priority_weight": {{.Priority}},
     "start_date": datetime.strptime({{ .JobDetails.Schedule.StartDate.Format "2006-01-02T15:04:05" | quote }}, "%Y-%m-%dT%H:%M:%S"),


### PR DESCRIPTION
fix incorrect arg `startup_timeout_in_secs` which is earlier passed to dag default args and pass it to kubernetespodoperator.

Note : Kubernetespodoperator explicitly cleans up the pod after the above timeout config.