### PR TITLE
feat: support resource spec v2

### DIFF
--- a/core/resource/handler/v1beta1/resource.go
+++ b/core/resource/handler/v1beta1/resource.go
@@ -435,6 +435,9 @@ func (rh ResourceHandler) GetResourceChangelogs(ctx context.Context, req *pb.Get
 	}
 
 	resourceName := resource.Name(req.GetResourceName())
+	if resourceName == "" {
+		return nil, errors.GRPCErr(errors.InvalidArgument(resource.EntityResource, "resource name is empty"))
+	}
 
 	changelogs, err := rh.changelogService.GetChangelogs(ctx, projectName, resourceName)
 	if err != nil {

--- a/core/resource/handler/v1beta1/resource.go
+++ b/core/resource/handler/v1beta1/resource.go
@@ -434,10 +434,7 @@ func (rh ResourceHandler) GetResourceChangelogs(ctx context.Context, req *pb.Get
 		return nil, errors.GRPCErr(err, "invalid project name")
 	}
 
-	resourceName, err := resource.NameFrom(req.GetResourceName())
-	if err != nil {
-		return nil, errors.GRPCErr(err, "invalid resource name")
-	}
+	resourceName := resource.Name(req.GetResourceName())
 
 	changelogs, err := rh.changelogService.GetChangelogs(ctx, projectName, resourceName)
 	if err != nil {

--- a/core/resource/handler/v1beta1/resource.go
+++ b/core/resource/handler/v1beta1/resource.go
@@ -436,7 +436,7 @@ func (rh ResourceHandler) GetResourceChangelogs(ctx context.Context, req *pb.Get
 
 	resourceName := resource.Name(req.GetResourceName())
 	if resourceName == "" {
-		return nil, errors.GRPCErr(errors.InvalidArgument(resource.EntityResource, "resource name is empty"))
+		return nil, errors.GRPCErr(errors.InvalidArgument(resource.EntityResource, "resource name is empty"), "invalid parameter")
 	}
 
 	changelogs, err := rh.changelogService.GetChangelogs(ctx, projectName, resourceName)

--- a/core/resource/resource.go
+++ b/core/resource/resource.go
@@ -17,6 +17,8 @@ const (
 
 	UnspecifiedImpactChange    UpdateImpact = "unspecified_impact"
 	ResourceDataPipeLineImpact UpdateImpact = "data_impact"
+
+	DefaultResourceSpecVersion = 2
 )
 
 type UpdateImpact string
@@ -181,6 +183,14 @@ func (r *Resource) Status() Status {
 
 func (r *Resource) Spec() map[string]any {
 	return r.spec
+}
+
+func (r *Resource) Version() int32 {
+	if r.metadata == nil {
+		return DefaultResourceSpecVersion
+	}
+
+	return r.metadata.Version
 }
 
 func (r *Resource) Equal(incoming *Resource) bool {

--- a/core/resource/resource.go
+++ b/core/resource/resource.go
@@ -189,7 +189,7 @@ func (r *Resource) Spec() map[string]any {
 }
 
 func (r *Resource) Version() int32 {
-	if r.metadata == nil {
+	if r.metadata == nil || r.metadata.Version == 0 {
 		return DefaultResourceSpecVersion
 	}
 

--- a/core/resource/resource.go
+++ b/core/resource/resource.go
@@ -18,7 +18,10 @@ const (
 	UnspecifiedImpactChange    UpdateImpact = "unspecified_impact"
 	ResourceDataPipeLineImpact UpdateImpact = "data_impact"
 
-	DefaultResourceSpecVersion = 2
+	ResourceSpecV1 = 1
+	ResourceSpecV2 = 2
+
+	DefaultResourceSpecVersion = ResourceSpecV1
 )
 
 type UpdateImpact string

--- a/core/resource/resource_test.go
+++ b/core/resource/resource_test.go
@@ -604,4 +604,41 @@ func TestResource(t *testing.T) {
 			})
 		})
 	})
+
+	t.Run("Version", func(t *testing.T) {
+		t.Run("returns default version if no version is provided", func(t *testing.T) {
+			tnnt, tnntErr := tenant.NewTenant("proj", "ns")
+			assert.Nil(t, tnntErr)
+
+			metadata := &resource.Metadata{
+				Description: "description",
+			}
+			spec := map[string]any{
+				"description": "spec for unit test",
+			}
+			res, err := resource.NewResource("proj.set.res_name", "table", resource.Bigquery, tnnt, metadata, spec)
+			assert.Nil(t, err)
+
+			version := res.Version()
+			assert.Equal(t, int32(resource.DefaultResourceSpecVersion), version)
+		})
+
+		t.Run("returns version from metadata if metadata is not nil", func(t *testing.T) {
+			tnnt, tnntErr := tenant.NewTenant("proj", "ns")
+			assert.Nil(t, tnntErr)
+
+			meta := &resource.Metadata{
+				Version:     resource.ResourceSpecV2,
+				Description: "description",
+			}
+			spec := map[string]any{
+				"description": "spec for unit test",
+			}
+			res, err := resource.NewResource("proj.set.res_name", "table", resource.Bigquery, tnnt, meta, spec)
+			assert.Nil(t, err)
+
+			version := res.Version()
+			assert.Equal(t, int32(resource.ResourceSpecV2), version)
+		})
+	})
 }

--- a/core/resource/service/resource_service.go
+++ b/core/resource/service/resource_service.go
@@ -26,6 +26,7 @@ type ResourceRepository interface {
 	ReadByFullName(ctx context.Context, tnnt tenant.Tenant, store resource.Store, fullName string, onlyActive bool) (*resource.Resource, error)
 	ReadAll(ctx context.Context, tnnt tenant.Tenant, store resource.Store, onlyActive bool) ([]*resource.Resource, error)
 	GetResources(ctx context.Context, tnnt tenant.Tenant, store resource.Store, names []string) ([]*resource.Resource, error)
+	ReadByURN(ctx context.Context, tnnt tenant.Tenant, urn resource.URN) (*resource.Resource, error)
 }
 
 type ResourceManager interface {
@@ -348,17 +349,7 @@ func (rs ResourceService) GetByURN(ctx context.Context, tnnt tenant.Tenant, urn 
 		return nil, errors.InvalidArgument(resource.EntityResource, "urn is zero value")
 	}
 
-	store, err := resource.FromStringToStore(urn.GetStore())
-	if err != nil {
-		return nil, err
-	}
-
-	name, err := resource.NameFrom(urn.GetName())
-	if err != nil {
-		return nil, err
-	}
-
-	return rs.repo.ReadByFullName(ctx, tnnt, store, name.String(), false)
+	return rs.repo.ReadByURN(ctx, tnnt, urn)
 }
 
 func (rs ResourceService) ExistInStore(ctx context.Context, tnnt tenant.Tenant, urn resource.URN) (bool, error) {

--- a/ext/store/bigquery/backup.go
+++ b/ext/store/bigquery/backup.go
@@ -92,7 +92,7 @@ func CreateIfDatasetDoesNotExist(ctx context.Context, client Client, dataset Dat
 }
 
 func BackupTable(ctx context.Context, backup *resource.Backup, source *resource.Resource, client Client) (string, error) {
-	sourceDataset, sourceName, err := determineDatasetAndResourceName(source)
+	sourceDataset, sourceName, err := getDatasetAndResourceName(source)
 	if err != nil {
 		return "", err
 	}

--- a/ext/store/bigquery/backup.go
+++ b/ext/store/bigquery/backup.go
@@ -92,11 +92,7 @@ func CreateIfDatasetDoesNotExist(ctx context.Context, client Client, dataset Dat
 }
 
 func BackupTable(ctx context.Context, backup *resource.Backup, source *resource.Resource, client Client) (string, error) {
-	sourceDataset, err := DataSetFor(source.Name())
-	if err != nil {
-		return "", err
-	}
-	sourceName, err := ResourceNameFor(source.Name(), source.Kind())
+	sourceDataset, sourceName, err := determineDatasetAndResourceName(source)
 	if err != nil {
 		return "", err
 	}

--- a/ext/store/bigquery/bigquery.go
+++ b/ext/store/bigquery/bigquery.go
@@ -77,7 +77,7 @@ func (s Store) Create(ctx context.Context, res *resource.Resource) error {
 	}
 	defer client.Close()
 
-	dataset, resourceName, err := determineDatasetAndResourceName(res)
+	dataset, resourceName, err := getDatasetAndResourceName(res)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func (s Store) Update(ctx context.Context, res *resource.Resource) error {
 	}
 	defer client.Close()
 
-	dataset, resourceName, err := determineDatasetAndResourceName(res)
+	dataset, resourceName, err := getDatasetAndResourceName(res)
 	if err != nil {
 		return err
 	}
@@ -146,19 +146,19 @@ func (s Store) Update(ctx context.Context, res *resource.Resource) error {
 	}
 }
 
-func determineDatasetAndResourceName(res *resource.Resource) (Dataset, string, error) {
+func getDatasetAndResourceName(res *resource.Resource) (Dataset, string, error) {
 	if res.Version() == resource.ResourceSpecV2 {
-		bqURN, err := NewResourceURNFromString(res.URN().String())
+		bqURN, err := getURNComponent(res)
 		if err != nil {
 			return Dataset{}, "", err
 		}
 
-		dataset, err := DataSetFrom(bqURN.Project(), bqURN.Dataset())
+		dataset, err := DataSetFrom(bqURN.Project, bqURN.Dataset)
 		if err != nil {
 			return Dataset{}, "", err
 		}
 
-		return dataset, bqURN.Name(), nil
+		return dataset, bqURN.Name, nil
 	}
 
 	dataset, err := DataSetFor(res.Name())

--- a/ext/store/bigquery/bigquery.go
+++ b/ext/store/bigquery/bigquery.go
@@ -77,7 +77,7 @@ func (s Store) Create(ctx context.Context, res *resource.Resource) error {
 	}
 	defer client.Close()
 
-	dataset, resourceName, err := s.determineDatasetAndResourceName(res)
+	dataset, resourceName, err := determineDatasetAndResourceName(res)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func (s Store) Update(ctx context.Context, res *resource.Resource) error {
 	}
 	defer client.Close()
 
-	dataset, resourceName, err := s.determineDatasetAndResourceName(res)
+	dataset, resourceName, err := determineDatasetAndResourceName(res)
 	if err != nil {
 		return err
 	}
@@ -146,8 +146,8 @@ func (s Store) Update(ctx context.Context, res *resource.Resource) error {
 	}
 }
 
-func (Store) determineDatasetAndResourceName(res *resource.Resource) (Dataset, string, error) {
-	if res.Version() == resource.DefaultResourceSpecVersion {
+func determineDatasetAndResourceName(res *resource.Resource) (Dataset, string, error) {
+	if res.Version() == resource.ResourceSpecV2 {
 		bqURN, err := NewResourceURNFromString(res.URN().String())
 		if err != nil {
 			return Dataset{}, "", err

--- a/ext/store/bigquery/bigquery.go
+++ b/ext/store/bigquery/bigquery.go
@@ -77,11 +77,7 @@ func (s Store) Create(ctx context.Context, res *resource.Resource) error {
 	}
 	defer client.Close()
 
-	dataset, err := DataSetFor(res.Name())
-	if err != nil {
-		return err
-	}
-	resourceName, err := ResourceNameFor(res.Name(), res.Kind())
+	dataset, resourceName, err := s.determineDatasetAndResourceName(res)
 	if err != nil {
 		return err
 	}
@@ -123,11 +119,7 @@ func (s Store) Update(ctx context.Context, res *resource.Resource) error {
 	}
 	defer client.Close()
 
-	dataset, err := DataSetFor(res.Name())
-	if err != nil {
-		return err
-	}
-	resourceName, err := ResourceNameFor(res.Name(), res.Kind())
+	dataset, resourceName, err := s.determineDatasetAndResourceName(res)
 	if err != nil {
 		return err
 	}
@@ -152,6 +144,34 @@ func (s Store) Update(ctx context.Context, res *resource.Resource) error {
 	default:
 		return errors.InvalidArgument(store, "invalid kind for bigquery resource "+res.Kind())
 	}
+}
+
+func (Store) determineDatasetAndResourceName(res *resource.Resource) (Dataset, string, error) {
+	if res.Version() == resource.DefaultResourceSpecVersion {
+		bqURN, err := NewResourceURNFromString(res.URN().String())
+		if err != nil {
+			return Dataset{}, "", err
+		}
+
+		dataset, err := DataSetFrom(bqURN.Project(), bqURN.Dataset())
+		if err != nil {
+			return Dataset{}, "", err
+		}
+
+		return dataset, bqURN.Name(), nil
+	}
+
+	dataset, err := DataSetFor(res.Name())
+	if err != nil {
+		return Dataset{}, "", err
+	}
+
+	resourceName, err := ResourceNameFor(res.Name(), res.Kind())
+	if err != nil {
+		return Dataset{}, "", err
+	}
+
+	return dataset, resourceName, nil
 }
 
 func (s Store) BatchUpdate(ctx context.Context, resources []*resource.Resource) error {

--- a/ext/store/bigquery/bigquery_test.go
+++ b/ext/store/bigquery/bigquery_test.go
@@ -226,6 +226,119 @@ func TestBigqueryStore(t *testing.T) {
 			err = bqStore.Create(ctx, extTable)
 			assert.Nil(t, err)
 		})
+
+		// v2 spec tests
+		metadataV2 := resource.Metadata{
+			Version: resource.ResourceSpecV2,
+		}
+		expectedDs := bigquery.Dataset{Project: "project-new", DatasetName: "dataset-new"}
+
+		t.Run("calls appropriate handler for dataset with v2 spec", func(t *testing.T) {
+			specV2 := map[string]any{
+				"description": "resource",
+				"project":     "project-new",
+				"dataset":     "dataset-new",
+			}
+
+			pts, _ := tenant.NewPlainTextSecret("secret_name", "secret_value")
+			secretProvider := new(mockSecretProvider)
+			secretProvider.On("GetSecret", mock.Anything, tnnt, "DATASTORE_BIGQUERY").
+				Return(pts, nil)
+			defer secretProvider.AssertExpectations(t)
+
+			datasetRes, err := resource.NewResource("project-dataset", bigquery.KindDataset, store, tnnt, &metadataV2, specV2)
+			assert.Nil(t, err)
+
+			datasetHandle := new(mockTableResourceHandle)
+			datasetHandle.On("Create", mock.Anything, datasetRes).Return(nil)
+			defer datasetHandle.AssertExpectations(t)
+
+			client := new(mockClient)
+			client.On("Close").Return(nil)
+			client.On("DatasetHandleFrom", expectedDs).Return(datasetHandle)
+			defer client.AssertExpectations(t)
+
+			clientProvider := new(mockClientProvider)
+			clientProvider.On("Get", mock.Anything, "secret_value").Return(client, nil)
+			defer clientProvider.AssertExpectations(t)
+
+			bqStore := bigquery.NewBigqueryDataStore(secretProvider, clientProvider)
+
+			err = bqStore.Create(ctx, datasetRes)
+			assert.Nil(t, err)
+		})
+
+		t.Run("calls appropriate handler for table with v2 spec", func(t *testing.T) {
+			specV2 := map[string]any{
+				"description": "resource",
+				"project":     "project-new",
+				"dataset":     "dataset-new",
+				"name":        "table-new",
+			}
+
+			pts, _ := tenant.NewPlainTextSecret("secret_name", "secret_value")
+			secretProvider := new(mockSecretProvider)
+			secretProvider.On("GetSecret", mock.Anything, tnnt, "DATASTORE_BIGQUERY").
+				Return(pts, nil)
+			defer secretProvider.AssertExpectations(t)
+
+			tableRes, err := resource.NewResource("project.dataset.table", bigquery.KindTable, store, tnnt, &metadataV2, specV2)
+			assert.Nil(t, err)
+
+			tableHandle := new(mockTableResourceHandle)
+			tableHandle.On("Create", mock.Anything, tableRes).Return(nil)
+			defer tableHandle.AssertExpectations(t)
+
+			client := new(mockClient)
+			client.On("Close").Return(nil)
+			client.On("TableHandleFrom", expectedDs, "table-new").Return(tableHandle)
+			defer client.AssertExpectations(t)
+
+			clientProvider := new(mockClientProvider)
+			clientProvider.On("Get", mock.Anything, "secret_value").Return(client, nil)
+			defer clientProvider.AssertExpectations(t)
+
+			bqStore := bigquery.NewBigqueryDataStore(secretProvider, clientProvider)
+
+			err = bqStore.Create(ctx, tableRes)
+			assert.Nil(t, err)
+		})
+
+		t.Run("calls appropriate handler for view with v2 spec", func(t *testing.T) {
+			specV2 := map[string]any{
+				"description": "resource",
+				"project":     "project-new",
+				"dataset":     "dataset-new",
+				"name":        "view-new",
+			}
+
+			pts, _ := tenant.NewPlainTextSecret("secret_name", "secret_value")
+			secretProvider := new(mockSecretProvider)
+			secretProvider.On("GetSecret", mock.Anything, tnnt, "DATASTORE_BIGQUERY").
+				Return(pts, nil)
+			defer secretProvider.AssertExpectations(t)
+
+			viewRes, err := resource.NewResource("project.dataset.table", bigquery.KindView, store, tnnt, &metadataV2, specV2)
+			assert.NoError(t, err)
+
+			viewHandle := new(mockTableResourceHandle)
+			viewHandle.On("Create", mock.Anything, viewRes).Return(nil)
+			defer viewHandle.AssertExpectations(t)
+
+			client := new(mockClient)
+			client.On("Close").Return(nil)
+			client.On("ViewHandleFrom", expectedDs, "view-new").Return(viewHandle)
+			defer client.AssertExpectations(t)
+
+			clientProvider := new(mockClientProvider)
+			clientProvider.On("Get", mock.Anything, "secret_value").Return(client, nil)
+			defer clientProvider.AssertExpectations(t)
+
+			bqStore := bigquery.NewBigqueryDataStore(secretProvider, clientProvider)
+
+			err = bqStore.Create(ctx, viewRes)
+			assert.Nil(t, err)
+		})
 	})
 	t.Run("Update", func(t *testing.T) {
 		t.Run("returns error when secret is not provided", func(t *testing.T) {
@@ -424,6 +537,119 @@ func TestBigqueryStore(t *testing.T) {
 			bqStore := bigquery.NewBigqueryDataStore(secretProvider, clientProvider)
 
 			err = bqStore.Update(ctx, extTable)
+			assert.Nil(t, err)
+		})
+
+		// v2 spec tests
+		metadataV2 := resource.Metadata{
+			Version: resource.ResourceSpecV2,
+		}
+		expectedDs := bigquery.Dataset{Project: "project-new", DatasetName: "dataset-new"}
+
+		t.Run("calls appropriate handler for dataset with v2 spec", func(t *testing.T) {
+			specV2 := map[string]any{
+				"description": "resource",
+				"project":     "project-new",
+				"dataset":     "dataset-new",
+			}
+
+			pts, _ := tenant.NewPlainTextSecret("secret_name", "secret_value")
+			secretProvider := new(mockSecretProvider)
+			secretProvider.On("GetSecret", mock.Anything, tnnt, "DATASTORE_BIGQUERY").
+				Return(pts, nil)
+			defer secretProvider.AssertExpectations(t)
+
+			datasetRes, err := resource.NewResource("project-dataset", bigquery.KindDataset, store, tnnt, &metadataV2, specV2)
+			assert.Nil(t, err)
+
+			datasetHandle := new(mockTableResourceHandle)
+			datasetHandle.On("Update", mock.Anything, datasetRes).Return(nil)
+			defer datasetHandle.AssertExpectations(t)
+
+			client := new(mockClient)
+			client.On("Close").Return(nil)
+			client.On("DatasetHandleFrom", expectedDs).Return(datasetHandle)
+			defer client.AssertExpectations(t)
+
+			clientProvider := new(mockClientProvider)
+			clientProvider.On("Get", mock.Anything, "secret_value").Return(client, nil)
+			defer clientProvider.AssertExpectations(t)
+
+			bqStore := bigquery.NewBigqueryDataStore(secretProvider, clientProvider)
+
+			err = bqStore.Update(ctx, datasetRes)
+			assert.Nil(t, err)
+		})
+
+		t.Run("calls appropriate handler for table with v2 spec", func(t *testing.T) {
+			specV2 := map[string]any{
+				"description": "resource",
+				"project":     "project-new",
+				"dataset":     "dataset-new",
+				"name":        "table-new",
+			}
+
+			pts, _ := tenant.NewPlainTextSecret("secret_name", "secret_value")
+			secretProvider := new(mockSecretProvider)
+			secretProvider.On("GetSecret", mock.Anything, tnnt, "DATASTORE_BIGQUERY").
+				Return(pts, nil)
+			defer secretProvider.AssertExpectations(t)
+
+			tableRes, err := resource.NewResource("project.dataset.table", bigquery.KindTable, store, tnnt, &metadataV2, specV2)
+			assert.Nil(t, err)
+
+			tableHandle := new(mockTableResourceHandle)
+			tableHandle.On("Update", mock.Anything, tableRes).Return(nil)
+			defer tableHandle.AssertExpectations(t)
+
+			client := new(mockClient)
+			client.On("Close").Return(nil)
+			client.On("TableHandleFrom", expectedDs, "table-new").Return(tableHandle)
+			defer client.AssertExpectations(t)
+
+			clientProvider := new(mockClientProvider)
+			clientProvider.On("Get", mock.Anything, "secret_value").Return(client, nil)
+			defer clientProvider.AssertExpectations(t)
+
+			bqStore := bigquery.NewBigqueryDataStore(secretProvider, clientProvider)
+
+			err = bqStore.Update(ctx, tableRes)
+			assert.Nil(t, err)
+		})
+
+		t.Run("calls appropriate handler for view with v2 spec", func(t *testing.T) {
+			specV2 := map[string]any{
+				"description": "resource",
+				"project":     "project-new",
+				"dataset":     "dataset-new",
+				"name":        "view-new",
+			}
+
+			pts, _ := tenant.NewPlainTextSecret("secret_name", "secret_value")
+			secretProvider := new(mockSecretProvider)
+			secretProvider.On("GetSecret", mock.Anything, tnnt, "DATASTORE_BIGQUERY").
+				Return(pts, nil)
+			defer secretProvider.AssertExpectations(t)
+
+			viewRes, err := resource.NewResource("project.dataset.table", bigquery.KindView, store, tnnt, &metadataV2, specV2)
+			assert.NoError(t, err)
+
+			viewHandle := new(mockTableResourceHandle)
+			viewHandle.On("Update", mock.Anything, viewRes).Return(nil)
+			defer viewHandle.AssertExpectations(t)
+
+			client := new(mockClient)
+			client.On("Close").Return(nil)
+			client.On("ViewHandleFrom", expectedDs, "view-new").Return(viewHandle)
+			defer client.AssertExpectations(t)
+
+			clientProvider := new(mockClientProvider)
+			clientProvider.On("Get", mock.Anything, "secret_value").Return(client, nil)
+			defer clientProvider.AssertExpectations(t)
+
+			bqStore := bigquery.NewBigqueryDataStore(secretProvider, clientProvider)
+
+			err = bqStore.Update(ctx, viewRes)
 			assert.Nil(t, err)
 		})
 	})

--- a/ext/store/bigquery/dataset_spec.go
+++ b/ext/store/bigquery/dataset_spec.go
@@ -196,9 +196,18 @@ func urnForV1(res *resource.Resource) (resource.URN, error) {
 	return resource.NewURN(resource.Bigquery.String(), name)
 }
 
-func urnForV2(res *resource.Resource) (resource.URN, error) {
+func getURNComponent(res *resource.Resource) (URNComponent, error) {
 	var spec URNComponent
 	if err := mapstructure.Decode(res.Spec(), &spec); err != nil {
+		return spec, err
+	}
+
+	return spec, nil
+}
+
+func urnForV2(res *resource.Resource) (resource.URN, error) {
+	spec, err := getURNComponent(res)
+	if err != nil {
 		return resource.ZeroURN(), errors.InvalidArgument(resource.EntityResource, "not able to decode spec")
 	}
 


### PR DESCRIPTION
### Summary
Add a new support for Resource Spec V2 in Optimus, which conceptually separates **Optimus resource name** from the actual name used to create the reosurce in respective datastore (for now, BigQuery).
Example:
```
version: 2
name: mart.namespace.table
type: table
labels:
  example: label
spec:
  project: warehouse-mart
  dataset:  namespace_specific
  name: table
  schema:
  - mode: NULLABLE
    name: event_timestamp
    type: DATE
  - mode: NULLABLE
    name: uuid
    type: STRING
```
the Optimus resource name is:`mart.namespace.table`, meanwhile the name of the table in bigquery will be: `warehouse-mart.namespace_specific.table`