### PR TITLE
feat: replay decentralization - provide execution project as namespace & project level config

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -69,3 +69,12 @@ log:
 #     batch_interval_second: 1
 #     broker_urls:
 #       - localhost:9092
+
+# replay:
+#   plugin_execution_project_config_names:
+#     bq2bq: EXECUTION_PROJECT
+#     bq2pg: BQ_EXECUTION_PROJECT
+#     pg2bq: BQ_EXECUTION_PROJECT
+#     bq2api: EXECUTION_PROJECT
+#     clevertap: EXECUTION_PROJECT
+#     transporterTask: EXECUTION_PROJECT

--- a/config/config_server.go
+++ b/config/config_server.go
@@ -61,8 +61,9 @@ type PluginConfig struct {
 }
 
 type ReplayConfig struct {
-	ReplayTimeoutInMinutes     int `mapstructure:"replay_timeout_in_minutes" default:"180"`
-	ExecutionIntervalInSeconds int `mapstructure:"execution_interval_in_seconds" default:"120"`
+	ReplayTimeoutInMinutes            int               `mapstructure:"replay_timeout_in_minutes" default:"180"`
+	ExecutionIntervalInSeconds        int               `mapstructure:"execution_interval_in_seconds" default:"120"`
+	PluginExecutionProjectConfigNames map[string]string `mapstructure:"plugin_execution_project_config_names"`
 }
 
 type Publisher struct {

--- a/core/scheduler/service/replay_service.go
+++ b/core/scheduler/service/replay_service.go
@@ -195,7 +195,6 @@ func NewReplayService(
 	logger log.Logger,
 	pluginToExecutionProjectKeyMap map[string]string,
 ) *ReplayService {
-
 	return &ReplayService{
 		replayRepo:                     replayRepo,
 		jobRepo:                        jobRepo,

--- a/core/scheduler/service/replay_service.go
+++ b/core/scheduler/service/replay_service.go
@@ -22,11 +22,9 @@ const (
 	defaultExecutionProjectConfigKey = "EXECUTION_PROJECT"
 )
 
-var (
-	namespaceConfigForReplayMap = map[string]string{
-		"REPLAY_EXECUTION_PROJECT": defaultExecutionProjectConfigKey,
-	}
-)
+var namespaceConfigForReplayMap = map[string]string{
+	"REPLAY_EXECUTION_PROJECT": defaultExecutionProjectConfigKey,
+}
 
 type SchedulerRunGetter interface {
 	GetJobRuns(ctx context.Context, t tenant.Tenant, criteria *scheduler.JobRunsCriteria, jobCron *cron.ScheduleSpec) ([]*scheduler.JobRunStatus, error)

--- a/optimus.sample.yaml
+++ b/optimus.sample.yaml
@@ -38,7 +38,9 @@ project:
 #    # relative path where resource spec for BQ are stored
 #    path: "bq"
 #  # namespace variables usable in specifications
-#  config: {}
+#  config: 
+#    # for bq-related jobs, execution project specific to replay jobs are stored here
+#    replay_execution_project: "data_replay_project"
 #- name: sample_namespace_2
 #  job:
 #    path: "ns2/job"

--- a/server/optimus.go
+++ b/server/optimus.go
@@ -338,7 +338,11 @@ func (s *OptimusServer) setupHandlers() error {
 	replayRepository := schedulerRepo.NewReplayRepository(s.dbPool)
 	replayWorker := schedulerService.NewReplayWorker(s.logger, replayRepository, jobProviderRepo, newScheduler, s.conf.Replay)
 	replayValidator := schedulerService.NewValidator(replayRepository, newScheduler, jobProviderRepo)
-	replayService := schedulerService.NewReplayService(replayRepository, jobProviderRepo, tenantService, replayValidator, replayWorker, newScheduler, s.logger)
+	replayService := schedulerService.NewReplayService(
+		replayRepository, jobProviderRepo, tenantService,
+		replayValidator, replayWorker, newScheduler,
+		s.logger, s.conf.Replay.PluginExecutionProjectConfigNames,
+	)
 
 	newJobRunService := schedulerService.NewJobRunService(
 		s.logger, jobProviderRepo, jobRunRepo, replayRepository, operatorRunRepository,

--- a/server/optimus.go
+++ b/server/optimus.go
@@ -338,7 +338,7 @@ func (s *OptimusServer) setupHandlers() error {
 	replayRepository := schedulerRepo.NewReplayRepository(s.dbPool)
 	replayWorker := schedulerService.NewReplayWorker(s.logger, replayRepository, jobProviderRepo, newScheduler, s.conf.Replay)
 	replayValidator := schedulerService.NewValidator(replayRepository, newScheduler, jobProviderRepo)
-	replayService := schedulerService.NewReplayService(replayRepository, jobProviderRepo, replayValidator, replayWorker, newScheduler, s.logger)
+	replayService := schedulerService.NewReplayService(replayRepository, jobProviderRepo, tNamespaceRepo, replayValidator, replayWorker, newScheduler, s.logger)
 
 	newJobRunService := schedulerService.NewJobRunService(
 		s.logger, jobProviderRepo, jobRunRepo, replayRepository, operatorRunRepository,

--- a/server/optimus.go
+++ b/server/optimus.go
@@ -338,7 +338,7 @@ func (s *OptimusServer) setupHandlers() error {
 	replayRepository := schedulerRepo.NewReplayRepository(s.dbPool)
 	replayWorker := schedulerService.NewReplayWorker(s.logger, replayRepository, jobProviderRepo, newScheduler, s.conf.Replay)
 	replayValidator := schedulerService.NewValidator(replayRepository, newScheduler, jobProviderRepo)
-	replayService := schedulerService.NewReplayService(replayRepository, jobProviderRepo, tNamespaceRepo, replayValidator, replayWorker, newScheduler, s.logger)
+	replayService := schedulerService.NewReplayService(replayRepository, jobProviderRepo, tenantService, replayValidator, replayWorker, newScheduler, s.logger)
 
 	newJobRunService := schedulerService.NewJobRunService(
 		s.logger, jobProviderRepo, jobRunRepo, replayRepository, operatorRunRepository,


### PR DESCRIPTION
# Description
Add a functionality in CreateReplay to read `REPLAY_EXECUTION_PROJECT` & `ALLOWED_EXECUTION_PROJECTS` config value from namespace-level & project-level config. This in turn adds a new config key stored in namespace & project.
Nevertheless we will still allow execution project override by providing replay job config in the command.
```yaml
# example
version: 1
log:
  level: INFO
  format: ""
host: localhost:9200
project:
  name: test-optimus-ahmad
  config:
    allowed_execution_projects: pilotdata-integration,data-test
    replay_execution_project: pilotdata-integration
  # ...
namespaces:
- name: test_namespace_ahmad
  config:
    replay_execution_project: pilotdata-integration-specific
  job:
    path: test_namespace_ahmad/jobs
  datastore:
  - type: bigquery
    path: test_namespace_ahmad/resources
    backup: {}
```