### PR TITLE
fix: increase timeout in optimus job validate to 60mins

### DIFF
--- a/client/cmd/job/validate.go
+++ b/client/cmd/job/validate.go
@@ -24,7 +24,7 @@ import (
 	pb "github.com/goto/optimus/protos/gotocompany/optimus/core/v1beta1"
 )
 
-const validateTimeout = time.Minute * 15
+const validateTimeout = time.Minute * 60
 
 type validateCommand struct {
 	logger     log.Logger


### PR DESCRIPTION
### Summary
Increase timeout for `optimus job validate` command's server side calls from 15 mins to 60 mins, to support large changes