### PR TITLE
fix: add missing param on successSentCounter.WithLabelValues in alertmanager

### DIFF
--- a/ext/notify/alertmanager/alertManager.go
+++ b/ext/notify/alertmanager/alertManager.go
@@ -126,7 +126,7 @@ func (a *AlertManager) worker(ctx context.Context) {
 				eventWorkerSendErrCounter.WithLabelValues(e.Project, e.LogTag, err.Error()).Inc()
 				a.workerErrChan <- fmt.Errorf("alert worker: %w", err)
 			} else {
-				successSentCounter.WithLabelValues().Inc()
+				successSentCounter.WithLabelValues(e.Project, e.LogTag).Inc()
 			}
 		case <-ctx.Done():
 			close(a.workerErrChan)


### PR DESCRIPTION
### Description
Add missing labels param in `successSentCounter.WithLabelValues` function call in alertManager.
The missing labels cause panic when our alerting system, Siren, returns 200.
<img width="1308" alt="image" src="https://github.com/user-attachments/assets/3d2ce7c0-c872-4185-ba29-ee4193a278ef">
