### PR TITLE
fix: bug updating table to add cluster is not reflected

### DIFF
--- a/ext/store/bigquery/table.go
+++ b/ext/store/bigquery/table.go
@@ -71,6 +71,10 @@ func (t TableHandle) Update(ctx context.Context, res *resource.Resource) error {
 		}
 	}
 
+	if table.Cluster != nil {
+		metadataToUpdate.Clustering = toBQClustering(table.Cluster)
+	}
+
 	_, err = t.bqTable.Update(ctx, metadataToUpdate, "")
 	if err != nil {
 		var metaErr *googleapi.Error

--- a/ext/store/bigquery/table_test.go
+++ b/ext/store/bigquery/table_test.go
@@ -245,6 +245,9 @@ func TestTableHandle(t *testing.T) {
 						"type": "INTEGER",
 					},
 				},
+				"cluster": map[string]any{
+					"using": []string{"session"},
+				},
 				"partition": map[string]any{
 					"field": "product_day",
 					"type":  "DAY",


### PR DESCRIPTION
When updating an existing resource with type table in order to add cluster, there's a bug in a way the cluster is not applied. This PR attempts to fix this.