### PR TITLE
fix: increase timeout in optimus apply to 60mins

### DIFF
--- a/client/cmd/apply/apply.go
+++ b/client/cmd/apply/apply.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	applyTimeout     = time.Minute * 5
+	applyTimeout     = time.Minute * 60
 	executedPlanFile = "plan_apply.json"
 )
 


### PR DESCRIPTION
### Summary
Increase timeout for `optimus apply` command from 5 mins to 60 mins, to support large changes