### PR TITLE
feat: support routine bigquery on job validation

### DIFF
--- a/ext/store/bigquery/bigquery.go
+++ b/ext/store/bigquery/bigquery.go
@@ -290,7 +290,7 @@ func (s Store) Exist(ctx context.Context, tnnt tenant.Tenant, urn resource.URN) 
 		},
 		KindExternalTable: client.ExternalTableHandleFrom,
 		KindView:          client.ViewHandleFrom,
-		KindFunction:      client.RoutineHandleFrom,
+		KindRoutine:       client.RoutineHandleFrom,
 	}
 
 	for kind, resourceHandleFn := range kindToHandleFn {

--- a/ext/store/bigquery/bigquery.go
+++ b/ext/store/bigquery/bigquery.go
@@ -43,6 +43,7 @@ type Client interface {
 	TableHandleFrom(dataset Dataset, name string) TableResourceHandle
 	ExternalTableHandleFrom(dataset Dataset, name string) ResourceHandle
 	ViewHandleFrom(dataset Dataset, name string) ResourceHandle
+	RoutineHandleFrom(ds Dataset, name string) ResourceHandle
 	BulkGetDDLView(ctx context.Context, dataset ProjectDataset, names []string) (map[ResourceURN]string, error)
 	Close() error
 }
@@ -289,6 +290,7 @@ func (s Store) Exist(ctx context.Context, tnnt tenant.Tenant, urn resource.URN) 
 		},
 		KindExternalTable: client.ExternalTableHandleFrom,
 		KindView:          client.ViewHandleFrom,
+		KindFunction:      client.RoutineHandleFrom,
 	}
 
 	for kind, resourceHandleFn := range kindToHandleFn {

--- a/ext/store/bigquery/bigquery_test.go
+++ b/ext/store/bigquery/bigquery_test.go
@@ -946,9 +946,6 @@ func TestBigqueryStore(t *testing.T) {
 			secretProvider := new(mockSecretProvider)
 			defer secretProvider.AssertExpectations(t)
 
-			extTableHandle := new(mockTableResourceHandle)
-			defer extTableHandle.AssertExpectations(t)
-
 			client := new(mockClient)
 			defer client.AssertExpectations(t)
 
@@ -996,6 +993,60 @@ func TestBigqueryStore(t *testing.T) {
 			actualExist, actualError := bqStore.Exist(ctx, tnnt, urn)
 
 			assert.True(t, actualExist)
+			assert.NoError(t, actualError)
+		})
+
+		t.Run("returns false and error if dataset exists and underlying routine does not exist", func(t *testing.T) {
+			secretProvider := new(mockSecretProvider)
+			defer secretProvider.AssertExpectations(t)
+
+			client := new(mockClient)
+			defer client.AssertExpectations(t)
+
+			clientProvider := new(mockClientProvider)
+			defer clientProvider.AssertExpectations(t)
+
+			dataSetHandle := new(mockTableResourceHandle)
+			tableHandle := new(mockTableResourceHandle)
+			externalTableHandle := new(mockTableResourceHandle)
+			viewHandle := new(mockTableResourceHandle)
+			routineHandle := new(mockTableResourceHandle)
+			defer func() {
+				dataSetHandle.AssertExpectations(t)
+				tableHandle.AssertExpectations(t)
+				externalTableHandle.AssertExpectations(t)
+				viewHandle.AssertExpectations(t)
+				routineHandle.AssertExpectations(t)
+			}()
+
+			bqStore := bigquery.NewBigqueryDataStore(secretProvider, clientProvider)
+
+			urn, err := resource.NewURN("bigquery", "project.dataset.routine")
+			assert.NoError(t, err)
+
+			pts, _ := tenant.NewPlainTextSecret("secret_name", "secret_value")
+			secretProvider.On("GetSecret", mock.Anything, tnnt, "DATASTORE_BIGQUERY").Return(pts, nil)
+
+			clientProvider.On("Get", mock.Anything, pts.Value()).Return(client, nil)
+
+			client.On("Close").Return(nil)
+
+			client.On("DatasetHandleFrom", mock.Anything, mock.Anything).Return(dataSetHandle)
+			dataSetHandle.On("Exists", mock.Anything).Return(true)
+
+			client.On("TableHandleFrom", mock.Anything, mock.Anything).Return(tableHandle).Maybe()
+			tableHandle.On("Exists", mock.Anything).Return(false).Maybe()
+			client.On("ExternalTableHandleFrom", mock.Anything, mock.Anything).Return(externalTableHandle).Maybe()
+			externalTableHandle.On("Exists", mock.Anything).Return(false).Maybe()
+			client.On("ViewHandleFrom", mock.Anything, mock.Anything).Return(viewHandle).Maybe()
+			viewHandle.On("Exists", mock.Anything).Return(false).Maybe()
+
+			client.On("RoutineHandleFrom", mock.Anything, mock.Anything).Return(routineHandle)
+			routineHandle.On("Exists", mock.Anything).Return(false)
+
+			actualExist, actualError := bqStore.Exist(ctx, tnnt, urn)
+
+			assert.False(t, actualExist)
 			assert.NoError(t, actualError)
 		})
 

--- a/ext/store/bigquery/bigquery_test.go
+++ b/ext/store/bigquery/bigquery_test.go
@@ -934,6 +934,7 @@ func TestBigqueryStore(t *testing.T) {
 			client.On("TableHandleFrom", mock.Anything, mock.Anything).Return(handle).Maybe()
 			client.On("ExternalTableHandleFrom", mock.Anything, mock.Anything).Return(handle).Maybe()
 			client.On("ViewHandleFrom", mock.Anything, mock.Anything).Return(handle).Maybe()
+			client.On("RoutineHandleFrom", mock.Anything, mock.Anything).Return(handle).Maybe()
 
 			actualExist, actualError := bqStore.Exist(ctx, tnnt, urn)
 
@@ -970,12 +971,13 @@ func TestBigqueryStore(t *testing.T) {
 			client.On("Close").Return(nil)
 
 			handle.On("Exists", mock.Anything).Return(true).Once()
-			handle.On("Exists", mock.Anything).Return(false).Times(3)
+			handle.On("Exists", mock.Anything).Return(false).Times(4)
 
 			client.On("DatasetHandleFrom", mock.Anything, mock.Anything).Return(handle)
 			client.On("TableHandleFrom", mock.Anything, mock.Anything).Return(handle)
 			client.On("ExternalTableHandleFrom", mock.Anything, mock.Anything).Return(handle)
 			client.On("ViewHandleFrom", mock.Anything, mock.Anything).Return(handle)
+			client.On("RoutineHandleFrom", mock.Anything, mock.Anything).Return(handle)
 
 			actualExist, actualError := bqStore.Exist(ctx, tnnt, urn)
 
@@ -1027,6 +1029,11 @@ func (m *mockClient) ExternalTableHandleFrom(ds bigquery.Dataset, name string) b
 func (m *mockClient) TableHandleFrom(ds bigquery.Dataset, name string) bigquery.TableResourceHandle {
 	args := m.Called(ds, name)
 	return args.Get(0).(bigquery.TableResourceHandle)
+}
+
+func (m *mockClient) RoutineHandleFrom(ds bigquery.Dataset, name string) bigquery.ResourceHandle {
+	args := m.Called(ds, name)
+	return args.Get(0).(bigquery.ResourceHandle)
 }
 
 func (m *mockClient) ViewHandleFrom(ds bigquery.Dataset, name string) bigquery.ResourceHandle {

--- a/ext/store/bigquery/bigquery_test.go
+++ b/ext/store/bigquery/bigquery_test.go
@@ -942,6 +942,63 @@ func TestBigqueryStore(t *testing.T) {
 			assert.NoError(t, actualError)
 		})
 
+		t.Run("returns true and nil if dataset exists and underlying routine does exist", func(t *testing.T) {
+			secretProvider := new(mockSecretProvider)
+			defer secretProvider.AssertExpectations(t)
+
+			extTableHandle := new(mockTableResourceHandle)
+			defer extTableHandle.AssertExpectations(t)
+
+			client := new(mockClient)
+			defer client.AssertExpectations(t)
+
+			clientProvider := new(mockClientProvider)
+			defer clientProvider.AssertExpectations(t)
+
+			dataSetHandle := new(mockTableResourceHandle)
+			tableHandle := new(mockTableResourceHandle)
+			externalTableHandle := new(mockTableResourceHandle)
+			viewHandle := new(mockTableResourceHandle)
+			routineHandle := new(mockTableResourceHandle)
+			defer func() {
+				dataSetHandle.AssertExpectations(t)
+				tableHandle.AssertExpectations(t)
+				externalTableHandle.AssertExpectations(t)
+				viewHandle.AssertExpectations(t)
+				routineHandle.AssertExpectations(t)
+			}()
+
+			bqStore := bigquery.NewBigqueryDataStore(secretProvider, clientProvider)
+
+			urn, err := resource.NewURN("bigquery", "project.dataset.routine")
+			assert.NoError(t, err)
+
+			pts, _ := tenant.NewPlainTextSecret("secret_name", "secret_value")
+			secretProvider.On("GetSecret", mock.Anything, tnnt, "DATASTORE_BIGQUERY").Return(pts, nil)
+
+			clientProvider.On("Get", mock.Anything, pts.Value()).Return(client, nil)
+
+			client.On("Close").Return(nil)
+
+			client.On("DatasetHandleFrom", mock.Anything, mock.Anything).Return(dataSetHandle)
+			dataSetHandle.On("Exists", mock.Anything).Return(true)
+
+			client.On("TableHandleFrom", mock.Anything, mock.Anything).Return(tableHandle).Maybe()
+			tableHandle.On("Exists", mock.Anything).Return(false).Maybe()
+			client.On("ExternalTableHandleFrom", mock.Anything, mock.Anything).Return(externalTableHandle).Maybe()
+			externalTableHandle.On("Exists", mock.Anything).Return(false).Maybe()
+			client.On("ViewHandleFrom", mock.Anything, mock.Anything).Return(viewHandle).Maybe()
+			viewHandle.On("Exists", mock.Anything).Return(false).Maybe()
+
+			client.On("RoutineHandleFrom", mock.Anything, mock.Anything).Return(routineHandle)
+			routineHandle.On("Exists", mock.Anything).Return(true)
+
+			actualExist, actualError := bqStore.Exist(ctx, tnnt, urn)
+
+			assert.True(t, actualExist)
+			assert.NoError(t, actualError)
+		})
+
 		t.Run("returns false and nil if dataset exists and underlying resource does not exist", func(t *testing.T) {
 			secretProvider := new(mockSecretProvider)
 			defer secretProvider.AssertExpectations(t)

--- a/ext/store/bigquery/bigquery_test.go
+++ b/ext/store/bigquery/bigquery_test.go
@@ -996,7 +996,7 @@ func TestBigqueryStore(t *testing.T) {
 			assert.NoError(t, actualError)
 		})
 
-		t.Run("returns false and error if dataset exists and underlying routine does not exist", func(t *testing.T) {
+		t.Run("returns false and nil error if dataset exists and underlying routine does not exist", func(t *testing.T) {
 			secretProvider := new(mockSecretProvider)
 			defer secretProvider.AssertExpectations(t)
 

--- a/ext/store/bigquery/client.go
+++ b/ext/store/bigquery/client.go
@@ -51,6 +51,11 @@ func (c *BqClient) TableHandleFrom(ds Dataset, name string) TableResourceHandle 
 	return NewTableHandle(t)
 }
 
+func (c *BqClient) RoutineHandleFrom(ds Dataset, name string) ResourceHandle {
+	t := c.DatasetInProject(ds.Project, ds.DatasetName).Routine(name)
+	return NewRoutineHandle(t)
+}
+
 func (c *BqClient) ExternalTableHandleFrom(ds Dataset, name string) ResourceHandle {
 	t := c.DatasetInProject(ds.Project, ds.DatasetName).Table(name)
 	return NewExternalTableHandle(t)

--- a/ext/store/bigquery/client_test.go
+++ b/ext/store/bigquery/client_test.go
@@ -87,6 +87,18 @@ func TestBqClient(t *testing.T) {
 			assert.NotNil(t, handle)
 		})
 	})
+	t.Run("RoutineHandleFrom", func(t *testing.T) {
+		t.Run("returns the routine handle", func(t *testing.T) {
+			c, err := bigquery.NewClient(ctx, testCredJSON)
+			assert.Nil(t, err)
+
+			dataset, err := bigquery.DataSetFrom("project", "dataset")
+			assert.Nil(t, err)
+
+			handle := c.RoutineHandleFrom(dataset, "routines")
+			assert.NotNil(t, handle)
+		})
+	})
 	t.Run("Close", func(t *testing.T) {
 		t.Run("calls close on bq client", func(t *testing.T) {
 			c, err := bigquery.NewClient(ctx, testCredJSON)

--- a/ext/store/bigquery/routine.go
+++ b/ext/store/bigquery/routine.go
@@ -11,7 +11,7 @@ import (
 
 const EntityRoutine = "routines"
 
-// BqRoutine is including UDF, Store Procedure, Table Function, Reference: https://cloud.google.com/bigquery/docs/routines#:~:text=In%20BigQuery%2C%20routines%20are%20a,Table%20functions.
+// BqRoutine is including UDF, Store Procedure, Table Function
 type BqRoutine interface {
 	Create(ctx context.Context, rm *bigquery.RoutineMetadata) (err error)
 	Update(ctx context.Context, upd *bigquery.RoutineMetadataToUpdate, etag string) (rm *bigquery.RoutineMetadata, err error)

--- a/ext/store/bigquery/routine.go
+++ b/ext/store/bigquery/routine.go
@@ -9,7 +9,7 @@ import (
 	"github.com/goto/optimus/internal/errors"
 )
 
-const EntityRoutine = "routines"
+const EntityRoutine = "resource_routine"
 
 // BqRoutine is including UDF, Store Procedure, Table Function
 type BqRoutine interface {

--- a/ext/store/bigquery/routine.go
+++ b/ext/store/bigquery/routine.go
@@ -1,0 +1,41 @@
+package bigquery
+
+import (
+	"context"
+
+	"cloud.google.com/go/bigquery"
+
+	"github.com/goto/optimus/core/resource"
+	"github.com/goto/optimus/internal/errors"
+)
+
+const EntityRoutine = "routines"
+
+// BqRoutine is including UDF, Store Procedure, Table Function, Reference: https://cloud.google.com/bigquery/docs/routines#:~:text=In%20BigQuery%2C%20routines%20are%20a,Table%20functions.
+type BqRoutine interface {
+	Create(ctx context.Context, rm *bigquery.RoutineMetadata) (err error)
+	Update(ctx context.Context, upd *bigquery.RoutineMetadataToUpdate, etag string) (rm *bigquery.RoutineMetadata, err error)
+	Metadata(ctx context.Context) (*bigquery.RoutineMetadata, error)
+}
+
+type RoutineHandle struct {
+	bqRoutine BqRoutine
+}
+
+func (r RoutineHandle) Create(_ context.Context, _ *resource.Resource) error {
+	return errors.FailedPrecondition(EntityRoutine, "create is not supported")
+}
+
+func (r RoutineHandle) Update(_ context.Context, _ *resource.Resource) error {
+	return errors.FailedPrecondition(EntityRoutine, "update is not supported")
+}
+
+func (r RoutineHandle) Exists(ctx context.Context) bool {
+	_, err := r.bqRoutine.Metadata(ctx)
+	// There can be connection issue, we return false for now
+	return err == nil
+}
+
+func NewRoutineHandle(bq BqRoutine) *RoutineHandle {
+	return &RoutineHandle{bqRoutine: bq}
+}

--- a/ext/store/bigquery/routine.go
+++ b/ext/store/bigquery/routine.go
@@ -22,11 +22,11 @@ type RoutineHandle struct {
 	bqRoutine BqRoutine
 }
 
-func (r RoutineHandle) Create(_ context.Context, _ *resource.Resource) error {
+func (RoutineHandle) Create(_ context.Context, _ *resource.Resource) error {
 	return errors.FailedPrecondition(EntityRoutine, "create is not supported")
 }
 
-func (r RoutineHandle) Update(_ context.Context, _ *resource.Resource) error {
+func (RoutineHandle) Update(_ context.Context, _ *resource.Resource) error {
 	return errors.FailedPrecondition(EntityRoutine, "update is not supported")
 }
 

--- a/ext/store/bigquery/routine_test.go
+++ b/ext/store/bigquery/routine_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 
 	"cloud.google.com/go/bigquery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/goto/optimus/core/resource"
 	"github.com/goto/optimus/core/tenant"
 	storebigquery "github.com/goto/optimus/ext/store/bigquery"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestRoutineHandle(t *testing.T) {
@@ -162,7 +162,8 @@ func (_m *mockBigQueryRoutine) Update(ctx context.Context, upd *bigquery.Routine
 func NewMockBigQueryRoutine(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *mockBigQueryRoutine {
+},
+) *mockBigQueryRoutine {
 	mock := &mockBigQueryRoutine{}
 	mock.Mock.Test(t)
 

--- a/ext/store/bigquery/routine_test.go
+++ b/ext/store/bigquery/routine_test.go
@@ -33,7 +33,7 @@ func TestRoutineHandle(t *testing.T) {
 			handle := storebigquery.NewRoutineHandle(v)
 
 			err := handle.Create(ctx, res)
-			assert.EqualError(t, err, "failed precondition for entity routines: create is not supported")
+			assert.EqualError(t, err, "failed precondition for entity resource_routine: create is not supported")
 		})
 	})
 
@@ -43,7 +43,7 @@ func TestRoutineHandle(t *testing.T) {
 			handle := storebigquery.NewRoutineHandle(v)
 
 			err := handle.Update(ctx, res)
-			assert.EqualError(t, err, "failed precondition for entity routines: update is not supported")
+			assert.EqualError(t, err, "failed precondition for entity resource_routine: update is not supported")
 		})
 	})
 

--- a/ext/store/bigquery/routine_test.go
+++ b/ext/store/bigquery/routine_test.go
@@ -29,7 +29,7 @@ func TestRoutineHandle(t *testing.T) {
 
 	t.Run("Create", func(t *testing.T) {
 		t.Run("return error, not supported", func(t *testing.T) {
-			v := new(mockBigQueryRoutine)
+			v := NewMockBigQueryRoutine(t)
 			handle := storebigquery.NewRoutineHandle(v)
 
 			err := handle.Create(ctx, res)
@@ -39,7 +39,7 @@ func TestRoutineHandle(t *testing.T) {
 
 	t.Run("Update", func(t *testing.T) {
 		t.Run("return error, not supported", func(t *testing.T) {
-			v := new(mockBigQueryRoutine)
+			v := NewMockBigQueryRoutine(t)
 			handle := storebigquery.NewRoutineHandle(v)
 
 			err := handle.Update(ctx, res)
@@ -49,7 +49,7 @@ func TestRoutineHandle(t *testing.T) {
 
 	t.Run("Exists", func(t *testing.T) {
 		t.Run("return true, routine exists", func(t *testing.T) {
-			v := new(mockBigQueryRoutine)
+			v := NewMockBigQueryRoutine(t)
 			handle := storebigquery.NewRoutineHandle(v)
 
 			v.On("Metadata", ctx).Return(nil, nil)
@@ -59,7 +59,7 @@ func TestRoutineHandle(t *testing.T) {
 		})
 
 		t.Run("return false, routine not exists", func(t *testing.T) {
-			v := new(mockBigQueryRoutine)
+			v := NewMockBigQueryRoutine(t)
 			handle := storebigquery.NewRoutineHandle(v)
 
 			v.On("Metadata", ctx).Return(nil, errors.New("some error"))
@@ -69,7 +69,7 @@ func TestRoutineHandle(t *testing.T) {
 		})
 
 		t.Run("return false, connection error", func(t *testing.T) {
-			v := new(mockBigQueryRoutine)
+			v := NewMockBigQueryRoutine(t)
 			handle := storebigquery.NewRoutineHandle(v)
 
 			v.On("Metadata", ctx).Return(nil, context.DeadlineExceeded)
@@ -159,7 +159,7 @@ func (_m *mockBigQueryRoutine) Update(ctx context.Context, upd *bigquery.Routine
 	return r0, r1
 }
 
-func NewBqRoutine(t interface {
+func NewMockBigQueryRoutine(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *mockBigQueryRoutine {

--- a/ext/store/bigquery/routine_test.go
+++ b/ext/store/bigquery/routine_test.go
@@ -1,0 +1,172 @@
+package bigquery_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+
+	"github.com/goto/optimus/core/resource"
+	"github.com/goto/optimus/core/tenant"
+	storebigquery "github.com/goto/optimus/ext/store/bigquery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestRoutineHandle(t *testing.T) {
+	ctx := context.Background()
+	bqStore := resource.Bigquery
+	tnnt, _ := tenant.NewTenant("proj", "ns")
+	metadata := resource.Metadata{
+		Version:     1,
+		Description: "resource description",
+		Labels:      map[string]string{"owner": "optimus"},
+	}
+	spec := map[string]any{"description": []string{"a", "b"}}
+	res, err := resource.NewResource("proj.dataset.view1", storebigquery.KindView, bqStore, tnnt, &metadata, spec)
+	assert.Nil(t, err)
+
+	t.Run("Create", func(t *testing.T) {
+		t.Run("return error, not supported", func(t *testing.T) {
+			v := new(mockBigQueryRoutine)
+			handle := storebigquery.NewRoutineHandle(v)
+
+			err := handle.Create(ctx, res)
+			assert.EqualError(t, err, "failed precondition for entity routines: create is not supported")
+		})
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		t.Run("return error, not supported", func(t *testing.T) {
+			v := new(mockBigQueryRoutine)
+			handle := storebigquery.NewRoutineHandle(v)
+
+			err := handle.Update(ctx, res)
+			assert.EqualError(t, err, "failed precondition for entity routines: update is not supported")
+		})
+	})
+
+	t.Run("Exists", func(t *testing.T) {
+		t.Run("return true, routine exists", func(t *testing.T) {
+			v := new(mockBigQueryRoutine)
+			handle := storebigquery.NewRoutineHandle(v)
+
+			v.On("Metadata", ctx).Return(nil, nil)
+
+			actual := handle.Exists(ctx)
+			assert.True(t, actual)
+		})
+
+		t.Run("return false, routine not exists", func(t *testing.T) {
+			v := new(mockBigQueryRoutine)
+			handle := storebigquery.NewRoutineHandle(v)
+
+			v.On("Metadata", ctx).Return(nil, errors.New("some error"))
+
+			actual := handle.Exists(ctx)
+			assert.False(t, actual)
+		})
+
+		t.Run("return false, connection error", func(t *testing.T) {
+			v := new(mockBigQueryRoutine)
+			handle := storebigquery.NewRoutineHandle(v)
+
+			v.On("Metadata", ctx).Return(nil, context.DeadlineExceeded)
+
+			actual := handle.Exists(ctx)
+			assert.False(t, actual)
+		})
+	})
+}
+
+type mockBigQueryRoutine struct {
+	mock.Mock
+}
+
+func (_m *mockBigQueryRoutine) Create(ctx context.Context, rm *bigquery.RoutineMetadata) error {
+	ret := _m.Called(ctx, rm)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Create")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *bigquery.RoutineMetadata) error); ok {
+		r0 = rf(ctx, rm)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+func (_m *mockBigQueryRoutine) Metadata(ctx context.Context) (*bigquery.RoutineMetadata, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Metadata")
+	}
+
+	var r0 *bigquery.RoutineMetadata
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (*bigquery.RoutineMetadata, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) *bigquery.RoutineMetadata); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*bigquery.RoutineMetadata)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+func (_m *mockBigQueryRoutine) Update(ctx context.Context, upd *bigquery.RoutineMetadataToUpdate, etag string) (*bigquery.RoutineMetadata, error) {
+	ret := _m.Called(ctx, upd, etag)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Update")
+	}
+
+	var r0 *bigquery.RoutineMetadata
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *bigquery.RoutineMetadataToUpdate, string) (*bigquery.RoutineMetadata, error)); ok {
+		return rf(ctx, upd, etag)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *bigquery.RoutineMetadataToUpdate, string) *bigquery.RoutineMetadata); ok {
+		r0 = rf(ctx, upd, etag)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*bigquery.RoutineMetadata)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *bigquery.RoutineMetadataToUpdate, string) error); ok {
+		r1 = rf(ctx, upd, etag)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+func NewBqRoutine(t interface {
+	mock.TestingT
+	Cleanup(func())
+}) *mockBigQueryRoutine {
+	mock := &mockBigQueryRoutine{}
+	mock.Mock.Test(t)
+
+	t.Cleanup(func() { mock.AssertExpectations(t) })
+
+	return mock
+}

--- a/ext/store/bigquery/schema.go
+++ b/ext/store/bigquery/schema.go
@@ -19,7 +19,7 @@ const (
 	KindTable         string = "table"
 	KindView          string = "view"
 	KindExternalTable string = "external_table"
-	KindFunction      string = "function"
+	KindRoutine       string = "routine"
 )
 
 type Schema []Field

--- a/ext/store/bigquery/schema.go
+++ b/ext/store/bigquery/schema.go
@@ -19,6 +19,7 @@ const (
 	KindTable         string = "table"
 	KindView          string = "view"
 	KindExternalTable string = "external_table"
+	KindFunction      string = "function"
 )
 
 type Schema []Field

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,6 @@ require (
 	gocloud.dev v0.26.0
 	golang.org/x/net v0.10.0
 	golang.org/x/oauth2 v0.6.0
-	golang.org/x/sys v0.11.0
 	google.golang.org/api v0.103.0
 	google.golang.org/genproto v0.0.0-20221117204609-8f9c96812029
 	google.golang.org/grpc v1.50.1
@@ -162,6 +161,7 @@ require (
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.12.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/term v0.11.0 // indirect
 	golang.org/x/text v0.12.0 // indirect
 	golang.org/x/time v0.3.0 // indirect


### PR DESCRIPTION
## Description
- support job validation depends on [Routine](https://cloud.google.com/bigquery/docs/routines#:~:text=In%20BigQuery%2C%20routines%20are%20a,Table%20functions.) in BigQuery datastore

## Glossary
- Routine is including User Defined Functions, Table Function, Store Procedure