### PR TITLE
fix: playground window navigation not working

### DIFF
--- a/client/cmd/playground/window/model.go
+++ b/client/cmd/playground/window/model.go
@@ -50,17 +50,17 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msgStr {
 	case "ctrl+c", "q":
 		return m, tea.Quit
-	case "up":
+	case "up", "w":
 		m.handleUp()
-	case "down":
+	case "down", "s":
 		m.handleDown()
-	case "left":
+	case "left", "a":
 		m.handleLeft()
-	case "right":
+	case "right", "d":
 		m.handleRight()
-	case "shift+up":
+	case "shift+up", "W":
 		m.handleIncrement()
-	case "shift+down":
+	case "shift+down", "S":
 		m.handleDecrement()
 	case "M", "h", "-",
 		"1", "2", "3", "4", "5",
@@ -108,8 +108,8 @@ func (m *model) generateWindowInputHintView() string {
 - d: truncate to day
 - h: truncate to hour
 
-press shift+up to increment value
-press shift+down to decrement value
+press (shift+up) or (shift+w) to increment value
+press (shift+down) or (shift+s) to decrement value
 `
 	case pointToOffset:
 		hint = `valid formats are:
@@ -128,32 +128,32 @@ both n and m can NOT be negative
 	case pointToYear:
 		hint = `year of the scheduled time
 
-press shift+up to increment value
-press shift+down to decrement value
+press (shift+up) or (shift+w) to increment value
+press (shift+down) or (shift+s) to decrement value
 `
 	case pointToMonth:
 		hint = `month of the scheduled time
 
-press shift+up to increment value
-press shift+down to decrement value
+press (shift+up) or (shift+w) to increment value
+press (shift+down) or (shift+s) to decrement value
 `
 	case pointToDay:
 		hint = `day of the scheduled time
 
-press shift+up to increment value
-press shift+down to decrement value
+press (shift+up) or (shift+w) to increment value
+press (shift+down) or (shift+s) to decrement value
 `
 	case pointToHour:
 		hint = `hour of the scheduled time
 
-press shift+up to increment value
-press shift+down to decrement value
+press (shift+up) or (shift+w) to increment value
+press (shift+down) or (shift+s) to decrement value
 `
 	case pointToMinute:
 		hint = `minute of the scheduled time
 
-press shift+up to increment value
-press shift+down to decrement value
+press (shift+up) or (shift+w) to increment value
+press (shift+down) or (shift+s) to decrement value
 `
 	}
 	return hint

--- a/client/cmd/playground/window/window.go
+++ b/client/cmd/playground/window/window.go
@@ -24,9 +24,26 @@ func NewCommand() *cobra.Command {
 }
 
 func (j *command) RunE(_ *cobra.Command, _ []string) error {
-	j.log.Info("Hi, this is an interactive CLI to play around with window configuration.")
-	j.log.Info("Navigate around the available configurations input with arrow keys.")
-	j.log.Info("If you want to quit, just press 'q' or 'ctr+c' key.\n")
+	message := `
+ __          __    _                              
+ \ \        / /   | |                             
+  \ \  /\  / /___ | |  ___  ___   _ __ ___    ___ 
+   \ \/  \/ // _ \| | / __|/ _ \ | '_ ' _ \  / _ \
+    \  /\  /|  __/| || (__| (_) || | | | | ||  __/
+     \/  \/  \___||_| \___|\___/ |_| |_| |_| \___|
+                                                  
+                                                  
+Hi, this is an interactive CLI to play around with window configuration.
+You can navigate around the available configurations with the following keys:
+   ______________________________
+  |  up   | : arrow up    ↑ or w |
+  | down  | : arrow down  ↓ or s |
+  | right | : arrow right → or d |
+  | left  | : arrow left  ← or a |
+  | quit  | : q or ctrl+c        |
+   ------------------------------
+`
+	j.log.Info(message)
 	p := tea.NewProgram(newModel())
 	return p.Start()
 }


### PR DESCRIPTION
On certain terminal (currently being confirmed on default terminal under MacOS), navigation for incrementing value does not work. The quickest update to address this issue is by providing additional key to act on the same result, like increment or decrement.