### PR TITLE
feat: add labels from job spec to job labels environment

### DIFF
--- a/core/scheduler/service/executor_input_compiler.go
+++ b/core/scheduler/service/executor_input_compiler.go
@@ -136,6 +136,15 @@ func (i InputCompiler) Compile(ctx context.Context, job *scheduler.JobWithDetail
 		"job_name":  job.Job.Name.String(),
 		"job_id":    job.Job.ID.String(),
 	}
+
+	if job.JobMetadata != nil {
+		for key, value := range job.JobMetadata.Labels {
+			if _, ok := jobLabelsToAdd[key]; !ok {
+				jobLabelsToAdd[key] = value
+			}
+		}
+	}
+
 	jobAttributionLabels := getJobLabelsString(jobLabelsToAdd)
 	if jobLabels, ok := confs[JobAttributionLabelsKey]; ok {
 		if len(jobLabels) == 0 {

--- a/core/scheduler/service/executor_input_compiler_test.go
+++ b/core/scheduler/service/executor_input_compiler_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -427,9 +428,17 @@ func TestExecutorCompiler(t *testing.T) {
 					"EXECUTION_TIME":  executedAt.Format(time.RFC3339),
 					"JOB_DESTINATION": job.Destination,
 					"hook.compiled":   "hook.val.compiled",
+					"JOB_LABELS":      "job_id=00000000-0000-0000-0000-000000000000,job_name=job1,namespace=ns1,project=proj1",
 				},
 				Secrets: map[string]string{"secret.hook.compiled": "hook.s.val.compiled"},
 				Files:   compiledFile,
+			}
+
+			assert.NotNil(t, inputExecutorResp)
+			if value, ok := inputExecutorResp.Configs["JOB_LABELS"]; ok {
+				splitValues := strings.Split(value, ",")
+				sort.Strings(splitValues)
+				inputExecutorResp.Configs["JOB_LABELS"] = strings.Join(splitValues, ",")
 			}
 			assert.Equal(t, expectedInputExecutor, inputExecutorResp)
 		})

--- a/core/scheduler/service/executor_input_compiler_test.go
+++ b/core/scheduler/service/executor_input_compiler_test.go
@@ -183,6 +183,12 @@ func TestExecutorCompiler(t *testing.T) {
 				Schedule: &scheduler.Schedule{
 					Interval: "0 * * * *",
 				},
+				JobMetadata: &scheduler.JobMetadata{
+					Labels: map[string]string{
+						"user-specified-label-key1": "user-specified-label-value-for-test-1",
+						"user-specified-label-key2": "user-specified-label-value-for-test-2",
+					},
+				},
 			}
 			config := scheduler.RunConfig{
 				Executor: scheduler.Executor{
@@ -272,7 +278,9 @@ func TestExecutorCompiler(t *testing.T) {
 					"project=proj1": true,
 					"namespace=ns1": true,
 					"job_name=job1": true,
-					"job_id=00000000-0000-0000-0000-000000000000": true,
+					"job_id=00000000-0000-0000-0000-000000000000":                     true,
+					"user-specified-label-key1=user-specified-label-value-for-test-1": true,
+					"user-specified-label-key2=user-specified-label-value-for-test-2": true,
 				}
 
 				for _, v := range strings.Split(inputExecutorResp.Configs["JOB_LABELS"], ",") {


### PR DESCRIPTION
This PR is to add labels from job spec, which are specified by the user, to the `JOB_LABELS` environment variables. This variable can then be used by the requiring plugins, like Transformers to add label for Big Query job.