### PR TITLE
feat: window playground v3

### DIFF
--- a/client/cmd/playground/window/constant.go
+++ b/client/cmd/playground/window/constant.go
@@ -9,16 +9,10 @@ const (
 	pointToHour   cursorPointer = "hour"
 	pointToMinute cursorPointer = "minute"
 
-	pointToTruncateTo cursorPointer = "truncate_to"
-	pointToOffset     cursorPointer = "offset"
-	pointToSize       cursorPointer = "size"
-)
-
-type truncateTo string
-
-const (
-	truncateToMonth truncateTo = "M"
-	truncateToWeek  truncateTo = "w"
-	truncateToDay   truncateTo = "d"
-	truncateToHour  truncateTo = "h"
+	pointToSizeInput      cursorPointer = "size_input"
+	pointToSizeUnit       cursorPointer = "size_unit"
+	pointToDelayInput     cursorPointer = "delay_input"
+	pointToDelayUnit      cursorPointer = "delay_unit"
+	pointToTruncateToUnit cursorPointer = "truncate_to_unit"
+	pointToLocationInput  cursorPointer = "location_input"
 )

--- a/client/cmd/playground/window/model.go
+++ b/client/cmd/playground/window/model.go
@@ -499,10 +499,12 @@ func (m *model) handleLeft() {
 
 func (m *model) handleDown() {
 	switch m.currentCursor {
-	case pointToSizeInput, pointToSizeUnit:
+	case pointToSizeInput:
 		m.sizeInput.Blur()
 		m.delayInput.Focus()
 		m.currentCursor = pointToDelayInput
+	case pointToSizeUnit:
+		m.currentCursor = pointToDelayUnit
 	case pointToDelayInput, pointToDelayUnit:
 		m.delayInput.Blur()
 		m.currentCursor = pointToTruncateToUnit
@@ -523,10 +525,12 @@ func (m *model) handleUp() {
 	case pointToSizeInput, pointToSizeUnit:
 		m.sizeInput.Blur()
 		m.currentCursor = pointToYear
-	case pointToDelayInput, pointToDelayUnit:
+	case pointToDelayInput:
 		m.delayInput.Blur()
 		m.sizeInput.Focus()
 		m.currentCursor = pointToSizeInput
+	case pointToDelayUnit:
+		m.currentCursor = pointToSizeUnit
 	case pointToTruncateToUnit:
 		m.delayInput.Focus()
 		m.currentCursor = pointToDelayInput

--- a/client/cmd/playground/window/model.go
+++ b/client/cmd/playground/window/model.go
@@ -1,21 +1,14 @@
 package window
 
 import (
-	"bytes"
-	"errors"
 	"fmt"
 	"reflect"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/olekukonko/tablewriter"
 
 	"github.com/goto/optimus/internal/lib/duration"
-	"github.com/goto/optimus/internal/lib/interval"
-	"github.com/goto/optimus/internal/lib/window"
 )
 
 type model struct {
@@ -91,265 +84,19 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *model) View() string {
-	buff := new(bytes.Buffer)
-	table := tablewriter.NewWriter(buff)
-	table.SetAutoWrapText(false)
-	table.SetBorder(false)
-	table.SetRowLine(false)
-	table.SetColumnSeparator("")
-	table.Append([]string{m.generateWindowInputView(), m.generateWindowInputHintView()})
-	table.Render()
+	view := view{
+		currentCursor:  m.currentCursor,
+		sizeInput:      m.sizeInput.Value(),
+		sizeUnit:       m.sizeUnit,
+		delayInput:     m.delayInput.Value(),
+		delayUnit:      m.delayUnit,
+		truncateToUnit: m.truncateToUnit,
+		locationInput:  m.locationInput.Value(),
 
-	var s strings.Builder
-	s.WriteString("INPUT")
-	s.WriteString("\n")
-	s.WriteString(buff.String())
-
-	s.WriteString("RESULT")
-	s.WriteString("\n")
-	s.WriteString(m.generateWindowResultView())
-	s.WriteString("\n")
-	s.WriteString("DOCUMENTATION:\n")
-	s.WriteString("- https://goto.github.io/optimus/docs/concepts/intervals-and-windows")
-	return s.String()
-}
-
-func (m *model) generateWindowResultView() string {
-	buff := new(bytes.Buffer)
-	table := tablewriter.NewWriter(buff)
-
-	interval, err := m.calculateInterval()
-	if err != nil {
-		table.SetHeader([]string{"ERROR"})
-		table.Append([]string{err.Error()})
-	} else {
-		startRow := interval.Start().Format(time.RFC3339)
-		endRow := interval.End().Format(time.RFC3339)
-
-		table.SetHeader([]string{"Start Time", "End Time"})
-		table.Append([]string{startRow, endRow})
+		scheduleTime: m.scheduleTime,
 	}
 
-	table.Render()
-	return buff.String()
-}
-
-func (m *model) generateWindowInputHintView() string {
-	var hint string
-	switch m.currentCursor {
-	case pointToSizeInput:
-		hint = "empty or positive numeric value only\n"
-	case pointToSizeUnit:
-		hint = `valid values are:
-- None or <empty>: only valid if size input is empty
-- h: hour
-- d: day
-- w: week
-- M: month
-- y: year
-
-press (shift+up) or (shift+w) to increment value
-press (shift+down) or (shift+s) to decrement value
-`
-	case pointToDelayInput:
-		hint = "empty or numeric value only (negative is allowed)"
-	case pointToDelayUnit:
-		hint = `valid values are:
-- None or <empty>: only valid if delay input is empty
-- h: hour
-- d: day
-- w: week
-- M: month
-- y: year
-
-press (shift+up) or (shift+w) to increment value
-press (shift+down) or (shift+s) to decrement value
-`
-	case pointToTruncateToUnit:
-		hint = `valid values are:
-- <empty>: truncation happens based on the size unit
-- None: enforce no trancation
-- h: hour
-- d: day
-- w: week
-- M: month
-- y: year
-
-press (shift+up) or (shift+w) to increment value
-press (shift+down) or (shift+s) to decrement value
-`
-	case pointToLocationInput:
-		hint = `valid value is from IANA Time Zone database
-lower case is encouraged`
-	case pointToYear:
-		hint = `year of the schedule time
-
-press (shift+up) or (shift+w) to increment value
-press (shift+down) or (shift+s) to decrement value
-`
-	case pointToMonth:
-		hint = `month of the schedule time
-
-press (shift+up) or (shift+w) to increment value
-press (shift+down) or (shift+s) to decrement value
-`
-	case pointToDay:
-		hint = `day of the schedule time
-
-press (shift+up) or (shift+w) to increment value
-press (shift+down) or (shift+s) to decrement value
-`
-	case pointToHour:
-		hint = `hour of the schedule time
-
-press (shift+up) or (shift+w) to increment value
-press (shift+down) or (shift+s) to decrement value
-`
-	case pointToMinute:
-		hint = `minute of the schedule time
-
-press (shift+up) or (shift+w) to increment value
-press (shift+down) or (shift+s) to decrement value
-`
-	}
-	return "!hint!\n" + hint
-}
-
-func (m *model) generateWindowInputView() string {
-	buff := new(bytes.Buffer)
-	table := tablewriter.NewWriter(buff)
-	table.SetAutoWrapText(false)
-	table.SetRowLine(true)
-	table.SetColumnAlignment([]int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT})
-	table.Append([]string{
-		"size",
-		m.generateSizeView(),
-	})
-	table.Append([]string{
-		"delay",
-		m.generateDelayView(),
-	})
-	table.Append([]string{
-		"truncate_to",
-		m.generateTruncateToView(),
-	})
-	table.Append([]string{
-		"location",
-		m.generateLocationView(),
-	})
-	table.Append([]string{
-		"job schedule",
-		m.generateScheduleTimeView(),
-	})
-	table.Render()
-	return buff.String()
-}
-
-func (m *model) calculateInterval() (interval.Interval, error) {
-	sizeDuration, err := m.getSizeDuration()
-	if err != nil {
-		return interval.Interval{}, err
-	}
-
-	delayDuration, err := m.getDelayDuration()
-	if err != nil {
-		return interval.Interval{}, err
-	}
-
-	location, err := time.LoadLocation(m.locationInput.Value())
-	if err != nil {
-		return interval.Interval{}, errors.New("location is not recognized")
-	}
-
-	var truncate string
-	if m.truncateToUnit != duration.None {
-		truncate = string(m.truncateToUnit)
-	}
-
-	customWindow := window.NewCustomWindow(sizeDuration, delayDuration, location, truncate)
-
-	return customWindow.GetInterval(m.scheduleTime)
-}
-
-func (m *model) getDelayDuration() (duration.Duration, error) {
-	return m.getDuration(m.delayInput.Value(), m.delayUnit)
-}
-
-func (m *model) getSizeDuration() (duration.Duration, error) {
-	sizeDuration, err := m.getDuration(m.sizeInput.Value(), m.sizeUnit)
-	if err != nil {
-		return duration.Duration{}, err
-	}
-
-	if sizeDuration.GetCount() < 0 {
-		return duration.Duration{}, errors.New("size can not be negative")
-	}
-
-	return sizeDuration, nil
-}
-
-func (*model) getDuration(rawCount string, unit duration.Unit) (duration.Duration, error) {
-	const maxDigit = 4
-	if len(rawCount) > maxDigit {
-		return duration.Duration{}, fmt.Errorf("maximum allowed digit is %d", maxDigit)
-	}
-
-	var count int
-	if rawCount != "" {
-		c, err := strconv.Atoi(rawCount)
-		if err != nil {
-			return duration.Duration{}, errors.New("value is not a valid integer")
-		}
-
-		count = c
-	}
-
-	if unit == "" {
-		unit = duration.None
-	}
-
-	return duration.NewDuration(count, unit), nil
-}
-
-func (m *model) generateSizeView() string {
-	sizeInput := m.generateValueWithCursorPointerView(pointToSizeInput, m.sizeInput.Value())
-	sizeUnit := m.generateValueWithCursorPointerView(pointToSizeUnit, string(m.sizeUnit))
-	return sizeInput + " " + sizeUnit
-}
-
-func (m *model) generateDelayView() string {
-	delayInput := m.generateValueWithCursorPointerView(pointToDelayInput, m.delayInput.Value())
-	delayUnit := m.generateValueWithCursorPointerView(pointToDelayUnit, string(m.delayUnit))
-	return delayInput + " " + delayUnit
-}
-
-func (m *model) generateTruncateToView() string {
-	return m.generateValueWithCursorPointerView(pointToTruncateToUnit, string(m.truncateToUnit))
-}
-
-func (m *model) generateLocationView() string {
-	return m.generateValueWithCursorPointerView(pointToLocationInput, m.locationInput.Value())
-}
-
-func (m *model) generateScheduleTimeView() string {
-	year := m.generateValueWithCursorPointerView(pointToYear, strconv.Itoa(m.scheduleTime.Year()))
-	month := m.generateValueWithCursorPointerView(pointToMonth, m.scheduleTime.Month().String())
-	day := m.generateValueWithCursorPointerView(pointToDay, strconv.Itoa(m.scheduleTime.Day()))
-	hour := m.generateValueWithCursorPointerView(pointToHour, strconv.Itoa(m.scheduleTime.Hour()))
-	minute := m.generateValueWithCursorPointerView(pointToMinute, strconv.Itoa(m.scheduleTime.Minute()))
-
-	return year + " " + month + " " + day + " " + hour + ":" + minute + " UTC | " + m.scheduleTime.Weekday().String()
-}
-
-func (m *model) generateValueWithCursorPointerView(targetCursor cursorPointer, value string) string {
-	if m.currentCursor == targetCursor {
-		var s strings.Builder
-		s.WriteString("[")
-		s.WriteString(value)
-		s.WriteString("]")
-		return s.String()
-	}
-	return value
+	return view.Render()
 }
 
 func (m *model) handleInput(msg tea.Msg) {

--- a/client/cmd/playground/window/model.go
+++ b/client/cmd/playground/window/model.go
@@ -2,6 +2,7 @@ package window
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -12,26 +13,47 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/olekukonko/tablewriter"
 
-	"github.com/goto/optimus/internal/models"
+	"github.com/goto/optimus/internal/lib/duration"
+	"github.com/goto/optimus/internal/lib/interval"
+	"github.com/goto/optimus/internal/lib/window"
 )
 
 type model struct {
 	currentCursor cursorPointer
 
-	truncateTo  truncateTo
-	sizeInput   textinput.Model
-	offsetInput textinput.Model
+	sizeInput      textinput.Model
+	sizeUnit       duration.Unit
+	delayInput     textinput.Model
+	delayUnit      duration.Unit
+	truncateToUnit duration.Unit
+	locationInput  textinput.Model
 
-	scheduledTime time.Time
+	scheduleTime time.Time
 }
 
 func newModel() *model {
+	sizeInput := textinput.New()
+	sizeInput.SetValue("1")
+	sizeUnit := duration.Day
+
+	delayInput := textinput.New()
+	delayInput.SetValue("1")
+	delayUnit := duration.Day
+
+	locationInput := textinput.New()
+	locationInput.SetValue("UTC")
+
+	truncateToUnit := duration.Day
+
 	return &model{
-		currentCursor: pointToTruncateTo,
-		truncateTo:    truncateToDay,
-		sizeInput:     textinput.New(),
-		offsetInput:   textinput.New(),
-		scheduledTime: time.Now(),
+		currentCursor:  pointToSizeInput,
+		sizeInput:      sizeInput,
+		sizeUnit:       sizeUnit,
+		delayInput:     delayInput,
+		delayUnit:      delayUnit,
+		locationInput:  locationInput,
+		truncateToUnit: truncateToUnit,
+		scheduleTime:   time.Now().UTC(),
 	}
 }
 
@@ -50,35 +72,39 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msgStr {
 	case "ctrl+c", "q":
 		return m, tea.Quit
-	case "up", "w":
+	case "up":
 		m.handleUp()
-	case "down", "s":
+	case "down":
 		m.handleDown()
-	case "left", "a":
+	case "left":
 		m.handleLeft()
-	case "right", "d":
+	case "right":
 		m.handleRight()
 	case "shift+up", "W":
 		m.handleIncrement()
 	case "shift+down", "S":
 		m.handleDecrement()
-	case "M", "h", "-",
-		"1", "2", "3", "4", "5",
-		"6", "7", "8", "9", "0",
-		"backspace":
+	default:
 		m.handleInput(msg)
 	}
 	return m, nil
 }
 
 func (m *model) View() string {
+	buff := new(bytes.Buffer)
+	table := tablewriter.NewWriter(buff)
+	table.SetAutoWrapText(false)
+	table.SetBorder(false)
+	table.SetRowLine(false)
+	table.SetColumnSeparator("")
+	table.Append([]string{m.generateWindowInputView(), m.generateWindowInputHintView()})
+	table.Render()
+
 	var s strings.Builder
 	s.WriteString("INPUT")
 	s.WriteString("\n")
-	s.WriteString(m.generateWindowInputView())
-	s.WriteString("\n")
-	s.WriteString(m.generateWindowInputHintView())
-	s.WriteString("\n")
+	s.WriteString(buff.String())
+
 	s.WriteString("RESULT")
 	s.WriteString("\n")
 	s.WriteString(m.generateWindowResultView())
@@ -89,11 +115,21 @@ func (m *model) View() string {
 }
 
 func (m *model) generateWindowResultView() string {
-	buff := &bytes.Buffer{}
+	buff := new(bytes.Buffer)
 	table := tablewriter.NewWriter(buff)
-	table.SetHeader([]string{"Version", "Start Time", "End Time"})
-	table.Append(m.generateWindowTableRowView(1))
-	table.Append(m.generateWindowTableRowView(2)) //nolint: gomnd
+
+	interval, err := m.calculateInterval()
+	if err != nil {
+		table.SetHeader([]string{"ERROR"})
+		table.Append([]string{err.Error()})
+	} else {
+		startRow := interval.Start().Format(time.RFC3339)
+		endRow := interval.End().Format(time.RFC3339)
+
+		table.SetHeader([]string{"Start Time", "End Time"})
+		table.Append([]string{startRow, endRow})
+	}
+
 	table.Render()
 	return buff.String()
 }
@@ -101,118 +137,207 @@ func (m *model) generateWindowResultView() string {
 func (m *model) generateWindowInputHintView() string {
 	var hint string
 	switch m.currentCursor {
-	case pointToTruncateTo:
+	case pointToSizeInput:
+		hint = "empty or positive numeric value only\n"
+	case pointToSizeUnit:
 		hint = `valid values are:
-- M: truncate to month
-- w: truncate to week
-- d: truncate to day
-- h: truncate to hour
+- None or <empty>: only valid if size input is empty
+- h: hour
+- d: day
+- w: week
+- M: month
+- y: year
 
 press (shift+up) or (shift+w) to increment value
 press (shift+down) or (shift+s) to decrement value
 `
-	case pointToOffset:
-		hint = `valid formats are:
-- nMmh: example 1M2h meaning 1 month 2 hours
-- mh: example 2h meaning 2 hours
+	case pointToDelayInput:
+		hint = "empty or numeric value only (negative is allowed)"
+	case pointToDelayUnit:
+		hint = `valid values are:
+- None or <empty>: only valid if delay input is empty
+- h: hour
+- d: day
+- w: week
+- M: month
+- y: year
 
-n can be negative, while m can be negative only if nM does NOT exist
+press (shift+up) or (shift+w) to increment value
+press (shift+down) or (shift+s) to decrement value
 `
-	case pointToSize:
-		hint = `valid formats are:
-- nMmh: example 1M2h meaning 1 month 2 hours
-- mh: example 2h meaning 2 hours
+	case pointToTruncateToUnit:
+		hint = `valid values are:
+- None or <empty>: truncation happens based on the unit if size
+- h: hour
+- d: day
+- w: week
+- M: month
+- y: year
 
-both n and m can NOT be negative
+press (shift+up) or (shift+w) to increment value
+press (shift+down) or (shift+s) to decrement value
 `
+	case pointToLocationInput:
+		hint = `valid value is from IANA Time Zone database
+lower case is encouraged`
 	case pointToYear:
-		hint = `year of the scheduled time
+		hint = `year of the schedule time
 
 press (shift+up) or (shift+w) to increment value
 press (shift+down) or (shift+s) to decrement value
 `
 	case pointToMonth:
-		hint = `month of the scheduled time
+		hint = `month of the schedule time
 
 press (shift+up) or (shift+w) to increment value
 press (shift+down) or (shift+s) to decrement value
 `
 	case pointToDay:
-		hint = `day of the scheduled time
+		hint = `day of the schedule time
 
 press (shift+up) or (shift+w) to increment value
 press (shift+down) or (shift+s) to decrement value
 `
 	case pointToHour:
-		hint = `hour of the scheduled time
+		hint = `hour of the schedule time
 
 press (shift+up) or (shift+w) to increment value
 press (shift+down) or (shift+s) to decrement value
 `
 	case pointToMinute:
-		hint = `minute of the scheduled time
+		hint = `minute of the schedule time
 
 press (shift+up) or (shift+w) to increment value
 press (shift+down) or (shift+s) to decrement value
 `
 	}
-	return hint
+	return "!hint!\n" + hint
 }
 
 func (m *model) generateWindowInputView() string {
-	buff := &bytes.Buffer{}
+	buff := new(bytes.Buffer)
 	table := tablewriter.NewWriter(buff)
+	table.SetAutoWrapText(false)
 	table.SetRowLine(true)
 	table.SetColumnAlignment([]int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT})
 	table.Append([]string{
-		"truncate_to",
-		m.generateValueWithCursorPointerView(pointToTruncateTo, string(m.truncateTo)),
-	})
-	table.Append([]string{
-		"offset",
-		m.generateValueWithCursorPointerView(pointToOffset, m.offsetInput.Value()),
-	})
-	table.Append([]string{
 		"size",
-		m.generateValueWithCursorPointerView(pointToSize, m.sizeInput.Value()),
+		m.generateSizeView(),
+	})
+	table.Append([]string{
+		"delay",
+		m.generateDelayView(),
+	})
+	table.Append([]string{
+		"truncate_to",
+		m.generateTruncateToView(),
+	})
+	table.Append([]string{
+		"location",
+		m.generateLocationView(),
 	})
 	table.Append([]string{
 		"job schedule",
-		m.generateSechduledTimeView(),
+		m.generateSechduleTimeView(),
 	})
 	table.Render()
 	return buff.String()
 }
 
-func (m *model) generateWindowTableRowView(version int) []string {
-	window, err := models.NewWindow(version, string(m.truncateTo), m.offsetInput.Value(), m.sizeInput.Value())
+func (m *model) calculateInterval() (interval.Interval, error) {
+	sizeDuration, err := m.getSizeDuration()
 	if err != nil {
-		return []string{fmt.Sprintf("%d", version), err.Error(), err.Error()}
+		return interval.Interval{}, err
 	}
 
-	var startTimeRow string
-	if startTime, err := window.GetStartTime(m.scheduledTime); err != nil {
-		startTimeRow = err.Error()
-	} else {
-		startTimeRow = startTime.Format(time.RFC3339)
+	delayDuration, err := m.getDelayDuration()
+	if err != nil {
+		return interval.Interval{}, err
 	}
 
-	var endTimeRow string
-	if endTime, err := window.GetEndTime(m.scheduledTime); err != nil {
-		endTimeRow = err.Error()
-	} else {
-		endTimeRow = endTime.Format(time.RFC3339)
+	location, err := time.LoadLocation(m.locationInput.Value())
+	if err != nil {
+		return interval.Interval{}, errors.New("location is not recognized")
 	}
-	return []string{fmt.Sprintf("%d", version), startTimeRow, endTimeRow}
+
+	var truncate string
+	if m.truncateToUnit != duration.None {
+		truncate = string(m.truncateToUnit)
+	}
+
+	customWindow := window.NewCustomWindow(sizeDuration, delayDuration, location, truncate)
+
+	return customWindow.GetInterval(m.scheduleTime)
 }
 
-func (m *model) generateSechduledTimeView() string {
-	year := m.generateValueWithCursorPointerView(pointToYear, strconv.Itoa(m.scheduledTime.Year()))
-	month := m.generateValueWithCursorPointerView(pointToMonth, m.scheduledTime.Month().String())
-	day := m.generateValueWithCursorPointerView(pointToDay, strconv.Itoa(m.scheduledTime.Day()))
-	hour := m.generateValueWithCursorPointerView(pointToHour, strconv.Itoa(m.scheduledTime.Hour()))
-	minute := m.generateValueWithCursorPointerView(pointToMinute, strconv.Itoa(m.scheduledTime.Minute()))
-	return year + " " + month + " " + day + " " + hour + ":" + minute
+func (m *model) getDelayDuration() (duration.Duration, error) {
+	return m.getDuration(m.delayInput.Value(), m.delayUnit)
+}
+
+func (m *model) getSizeDuration() (duration.Duration, error) {
+	sizeDuration, err := m.getDuration(m.sizeInput.Value(), m.sizeUnit)
+	if err != nil {
+		return duration.Duration{}, err
+	}
+
+	if sizeDuration.GetCount() < 0 {
+		return duration.Duration{}, errors.New("size can not be negative")
+	}
+
+	return sizeDuration, nil
+}
+
+func (*model) getDuration(rawCount string, unit duration.Unit) (duration.Duration, error) {
+	const maxDigit = 4
+	if len(rawCount) > maxDigit {
+		return duration.Duration{}, fmt.Errorf("maximum allowed digit is %d", maxDigit)
+	}
+
+	var count int
+	if rawCount != "" {
+		c, err := strconv.Atoi(rawCount)
+		if err != nil {
+			return duration.Duration{}, errors.New("value is not a valid integer")
+		}
+
+		count = c
+	}
+
+	if unit == "" {
+		unit = duration.None
+	}
+
+	return duration.NewDuration(count, unit), nil
+}
+
+func (m *model) generateSizeView() string {
+	sizeInput := m.generateValueWithCursorPointerView(pointToSizeInput, m.sizeInput.Value())
+	sizeUnit := m.generateValueWithCursorPointerView(pointToSizeUnit, string(m.sizeUnit))
+	return sizeInput + " " + sizeUnit
+}
+
+func (m *model) generateDelayView() string {
+	delayInput := m.generateValueWithCursorPointerView(pointToDelayInput, m.delayInput.Value())
+	delayUnit := m.generateValueWithCursorPointerView(pointToDelayUnit, string(m.delayUnit))
+	return delayInput + " " + delayUnit
+}
+
+func (m *model) generateTruncateToView() string {
+	return m.generateValueWithCursorPointerView(pointToTruncateToUnit, string(m.truncateToUnit))
+}
+
+func (m *model) generateLocationView() string {
+	return m.generateValueWithCursorPointerView(pointToLocationInput, m.locationInput.Value())
+}
+
+func (m *model) generateSechduleTimeView() string {
+	year := m.generateValueWithCursorPointerView(pointToYear, strconv.Itoa(m.scheduleTime.Year()))
+	month := m.generateValueWithCursorPointerView(pointToMonth, m.scheduleTime.Month().String())
+	day := m.generateValueWithCursorPointerView(pointToDay, strconv.Itoa(m.scheduleTime.Day()))
+	hour := m.generateValueWithCursorPointerView(pointToHour, strconv.Itoa(m.scheduleTime.Hour()))
+	minute := m.generateValueWithCursorPointerView(pointToMinute, strconv.Itoa(m.scheduleTime.Minute()))
+
+	return year + " " + month + " " + day + " " + hour + ":" + minute + " UTC | " + m.scheduleTime.Weekday().String()
 }
 
 func (m *model) generateValueWithCursorPointerView(targetCursor cursorPointer, value string) string {
@@ -228,84 +353,104 @@ func (m *model) generateValueWithCursorPointerView(targetCursor cursorPointer, v
 
 func (m *model) handleInput(msg tea.Msg) {
 	switch m.currentCursor {
-	case pointToOffset:
-		m.offsetInput, _ = m.offsetInput.Update(msg)
-	case pointToSize:
+	case pointToSizeInput:
 		m.sizeInput, _ = m.sizeInput.Update(msg)
+	case pointToDelayInput:
+		m.delayInput, _ = m.delayInput.Update(msg)
+	case pointToLocationInput:
+		m.locationInput, _ = m.locationInput.Update(msg)
 	}
 }
 
 func (m *model) handleDecrement() {
 	switch m.currentCursor {
-	case pointToTruncateTo:
-		m.decrementTruncateTo()
+	case pointToSizeUnit:
+		m.decrementUnit(&m.sizeUnit)
+		m.truncateToUnit = m.sizeUnit
+	case pointToDelayUnit:
+		m.decrementUnit(&m.delayUnit)
+	case pointToTruncateToUnit:
+		m.decrementUnit(&m.truncateToUnit)
 	default:
-		m.decrementScheduledTime()
+		m.decrementScheduleTime()
 	}
 }
 
-func (m *model) decrementScheduledTime() {
+func (m *model) decrementScheduleTime() {
 	switch m.currentCursor {
 	case pointToMinute:
-		m.scheduledTime = m.scheduledTime.Add(-1 * time.Minute)
+		m.scheduleTime = m.scheduleTime.Add(-1 * time.Minute)
 	case pointToHour:
-		m.scheduledTime = m.scheduledTime.Add(-1 * time.Hour)
+		m.scheduleTime = m.scheduleTime.Add(-1 * time.Hour)
 	case pointToDay:
-		m.scheduledTime = m.scheduledTime.AddDate(0, 0, -1)
+		m.scheduleTime = m.scheduleTime.AddDate(0, 0, -1)
 	case pointToMonth:
-		m.scheduledTime = m.scheduledTime.AddDate(0, -1, 0)
+		m.scheduleTime = m.scheduleTime.AddDate(0, -1, 0)
 	case pointToYear:
-		m.scheduledTime = m.scheduledTime.AddDate(-1, 0, 0)
+		m.scheduleTime = m.scheduleTime.AddDate(-1, 0, 0)
 	}
 }
 
-func (m *model) decrementTruncateTo() {
-	switch m.truncateTo {
-	case truncateToMonth:
-		m.truncateTo = truncateToWeek
-	case truncateToWeek:
-		m.truncateTo = truncateToDay
-	case truncateToDay:
-		m.truncateTo = truncateToHour
-	case truncateToHour:
-		m.truncateTo = truncateToMonth
+func (*model) decrementUnit(unit *duration.Unit) {
+	switch *unit {
+	case duration.None:
+		*unit = duration.Hour
+	case duration.Hour:
+		*unit = duration.Day
+	case duration.Day:
+		*unit = duration.Week
+	case duration.Week:
+		*unit = duration.Month
+	case duration.Month:
+		*unit = duration.Year
+	case duration.Year:
+		*unit = duration.None
 	}
 }
 
 func (m *model) handleIncrement() {
 	switch m.currentCursor {
-	case pointToTruncateTo:
-		m.incrementTruncateTo()
+	case pointToSizeUnit:
+		m.incrementUnit(&m.sizeUnit)
+		m.truncateToUnit = m.sizeUnit
+	case pointToDelayUnit:
+		m.incrementUnit(&m.delayUnit)
+	case pointToTruncateToUnit:
+		m.incrementUnit(&m.truncateToUnit)
 	default:
-		m.incrementScheduledTime()
+		m.incrementScheduleTime()
 	}
 }
 
-func (m *model) incrementScheduledTime() {
+func (m *model) incrementScheduleTime() {
 	switch m.currentCursor {
 	case pointToMinute:
-		m.scheduledTime = m.scheduledTime.Add(time.Minute)
+		m.scheduleTime = m.scheduleTime.Add(time.Minute)
 	case pointToHour:
-		m.scheduledTime = m.scheduledTime.Add(time.Hour)
+		m.scheduleTime = m.scheduleTime.Add(time.Hour)
 	case pointToDay:
-		m.scheduledTime = m.scheduledTime.AddDate(0, 0, 1)
+		m.scheduleTime = m.scheduleTime.AddDate(0, 0, 1)
 	case pointToMonth:
-		m.scheduledTime = m.scheduledTime.AddDate(0, 1, 0)
+		m.scheduleTime = m.scheduleTime.AddDate(0, 1, 0)
 	case pointToYear:
-		m.scheduledTime = m.scheduledTime.AddDate(1, 0, 0)
+		m.scheduleTime = m.scheduleTime.AddDate(1, 0, 0)
 	}
 }
 
-func (m *model) incrementTruncateTo() {
-	switch m.truncateTo {
-	case truncateToHour:
-		m.truncateTo = truncateToDay
-	case truncateToDay:
-		m.truncateTo = truncateToWeek
-	case truncateToWeek:
-		m.truncateTo = truncateToMonth
-	case truncateToMonth:
-		m.truncateTo = truncateToHour
+func (*model) incrementUnit(unit *duration.Unit) {
+	switch *unit {
+	case duration.None:
+		*unit = duration.Year
+	case duration.Hour:
+		*unit = duration.None
+	case duration.Day:
+		*unit = duration.Hour
+	case duration.Week:
+		*unit = duration.Day
+	case duration.Month:
+		*unit = duration.Week
+	case duration.Year:
+		*unit = duration.Month
 	}
 }
 
@@ -321,6 +466,12 @@ func (m *model) handleRight() {
 		m.currentCursor = pointToMinute
 	case pointToMinute:
 		m.currentCursor = pointToYear
+	case pointToSizeInput:
+		m.sizeInput.Blur()
+		m.currentCursor = pointToSizeUnit
+	case pointToDelayInput:
+		m.delayInput.Blur()
+		m.currentCursor = pointToDelayUnit
 	}
 }
 
@@ -336,39 +487,53 @@ func (m *model) handleLeft() {
 		m.currentCursor = pointToYear
 	case pointToYear:
 		m.currentCursor = pointToMinute
+	case pointToSizeUnit:
+		m.sizeInput.Focus()
+		m.currentCursor = pointToSizeInput
+	case pointToDelayUnit:
+		m.delayInput.Focus()
+		m.currentCursor = pointToDelayInput
 	}
 }
 
 func (m *model) handleDown() {
 	switch m.currentCursor {
-	case pointToTruncateTo:
-		m.offsetInput.Focus()
-		m.currentCursor = pointToOffset
-	case pointToOffset:
-		m.offsetInput.Blur()
-		m.sizeInput.Focus()
-		m.currentCursor = pointToSize
-	case pointToSize:
+	case pointToSizeInput, pointToSizeUnit:
 		m.sizeInput.Blur()
+		m.delayInput.Focus()
+		m.currentCursor = pointToDelayInput
+	case pointToDelayInput, pointToDelayUnit:
+		m.delayInput.Blur()
+		m.currentCursor = pointToTruncateToUnit
+	case pointToTruncateToUnit:
+		m.locationInput.Focus()
+		m.currentCursor = pointToLocationInput
+	case pointToLocationInput:
+		m.locationInput.Blur()
 		m.currentCursor = pointToYear
 	default:
-		m.currentCursor = pointToTruncateTo
+		m.currentCursor = pointToSizeInput
+		m.sizeInput.Focus()
 	}
 }
 
 func (m *model) handleUp() {
 	switch m.currentCursor {
-	case pointToTruncateTo:
-		m.currentCursor = pointToYear
-	case pointToOffset:
-		m.offsetInput.Blur()
-		m.currentCursor = pointToTruncateTo
-	case pointToSize:
+	case pointToSizeInput, pointToSizeUnit:
 		m.sizeInput.Blur()
-		m.offsetInput.Focus()
-		m.currentCursor = pointToOffset
-	default:
+		m.currentCursor = pointToYear
+	case pointToDelayInput, pointToDelayUnit:
+		m.delayInput.Blur()
 		m.sizeInput.Focus()
-		m.currentCursor = pointToSize
+		m.currentCursor = pointToSizeInput
+	case pointToTruncateToUnit:
+		m.delayInput.Focus()
+		m.currentCursor = pointToDelayInput
+	case pointToLocationInput:
+		m.locationInput.Blur()
+		m.currentCursor = pointToTruncateToUnit
+	default:
+		m.locationInput.Focus()
+		m.currentCursor = pointToLocationInput
 	}
 }

--- a/client/cmd/playground/window/model.go
+++ b/client/cmd/playground/window/model.go
@@ -239,7 +239,7 @@ func (m *model) generateWindowInputView() string {
 	})
 	table.Append([]string{
 		"job schedule",
-		m.generateSechduleTimeView(),
+		m.generateScheduleTimeView(),
 	})
 	table.Render()
 	return buff.String()
@@ -331,7 +331,7 @@ func (m *model) generateLocationView() string {
 	return m.generateValueWithCursorPointerView(pointToLocationInput, m.locationInput.Value())
 }
 
-func (m *model) generateSechduleTimeView() string {
+func (m *model) generateScheduleTimeView() string {
 	year := m.generateValueWithCursorPointerView(pointToYear, strconv.Itoa(m.scheduleTime.Year()))
 	month := m.generateValueWithCursorPointerView(pointToMonth, m.scheduleTime.Month().String())
 	day := m.generateValueWithCursorPointerView(pointToDay, strconv.Itoa(m.scheduleTime.Day()))

--- a/client/cmd/playground/window/model.go
+++ b/client/cmd/playground/window/model.go
@@ -167,7 +167,8 @@ press (shift+down) or (shift+s) to decrement value
 `
 	case pointToTruncateToUnit:
 		hint = `valid values are:
-- None or <empty>: truncation happens based on the unit if size
+- <empty>: truncation happens based on the size unit
+- None: enforce no trancation
 - h: hour
 - d: day
 - w: week

--- a/client/cmd/playground/window/v1v2/constant.go
+++ b/client/cmd/playground/window/v1v2/constant.go
@@ -1,0 +1,24 @@
+package v1v2
+
+type cursorPointer string
+
+const (
+	pointToYear   cursorPointer = "year"
+	pointToMonth  cursorPointer = "month"
+	pointToDay    cursorPointer = "day"
+	pointToHour   cursorPointer = "hour"
+	pointToMinute cursorPointer = "minute"
+
+	pointToTruncateTo cursorPointer = "truncate_to"
+	pointToOffset     cursorPointer = "offset"
+	pointToSize       cursorPointer = "size"
+)
+
+type truncateTo string
+
+const (
+	truncateToMonth truncateTo = "M"
+	truncateToWeek  truncateTo = "w"
+	truncateToDay   truncateTo = "d"
+	truncateToHour  truncateTo = "h"
+)

--- a/client/cmd/playground/window/v1v2/doc.go
+++ b/client/cmd/playground/window/v1v2/doc.go
@@ -1,0 +1,4 @@
+// v1v2 package is a temporary playground package for window v1 and v2.
+// Along with deprecation of window v1 and v2, this package will also be removed.
+// This makes playground to be only for window v3.
+package v1v2

--- a/client/cmd/playground/window/v1v2/model.go
+++ b/client/cmd/playground/window/v1v2/model.go
@@ -1,0 +1,374 @@
+package v1v2
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/olekukonko/tablewriter"
+
+	"github.com/goto/optimus/internal/models"
+)
+
+type model struct {
+	currentCursor cursorPointer
+
+	truncateTo  truncateTo
+	sizeInput   textinput.Model
+	offsetInput textinput.Model
+
+	scheduledTime time.Time
+}
+
+func NewModel() *model {
+	return &model{
+		currentCursor: pointToTruncateTo,
+		truncateTo:    truncateToDay,
+		sizeInput:     textinput.New(),
+		offsetInput:   textinput.New(),
+		scheduledTime: time.Now(),
+	}
+}
+
+func (*model) Init() tea.Cmd {
+	// this method is to adhere to library contract
+	return nil
+}
+
+func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	currMsg := reflect.TypeOf(msg)
+	if currMsg.String() != "tea.KeyMsg" {
+		return m, nil
+	}
+
+	msgStr := fmt.Sprintf("%s", msg)
+	switch msgStr {
+	case "ctrl+c", "q":
+		return m, tea.Quit
+	case "up", "w":
+		m.handleUp()
+	case "down", "s":
+		m.handleDown()
+	case "left", "a":
+		m.handleLeft()
+	case "right", "d":
+		m.handleRight()
+	case "shift+up", "W":
+		m.handleIncrement()
+	case "shift+down", "S":
+		m.handleDecrement()
+	case "M", "h", "-",
+		"1", "2", "3", "4", "5",
+		"6", "7", "8", "9", "0",
+		"backspace":
+		m.handleInput(msg)
+	}
+	return m, nil
+}
+
+func (m *model) View() string {
+	var s strings.Builder
+	s.WriteString("INPUT")
+	s.WriteString("\n")
+	s.WriteString(m.generateWindowInputView())
+	s.WriteString("\n")
+	s.WriteString(m.generateWindowInputHintView())
+	s.WriteString("\n")
+	s.WriteString("RESULT")
+	s.WriteString("\n")
+	s.WriteString(m.generateWindowResultView())
+	s.WriteString("\n")
+	s.WriteString("DOCUMENTATION:\n")
+	s.WriteString("- https://goto.github.io/optimus/docs/concepts/intervals-and-windows")
+	return s.String()
+}
+
+func (m *model) generateWindowResultView() string {
+	buff := &bytes.Buffer{}
+	table := tablewriter.NewWriter(buff)
+	table.SetHeader([]string{"Version", "Start Time", "End Time"})
+	table.Append(m.generateWindowTableRowView(1))
+	table.Append(m.generateWindowTableRowView(2)) //nolint: gomnd
+	table.Render()
+	return buff.String()
+}
+
+func (m *model) generateWindowInputHintView() string {
+	var hint string
+	switch m.currentCursor {
+	case pointToTruncateTo:
+		hint = `valid values are:
+- M: truncate to month
+- w: truncate to week
+- d: truncate to day
+- h: truncate to hour
+
+press (shift+up) or (shift+w) to increment value
+press (shift+down) or (shift+s) to decrement value
+`
+	case pointToOffset:
+		hint = `valid formats are:
+- nMmh: example 1M2h meaning 1 month 2 hours
+- mh: example 2h meaning 2 hours
+
+n can be negative, while m can be negative only if nM does NOT exist
+`
+	case pointToSize:
+		hint = `valid formats are:
+- nMmh: example 1M2h meaning 1 month 2 hours
+- mh: example 2h meaning 2 hours
+
+both n and m can NOT be negative
+`
+	case pointToYear:
+		hint = `year of the scheduled time
+
+press (shift+up) or (shift+w) to increment value
+press (shift+down) or (shift+s) to decrement value
+`
+	case pointToMonth:
+		hint = `month of the scheduled time
+
+press (shift+up) or (shift+w) to increment value
+press (shift+down) or (shift+s) to decrement value
+`
+	case pointToDay:
+		hint = `day of the scheduled time
+
+press (shift+up) or (shift+w) to increment value
+press (shift+down) or (shift+s) to decrement value
+`
+	case pointToHour:
+		hint = `hour of the scheduled time
+
+press (shift+up) or (shift+w) to increment value
+press (shift+down) or (shift+s) to decrement value
+`
+	case pointToMinute:
+		hint = `minute of the scheduled time
+
+press (shift+up) or (shift+w) to increment value
+press (shift+down) or (shift+s) to decrement value
+`
+	}
+	return hint
+}
+
+func (m *model) generateWindowInputView() string {
+	buff := &bytes.Buffer{}
+	table := tablewriter.NewWriter(buff)
+	table.SetRowLine(true)
+	table.SetColumnAlignment([]int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT})
+	table.Append([]string{
+		"truncate_to",
+		m.generateValueWithCursorPointerView(pointToTruncateTo, string(m.truncateTo)),
+	})
+	table.Append([]string{
+		"offset",
+		m.generateValueWithCursorPointerView(pointToOffset, m.offsetInput.Value()),
+	})
+	table.Append([]string{
+		"size",
+		m.generateValueWithCursorPointerView(pointToSize, m.sizeInput.Value()),
+	})
+	table.Append([]string{
+		"job schedule",
+		m.generateSechduledTimeView(),
+	})
+	table.Render()
+	return buff.String()
+}
+
+func (m *model) generateWindowTableRowView(version int) []string {
+	window, err := models.NewWindow(version, string(m.truncateTo), m.offsetInput.Value(), m.sizeInput.Value())
+	if err != nil {
+		return []string{fmt.Sprintf("%d", version), err.Error(), err.Error()}
+	}
+
+	var startTimeRow string
+	if startTime, err := window.GetStartTime(m.scheduledTime); err != nil {
+		startTimeRow = err.Error()
+	} else {
+		startTimeRow = startTime.Format(time.RFC3339)
+	}
+
+	var endTimeRow string
+	if endTime, err := window.GetEndTime(m.scheduledTime); err != nil {
+		endTimeRow = err.Error()
+	} else {
+		endTimeRow = endTime.Format(time.RFC3339)
+	}
+	return []string{fmt.Sprintf("%d", version), startTimeRow, endTimeRow}
+}
+
+func (m *model) generateSechduledTimeView() string {
+	year := m.generateValueWithCursorPointerView(pointToYear, strconv.Itoa(m.scheduledTime.Year()))
+	month := m.generateValueWithCursorPointerView(pointToMonth, m.scheduledTime.Month().String())
+	day := m.generateValueWithCursorPointerView(pointToDay, strconv.Itoa(m.scheduledTime.Day()))
+	hour := m.generateValueWithCursorPointerView(pointToHour, strconv.Itoa(m.scheduledTime.Hour()))
+	minute := m.generateValueWithCursorPointerView(pointToMinute, strconv.Itoa(m.scheduledTime.Minute()))
+	return year + " " + month + " " + day + " " + hour + ":" + minute
+}
+
+func (m *model) generateValueWithCursorPointerView(targetCursor cursorPointer, value string) string {
+	if m.currentCursor == targetCursor {
+		var s strings.Builder
+		s.WriteString("[")
+		s.WriteString(value)
+		s.WriteString("]")
+		return s.String()
+	}
+	return value
+}
+
+func (m *model) handleInput(msg tea.Msg) {
+	switch m.currentCursor {
+	case pointToOffset:
+		m.offsetInput, _ = m.offsetInput.Update(msg)
+	case pointToSize:
+		m.sizeInput, _ = m.sizeInput.Update(msg)
+	}
+}
+
+func (m *model) handleDecrement() {
+	switch m.currentCursor {
+	case pointToTruncateTo:
+		m.decrementTruncateTo()
+	default:
+		m.decrementScheduledTime()
+	}
+}
+
+func (m *model) decrementScheduledTime() {
+	switch m.currentCursor {
+	case pointToMinute:
+		m.scheduledTime = m.scheduledTime.Add(-1 * time.Minute)
+	case pointToHour:
+		m.scheduledTime = m.scheduledTime.Add(-1 * time.Hour)
+	case pointToDay:
+		m.scheduledTime = m.scheduledTime.AddDate(0, 0, -1)
+	case pointToMonth:
+		m.scheduledTime = m.scheduledTime.AddDate(0, -1, 0)
+	case pointToYear:
+		m.scheduledTime = m.scheduledTime.AddDate(-1, 0, 0)
+	}
+}
+
+func (m *model) decrementTruncateTo() {
+	switch m.truncateTo {
+	case truncateToMonth:
+		m.truncateTo = truncateToWeek
+	case truncateToWeek:
+		m.truncateTo = truncateToDay
+	case truncateToDay:
+		m.truncateTo = truncateToHour
+	case truncateToHour:
+		m.truncateTo = truncateToMonth
+	}
+}
+
+func (m *model) handleIncrement() {
+	switch m.currentCursor {
+	case pointToTruncateTo:
+		m.incrementTruncateTo()
+	default:
+		m.incrementScheduledTime()
+	}
+}
+
+func (m *model) incrementScheduledTime() {
+	switch m.currentCursor {
+	case pointToMinute:
+		m.scheduledTime = m.scheduledTime.Add(time.Minute)
+	case pointToHour:
+		m.scheduledTime = m.scheduledTime.Add(time.Hour)
+	case pointToDay:
+		m.scheduledTime = m.scheduledTime.AddDate(0, 0, 1)
+	case pointToMonth:
+		m.scheduledTime = m.scheduledTime.AddDate(0, 1, 0)
+	case pointToYear:
+		m.scheduledTime = m.scheduledTime.AddDate(1, 0, 0)
+	}
+}
+
+func (m *model) incrementTruncateTo() {
+	switch m.truncateTo {
+	case truncateToHour:
+		m.truncateTo = truncateToDay
+	case truncateToDay:
+		m.truncateTo = truncateToWeek
+	case truncateToWeek:
+		m.truncateTo = truncateToMonth
+	case truncateToMonth:
+		m.truncateTo = truncateToHour
+	}
+}
+
+func (m *model) handleRight() {
+	switch m.currentCursor {
+	case pointToYear:
+		m.currentCursor = pointToMonth
+	case pointToMonth:
+		m.currentCursor = pointToDay
+	case pointToDay:
+		m.currentCursor = pointToHour
+	case pointToHour:
+		m.currentCursor = pointToMinute
+	case pointToMinute:
+		m.currentCursor = pointToYear
+	}
+}
+
+func (m *model) handleLeft() {
+	switch m.currentCursor {
+	case pointToMinute:
+		m.currentCursor = pointToHour
+	case pointToHour:
+		m.currentCursor = pointToDay
+	case pointToDay:
+		m.currentCursor = pointToMonth
+	case pointToMonth:
+		m.currentCursor = pointToYear
+	case pointToYear:
+		m.currentCursor = pointToMinute
+	}
+}
+
+func (m *model) handleDown() {
+	switch m.currentCursor {
+	case pointToTruncateTo:
+		m.offsetInput.Focus()
+		m.currentCursor = pointToOffset
+	case pointToOffset:
+		m.offsetInput.Blur()
+		m.sizeInput.Focus()
+		m.currentCursor = pointToSize
+	case pointToSize:
+		m.sizeInput.Blur()
+		m.currentCursor = pointToYear
+	default:
+		m.currentCursor = pointToTruncateTo
+	}
+}
+
+func (m *model) handleUp() {
+	switch m.currentCursor {
+	case pointToTruncateTo:
+		m.currentCursor = pointToYear
+	case pointToOffset:
+		m.offsetInput.Blur()
+		m.currentCursor = pointToTruncateTo
+	case pointToSize:
+		m.sizeInput.Blur()
+		m.offsetInput.Focus()
+		m.currentCursor = pointToOffset
+	default:
+		m.sizeInput.Focus()
+		m.currentCursor = pointToSize
+	}
+}

--- a/client/cmd/playground/window/view.go
+++ b/client/cmd/playground/window/view.go
@@ -1,0 +1,337 @@
+package window
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/olekukonko/tablewriter"
+
+	"github.com/goto/optimus/internal/lib/duration"
+	"github.com/goto/optimus/internal/lib/interval"
+	"github.com/goto/optimus/internal/lib/window"
+)
+
+type view struct {
+	currentCursor cursorPointer
+
+	sizeInput      string
+	sizeUnit       duration.Unit
+	delayInput     string
+	delayUnit      duration.Unit
+	truncateToUnit duration.Unit
+	locationInput  string
+
+	scheduleTime time.Time
+}
+
+// Render renders the view into a string format.
+// This is the only method which should be called for `view` type
+// from the caller outside `view`, emphasized with the first capitalized letter.
+func (v *view) Render() string {
+	var s strings.Builder
+	s.WriteString(v.getInputSection())
+	s.WriteString(v.getResultSection())
+	s.WriteString("DOCUMENTATION:\n")
+	s.WriteString("- https://goto.github.io/optimus/docs/concepts/intervals-and-windows")
+
+	return s.String()
+}
+
+func (v *view) getInputSection() string {
+	buff := new(bytes.Buffer)
+
+	table := tablewriter.NewWriter(buff)
+	table.SetAutoWrapText(false)
+	table.SetBorder(false)
+	table.SetRowLine(false)
+	table.SetColumnSeparator("")
+
+	inputTable := v.getInputTable()
+	inputHint := v.getInputHint()
+
+	table.Append([]string{"INPUT", "HINT"})
+	table.Append([]string{inputTable, inputHint})
+
+	table.Render()
+
+	return buff.String()
+}
+
+func (v *view) getResultSection() string {
+	buff := new(bytes.Buffer)
+
+	table := tablewriter.NewWriter(buff)
+	table.SetAutoWrapText(false)
+	table.SetBorder(false)
+	table.SetRowLine(false)
+	table.SetColumnSeparator("")
+
+	table.Append([]string{"RESULT"})
+	table.Append([]string{v.getResultTable()})
+	table.Render()
+
+	return buff.String()
+}
+
+func (v *view) getResultTable() string {
+	buff := new(bytes.Buffer)
+	table := tablewriter.NewWriter(buff)
+
+	interval, err := v.calculateInterval()
+	if err != nil {
+		table.SetHeader([]string{"ERROR"})
+		table.Append([]string{err.Error()})
+	} else {
+		startRow := interval.Start().Format(time.RFC3339)
+		endRow := interval.End().Format(time.RFC3339)
+
+		table.SetHeader([]string{"Start Time", "End Time"})
+		table.Append([]string{startRow, endRow})
+	}
+
+	table.Render()
+	return buff.String()
+}
+
+func (v *view) getInputHint() string {
+	var hint string
+	switch v.currentCursor {
+	case pointToSizeInput:
+		hint = "empty or positive numeric value only"
+	case pointToSizeUnit:
+		hint = `valid values are:
+- <empty> or None
+- h: hour
+- d: day
+- w: week
+- M: month
+- y: year
+
+<empty> or None are only valid if size value is empty
+
+(shift+up) or (shift+w) to increment
+(shift+down) or (shift+s) to decrement
+`
+	case pointToDelayInput:
+		hint = `empty or numeric value only
+negative is allowed`
+	case pointToDelayUnit:
+		hint = `valid values are:
+- <empty> or None
+- h: hour
+- d: day
+- w: week
+- M: month
+- y: year
+
+<empty> or None are only valid if delay value is empty
+
+(shift+up) or (shift+w) to increment
+(shift+down) or (shift+s) to decrement
+`
+	case pointToTruncateToUnit:
+		hint = `valid values are:
+- <empty> or None
+- h: hour
+- d: day
+- w: week
+- M: month
+- y: year
+
+<empty> unit enforces truncation based on the size unit
+None unit enforces no truncation
+
+(shift+up) or (shift+w) to increment
+(shift+down) or (shift+s) to decrement
+`
+	case pointToLocationInput:
+		hint = `valid value is from IANA Time Zone database
+lower case is encouraged`
+	case pointToYear:
+		hint = `year of the schedule time
+
+(shift+up) or (shift+w) to increment
+(shift+down) or (shift+s) to decrement
+`
+	case pointToMonth:
+		hint = `month of the schedule time
+
+(shift+up) or (shift+w) to increment
+(shift+down) or (shift+s) to decrement
+`
+	case pointToDay:
+		hint = `day of the schedule time
+
+(shift+up) or (shift+w) to increment
+(shift+down) or (shift+s) to decrement
+`
+	case pointToHour:
+		hint = `hour of the schedule time
+
+(shift+up) or (shift+w) to increment
+(shift+down) or (shift+s) to decrement
+`
+	case pointToMinute:
+		hint = `minute of the schedule time
+
+(shift+up) or (shift+w) to increment
+(shift+down) or (shift+s) to decrement
+`
+	}
+
+	return hint
+}
+
+func (v *view) getInputTable() string {
+	buff := new(bytes.Buffer)
+
+	table := tablewriter.NewWriter(buff)
+	table.SetAutoMergeCellsByColumnIndex([]int{0})
+	table.SetRowLine(true)
+	table.SetColumnAlignment([]int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT})
+
+	table.Append([]string{
+		"size",
+		v.getSizeInput(),
+	})
+	table.Append([]string{
+		"delay",
+		v.getDelayInput(),
+	})
+	table.Append([]string{
+		"truncate_to",
+		v.getTruncateToInput(),
+	})
+	table.Append([]string{
+		"location",
+		v.getLocationInput(),
+	})
+	table.Append([]string{
+		"job schedule",
+		v.getScheduleTimeInput(),
+	})
+	table.Append([]string{
+		"job schedule",
+		v.scheduleTime.Weekday().String(),
+	})
+
+	table.Render()
+	return buff.String() + "\n"
+}
+
+func (v *view) calculateInterval() (interval.Interval, error) {
+	sizeDuration, err := v.getSizeDuration()
+	if err != nil {
+		return interval.Interval{}, err
+	}
+
+	delayDuration, err := v.getDelayDuration()
+	if err != nil {
+		return interval.Interval{}, err
+	}
+
+	location, err := time.LoadLocation(v.locationInput)
+	if err != nil {
+		return interval.Interval{}, errors.New("location is not recognized")
+	}
+
+	var truncate string
+	if v.truncateToUnit != duration.None {
+		truncate = string(v.truncateToUnit)
+	}
+
+	customWindow := window.NewCustomWindow(sizeDuration, delayDuration, location, truncate)
+
+	return customWindow.GetInterval(v.scheduleTime)
+}
+
+func (v *view) getDelayDuration() (duration.Duration, error) {
+	return v.getDuration(v.delayInput, v.delayUnit)
+}
+
+func (v *view) getSizeDuration() (duration.Duration, error) {
+	sizeDuration, err := v.getDuration(v.sizeInput, v.sizeUnit)
+	if err != nil {
+		return duration.Duration{}, err
+	}
+
+	if sizeDuration.GetCount() < 0 {
+		return duration.Duration{}, errors.New("size can not be negative")
+	}
+
+	return sizeDuration, nil
+}
+
+func (*view) getDuration(rawCount string, unit duration.Unit) (duration.Duration, error) {
+	const maxDigit = 4
+	if len(rawCount) > maxDigit {
+		return duration.Duration{}, fmt.Errorf("maximum allowed digit is %d", maxDigit)
+	}
+
+	var count int
+	if rawCount != "" {
+		c, err := strconv.Atoi(rawCount)
+		if err != nil {
+			return duration.Duration{}, errors.New("value is not a valid integer")
+		}
+
+		count = c
+	}
+
+	if unit == "" {
+		unit = duration.None
+	}
+
+	return duration.NewDuration(count, unit), nil
+}
+
+func (v *view) getSizeInput() string {
+	sizeInput := v.getValueWithCursor(pointToSizeInput, v.sizeInput)
+	sizeUnit := v.getValueWithCursor(pointToSizeUnit, string(v.sizeUnit))
+	return sizeInput + " " + sizeUnit
+}
+
+func (v *view) getDelayInput() string {
+	delayInput := v.getValueWithCursor(pointToDelayInput, v.delayInput)
+	delayUnit := v.getValueWithCursor(pointToDelayUnit, string(v.delayUnit))
+	return delayInput + " " + delayUnit
+}
+
+func (v *view) getTruncateToInput() string {
+	return v.getValueWithCursor(pointToTruncateToUnit, string(v.truncateToUnit))
+}
+
+func (v *view) getLocationInput() string {
+	return v.getValueWithCursor(pointToLocationInput, v.locationInput)
+}
+
+func (v *view) getScheduleTimeInput() string {
+	year := v.getValueWithCursor(pointToYear, strconv.Itoa(v.scheduleTime.Year()))
+	month := v.getValueWithCursor(pointToMonth, v.scheduleTime.Month().String())
+	day := v.getValueWithCursor(pointToDay, strconv.Itoa(v.scheduleTime.Day()))
+	hour := v.getValueWithCursor(pointToHour, strconv.Itoa(v.scheduleTime.Hour()))
+	minute := v.getValueWithCursor(pointToMinute, strconv.Itoa(v.scheduleTime.Minute()))
+
+	return year + " " + month + " " + day + " " + hour + ":" + minute + v.getUTC()
+}
+
+func (v *view) getValueWithCursor(targetCursor cursorPointer, value string) string {
+	if v.currentCursor == targetCursor {
+		return "[" + value + "]"
+	}
+
+	return value
+}
+
+func (v *view) getUTC() string {
+	switch v.currentCursor {
+	case pointToYear, pointToMonth, pointToDay, pointToHour, pointToMinute:
+		return " UTC"
+	}
+
+	return " UTC  "
+}

--- a/client/cmd/playground/window/view.go
+++ b/client/cmd/playground/window/view.go
@@ -101,7 +101,7 @@ func (v *view) getInputHint() string {
 	var hint string
 	switch v.currentCursor {
 	case pointToSizeInput:
-		hint = "empty or positive numeric value only"
+		hint = "empty or positive numeric value"
 	case pointToSizeUnit:
 		hint = `valid values are:
 - <empty> or None
@@ -117,8 +117,8 @@ func (v *view) getInputHint() string {
 (shift+down) or (shift+s) to decrement
 `
 	case pointToDelayInput:
-		hint = `empty or numeric value only
-negative is allowed`
+		hint = `empty or numeric value
+(and negative is allowed)`
 	case pointToDelayUnit:
 		hint = `valid values are:
 - <empty> or None

--- a/client/cmd/playground/window/window.go
+++ b/client/cmd/playground/window/window.go
@@ -70,7 +70,8 @@ func (j *command) runV1V2() error {
     \  /\  /|  __/| || (__| (_) || | | | | ||  __/
      \/  \/  \___||_| \___|\___/ |_| |_| |_| \___|
                                                   
-                                                  
+    🚨THIS VERSION IS SOON TO BE DEPRECATED🚨
+
 Hi, this is an interactive CLI to play around with window configuration for v1 and v2.
 You can navigate around the available configurations with the following keys:
    ______________________________

--- a/client/cmd/playground/window/window.go
+++ b/client/cmd/playground/window/window.go
@@ -6,10 +6,13 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/goto/optimus/client/cmd/internal/logger"
+	"github.com/goto/optimus/client/cmd/playground/window/v1v2"
 )
 
 type command struct {
 	log log.Logger
+
+	isV1V2 bool
 }
 
 // NewCommand initializes command for window playground
@@ -20,10 +23,45 @@ func NewCommand() *cobra.Command {
 		Short: "Play around with window configuration",
 		RunE:  window.RunE,
 	}
+
+	cmd.Flags().BoolVar(&window.isV1V2, "v1-v2", false, "if set, then playground will be for v1 and v2")
 	return cmd
 }
 
 func (j *command) RunE(_ *cobra.Command, _ []string) error {
+	if j.isV1V2 {
+		return j.runV1V2()
+	}
+
+	return j.runV3()
+}
+
+func (j *command) runV3() error {
+	welcome := `
+ __          __    _                              
+ \ \        / /   | |                             
+  \ \  /\  / /___ | |  ___  ___   _ __ ___    ___ 
+   \ \/  \/ // _ \| | / __|/ _ \ | '_ ' _ \  / _ \
+    \  /\  /|  __/| || (__| (_) || | | | | ||  __/
+     \/  \/  \___||_| \___|\___/ |_| |_| |_| \___|
+`
+
+	instruction := `
+                                       _________________________
+Hi, this is an interactive CLI to     |  up   | : arrow up    ↑ |
+play around with window v3.           | down  | : arrow down  ↓ |
+You can navigate around the           | right | : arrow right → |
+available configurations with         | left  | : arrow left  ← |
+the following keys                    | quit  | : q or ctrl+c   |
+                                       -------------------------
+`
+	j.log.Info(welcome)
+	j.log.Info(instruction)
+	p := tea.NewProgram(newModel())
+	return p.Start()
+}
+
+func (j *command) runV1V2() error {
 	message := `
  __          __    _                              
  \ \        / /   | |                             
@@ -33,7 +71,7 @@ func (j *command) RunE(_ *cobra.Command, _ []string) error {
      \/  \/  \___||_| \___|\___/ |_| |_| |_| \___|
                                                   
                                                   
-Hi, this is an interactive CLI to play around with window configuration.
+Hi, this is an interactive CLI to play around with window configuration for v1 and v2.
 You can navigate around the available configurations with the following keys:
    ______________________________
   |  up   | : arrow up    ↑ or w |
@@ -44,6 +82,6 @@ You can navigate around the available configurations with the following keys:
    ------------------------------
 `
 	j.log.Info(message)
-	p := tea.NewProgram(newModel())
+	p := tea.NewProgram(v1v2.NewModel())
 	return p.Start()
 }

--- a/docs/docs/concepts/intervals-and-windows.md
+++ b/docs/docs/concepts/intervals-and-windows.md
@@ -123,7 +123,7 @@ dependencies: []
 
 Notice the window configuration is specified under field `task.window`. **Important** note, the `version` field decides which
 version of window capability to be used. Currently available window version are `version: 1`, `version: 2` and `version: 3`. Version 3 is recommended
-to be used as version 1 will soon be deprecated. To play around with window configuration, try `playground` feature for window:
+to be used as version 1 and version 2 will soon be deprecated. To play around with window configuration, try `playground` feature for window:
 
 ```bash
 # executes playground for v3

--- a/docs/docs/concepts/intervals-and-windows.md
+++ b/docs/docs/concepts/intervals-and-windows.md
@@ -123,10 +123,14 @@ dependencies: []
 
 Notice the window configuration is specified under field `task.window`. **Important** note, the `version` field decides which
 version of window capability to be used. Currently available window version are `version: 1`, `version: 2` and `version: 3`. Version 3 is recommended
-to be used as version 1 will soon be deprecated. To know the difference between the two version, run the `playground` feature for window:
+to be used as version 1 will soon be deprecated. To play around with window configuration, try `playground` feature for window:
 
 ```bash
+# executes playground for v3
 optimus playground window
+
+# executes playground for v1 and v2
+optimus playground window --v1-v2
 ```
 
 ### Window Preset (since v0.10.0)


### PR DESCRIPTION
This PR is to add window playground v3. Version 3 is the main version of playground. Version 1 and version 2 are moved to another package. In order to activate the version 1 and version 2 mode, the user needs to use flag `--v1-v2` when executing playground. Example:

```zsh
# execute window playground v3
optimus playground window

# execute window playground v1 and v2
opitmus playground window --v1-v2
```