### PR TITLE
fix: plan migrate job log verbose

### DIFF
--- a/client/cmd/job/plan.go
+++ b/client/cmd/job/plan.go
@@ -206,7 +206,7 @@ func (p *planCommand) printPlan(plans plan.Plan) {
 		p.logger.Info(msg)
 	}
 
-	for namespace, planList := range plans.Resource.Migrate {
+	for namespace, planList := range plans.Job.Migrate {
 		for i := range planList {
 			msg := fmt.Sprintf("[%s] plan migrate job %v from old_namespace: %s", namespace, planList[i].GetName(), *planList[i].OldNamespace)
 			p.logger.Info(msg)


### PR DESCRIPTION
## Description
- before this changes, job migrate plan are not logged
- this changes will logged job migrate plan properly when verbose flag are set