### PR TITLE
fix: update validation error to include dataset name for easier discovery

### DIFF
--- a/ext/store/bigquery/batch.go
+++ b/ext/store/bigquery/batch.go
@@ -131,7 +131,7 @@ func (b *Batch) validateDataset(ctx context.Context, client Client) error {
 
 	dsHandle := client.DatasetHandleFrom(b.Dataset)
 	if !dsHandle.Exists(ctx) {
-		return errors.NotFound(EntityDataset, "dataset is not found")
+		return errors.NotFound(EntityDataset, "dataset ["+b.Dataset.FullName()+"] is not found")
 	}
 
 	return nil

--- a/ext/store/bigquery/batch_test.go
+++ b/ext/store/bigquery/batch_test.go
@@ -204,7 +204,7 @@ func TestBatches(t *testing.T) {
 		testParallel := parallel.NewRunner()
 		for _, batch := range batches {
 			actualError := batch.QueueJobs(ctx, accountSecret, testParallel)
-			assert.ErrorContains(t, actualError, "dataset is not found")
+			assert.ErrorContains(t, actualError, "dataset ["+tab1Dataset.FullName()+"] is not found")
 		}
 	})
 


### PR DESCRIPTION
This PR is to include dataset name when there's error when validating it. The purpose is to make it easier to discover if there's error when a large number of data is being processed.