### PR TITLE
fix: retry delay in jobspec ignored issue

### DIFF
--- a/core/job/handler/v1beta1/job_adapter.go
+++ b/core/job/handler/v1beta1/job_adapter.go
@@ -252,7 +252,7 @@ func toRetry(protoRetry *pb.JobSpecification_Behavior_Retry) *job.Retry {
 	if protoRetry == nil {
 		return nil
 	}
-	return job.NewRetry(int(protoRetry.Count), protoRetry.Delay.GetNanos(), protoRetry.ExponentialBackoff)
+	return job.NewRetry(int(protoRetry.Count), protoRetry.Delay.GetSeconds(), protoRetry.ExponentialBackoff)
 }
 
 func fromRetry(jobRetry *job.Retry) *pb.JobSpecification_Behavior_Retry {
@@ -261,7 +261,7 @@ func fromRetry(jobRetry *job.Retry) *pb.JobSpecification_Behavior_Retry {
 	}
 	return &pb.JobSpecification_Behavior_Retry{
 		Count:              int32(jobRetry.Count()),
-		Delay:              &durationpb.Duration{Nanos: jobRetry.Delay()},
+		Delay:              &durationpb.Duration{Seconds: jobRetry.DelayInSeconds()},
 		ExponentialBackoff: jobRetry.ExponentialBackoff(),
 	}
 }

--- a/core/job/spec.go
+++ b/core/job/spec.go
@@ -279,7 +279,7 @@ func (s ScheduleDate) String() string {
 
 type Retry struct {
 	count              int
-	delay              int32
+	delayInSeconds     int64
 	exponentialBackoff bool
 }
 
@@ -287,16 +287,16 @@ func (r Retry) Count() int {
 	return r.count
 }
 
-func (r Retry) Delay() int32 {
-	return r.delay
+func (r Retry) DelayInSeconds() int64 {
+	return r.delayInSeconds
 }
 
 func (r Retry) ExponentialBackoff() bool {
 	return r.exponentialBackoff
 }
 
-func NewRetry(count int, delay int32, exponentialBackoff bool) *Retry {
-	return &Retry{count: count, delay: delay, exponentialBackoff: exponentialBackoff}
+func NewRetry(count int, delay int64, exponentialBackoff bool) *Retry {
+	return &Retry{count: count, delayInSeconds: delay, exponentialBackoff: exponentialBackoff}
 }
 
 type Schedule struct {

--- a/core/job/spec_test.go
+++ b/core/job/spec_test.go
@@ -16,7 +16,7 @@ func TestEntitySpec(t *testing.T) {
 	jobVersion := 1
 	startDate, _ := job.ScheduleDateFrom("2022-10-01")
 	endDate, _ := job.ScheduleDateFrom("2022-10-02")
-	retry := job.NewRetry(0, int32(0), false)
+	retry := job.NewRetry(0, int64(0), false)
 	jobSchedule, _ := job.NewScheduleBuilder(startDate).
 		WithEndDate(endDate).
 		WithInterval("0 2 * * *").
@@ -65,7 +65,7 @@ func TestEntitySpec(t *testing.T) {
 
 			assert.Equal(t, jobSchedule, specA.Schedule())
 			assert.Equal(t, jobSchedule.Retry(), specA.Schedule().Retry())
-			assert.Equal(t, jobSchedule.Retry().Delay(), specA.Schedule().Retry().Delay())
+			assert.Equal(t, jobSchedule.Retry().DelayInSeconds(), specA.Schedule().Retry().DelayInSeconds())
 			assert.Equal(t, jobSchedule.Retry().Count(), specA.Schedule().Retry().Count())
 			assert.Equal(t, jobSchedule.Retry().ExponentialBackoff(), specA.Schedule().Retry().ExponentialBackoff())
 			assert.Equal(t, jobSchedule.EndDate(), specA.Schedule().EndDate())

--- a/internal/store/postgres/job/adapter.go
+++ b/internal/store/postgres/job/adapter.go
@@ -77,7 +77,7 @@ type Window struct {
 
 type Retry struct {
 	Count              int
-	Delay              int32
+	Delay              int64
 	ExponentialBackoff bool
 }
 
@@ -314,7 +314,7 @@ func toStorageSchedule(scheduleSpec *job.Schedule) ([]byte, error) {
 	if scheduleSpec.Retry() != nil {
 		retry = &Retry{
 			Count:              scheduleSpec.Retry().Count(),
-			Delay:              scheduleSpec.Retry().Delay(),
+			Delay:              scheduleSpec.Retry().DelayInSeconds(),
 			ExponentialBackoff: scheduleSpec.Retry().ExponentialBackoff(),
 		}
 	}


### PR DESCRIPTION
### Bug Description
Retry delay is configurable through the job specification file (`behavior.retry.delay`) or the scheduler's project variables (`dag_retry_delay_in_secs`). If both are configured, then the value that is configured in job specification file will be prioritized.

A bug encountered the config is set in both of the places, however the value is job specification file is ignored.

Sample job specification file:
```yaml
behavior:
  depends_on_past: False
  retry:
    count: 10
    exponential_backoff: false
    delay: 10m
```

Expectation in DAG file:
```python
DAG_RETRY_DELAY = int(Variable.get("dag_retry_delay_in_secs", default_var=5 * 60))
default_args = {
    ...
    "retry_delay": timedelta(seconds=600),
    ...
}
```

Current DAG file result:
```python
DAG_RETRY_DELAY = int(Variable.get("dag_retry_delay_in_secs", default_var=5 * 60))
default_args = {
    ...
    "retry_delay": timedelta(seconds=DAG_RETRY_DELAY),
    ...
}
```
