### PR TITLE
fix: DSTART on replay 

### DIFF
--- a/ext/scheduler/airflow/dag/expected_dag.2.1.py
+++ b/ext/scheduler/airflow/dag/expected_dag.2.1.py
@@ -102,7 +102,6 @@ init_env_vars = [
     k8s.V1EnvVar(name="JOB_NAME", value='infra.billing.weekly-status-reports'),
     k8s.V1EnvVar(name="OPTIMUS_HOST", value='http://optimus.example.com'),
     k8s.V1EnvVar(name="PROJECT", value='example-proj'),
-    k8s.V1EnvVar(name="SCHEDULED_AT", value='{{ next_execution_date }}'),
 ]
 
 init_container = k8s.V1Container(

--- a/ext/scheduler/airflow/dag/expected_dag.2.4.py
+++ b/ext/scheduler/airflow/dag/expected_dag.2.4.py
@@ -102,7 +102,6 @@ init_env_vars = [
     k8s.V1EnvVar(name="JOB_NAME", value='infra.billing.weekly-status-reports'),
     k8s.V1EnvVar(name="OPTIMUS_HOST", value='http://optimus.example.com'),
     k8s.V1EnvVar(name="PROJECT", value='example-proj'),
-    k8s.V1EnvVar(name="SCHEDULED_AT", value='{{ data_interval_end }}'),
 ]
 
 init_container = k8s.V1Container(

--- a/ext/scheduler/airflow/dag/expected_dag.2.6.py
+++ b/ext/scheduler/airflow/dag/expected_dag.2.6.py
@@ -102,7 +102,6 @@ init_env_vars = [
     k8s.V1EnvVar(name="JOB_NAME", value='infra.billing.weekly-status-reports'),
     k8s.V1EnvVar(name="OPTIMUS_HOST", value='http://optimus.example.com'),
     k8s.V1EnvVar(name="PROJECT", value='example-proj'),
-    k8s.V1EnvVar(name="SCHEDULED_AT", value='{{ data_interval_end }}'),
 ]
 
 init_container = k8s.V1Container(

--- a/ext/scheduler/airflow/dag/template/dag.2.1.py.tmpl
+++ b/ext/scheduler/airflow/dag/template/dag.2.1.py.tmpl
@@ -132,7 +132,6 @@ init_env_vars = [
     k8s.V1EnvVar(name="JOB_NAME", value='{{$.JobDetails.Name}}'),
     k8s.V1EnvVar(name="OPTIMUS_HOST", value='{{$.Hostname}}'),
     k8s.V1EnvVar(name="PROJECT", value='{{$.Tenant.ProjectName.String}}'),
-    k8s.V1EnvVar(name="SCHEDULED_AT", value='{{ "{{ next_execution_date }}" }}'),
 ]
 
 init_container = k8s.V1Container(

--- a/ext/scheduler/airflow/dag/template/dag.2.4.py.tmpl
+++ b/ext/scheduler/airflow/dag/template/dag.2.4.py.tmpl
@@ -132,7 +132,6 @@ init_env_vars = [
     k8s.V1EnvVar(name="JOB_NAME", value='{{$.JobDetails.Name}}'),
     k8s.V1EnvVar(name="OPTIMUS_HOST", value='{{$.Hostname}}'),
     k8s.V1EnvVar(name="PROJECT", value='{{$.Tenant.ProjectName.String}}'),
-    k8s.V1EnvVar(name="SCHEDULED_AT", value='{{ "{{ data_interval_end }}" }}'),
 ]
 
 init_container = k8s.V1Container(

--- a/ext/scheduler/airflow/dag/template/dag.2.6.py.tmpl
+++ b/ext/scheduler/airflow/dag/template/dag.2.6.py.tmpl
@@ -132,7 +132,6 @@ init_env_vars = [
     k8s.V1EnvVar(name="JOB_NAME", value='{{$.JobDetails.Name}}'),
     k8s.V1EnvVar(name="OPTIMUS_HOST", value='{{$.Hostname}}'),
     k8s.V1EnvVar(name="PROJECT", value='{{$.Tenant.ProjectName.String}}'),
-    k8s.V1EnvVar(name="SCHEDULED_AT", value='{{ "{{ data_interval_end }}" }}'),
 ]
 
 init_container = k8s.V1Container(


### PR DESCRIPTION
derive `schedule time` by `execution_date` in airflow 2.1.4