### PR TITLE
feat: add apply masking policy function to maxcompute table

### DIFF
--- a/ext/store/maxcompute/client.go
+++ b/ext/store/maxcompute/client.go
@@ -44,12 +44,12 @@ func NewClient(svcAccount string) (*MaxComputeClient, error) {
 	return &MaxComputeClient{odpsIns}, nil
 }
 
-func (c *MaxComputeClient) TableHandleFrom(projectSchema ProjectSchema) TableResourceHandle {
+func (c *MaxComputeClient) TableHandleFrom(projectSchema ProjectSchema, maskingPolicyHandle TableMaskingPolicyHandle) TableResourceHandle {
 	c.SetDefaultProjectName(projectSchema.Project)
 	c.SetCurrentSchemaName(projectSchema.Schema)
 	s := c.Schemas()
 	t := c.Tables()
-	return NewTableHandle(c, s, t)
+	return NewTableHandle(c, s, t, maskingPolicyHandle)
 }
 
 func (c *MaxComputeClient) ExternalTableHandleFrom(projectSchema ProjectSchema, getter TenantDetailsGetter) TableResourceHandle {
@@ -66,6 +66,14 @@ func (c *MaxComputeClient) ViewHandleFrom(projectSchema ProjectSchema) TableReso
 	s := c.Schemas()
 	t := c.Tables()
 	return NewViewHandle(c, s, t)
+}
+
+func (c *MaxComputeClient) TableMaskingPolicyHandleFrom(projectSchema ProjectSchema) TableMaskingPolicyHandle {
+	c.SetDefaultProjectName(projectSchema.Project)
+	c.SetCurrentSchemaName(projectSchema.Schema)
+	t := c.Tables()
+	w := McTableWrapper{t}
+	return NewMaskingPolicyHandle(c, w)
 }
 
 func (c *MaxComputeClient) GetDDLView(_ context.Context, table string) (string, error) {

--- a/ext/store/maxcompute/client_test.go
+++ b/ext/store/maxcompute/client_test.go
@@ -38,7 +38,10 @@ func TestMaxComputeClient(t *testing.T) {
 			projectSchema, err := maxcompute.ProjectSchemaFrom("proj", "schema")
 			assert.Nil(t, err)
 
-			tableHandle := client.TableHandleFrom(projectSchema)
+			maskingPolicyHandle := client.TableMaskingPolicyHandleFrom(projectSchema)
+			assert.Nil(t, err)
+
+			tableHandle := client.TableHandleFrom(projectSchema, maskingPolicyHandle)
 			assert.NotNil(t, tableHandle)
 		})
 	})

--- a/ext/store/maxcompute/masking_policy.go
+++ b/ext/store/maxcompute/masking_policy.go
@@ -38,7 +38,7 @@ func NewMaskingPolicyHandle(mcSQLExecutor McSQLExecutor, mcTables McTables) Tabl
 
 func (h MaskingPolicyHandle) Process(table *Table) error {
 	newMaskPolicies := h.getNewMaskPolicies(table)
-	existingMaskPolicies, err := h.getExistingMaskPolicies(table.FullName())
+	existingMaskPolicies, err := h.getExistingMaskPolicies(table.Name)
 	if err != nil {
 		return err
 	}

--- a/ext/store/maxcompute/masking_policy.go
+++ b/ext/store/maxcompute/masking_policy.go
@@ -1,0 +1,149 @@
+package maxcompute
+
+import (
+	"fmt"
+
+	"github.com/aliyun/aliyun-odps-go-sdk/odps"
+
+	"github.com/goto/optimus/internal/errors"
+	"github.com/goto/optimus/internal/utils"
+)
+
+type McTables interface {
+	BatchLoadTables(tableNames []string) ([]McTableInstance, error)
+}
+
+type McTableInstance interface {
+	Load() error
+	ColumnMaskInfos() ([]odps.ColumnMaskInfo, error)
+}
+
+type maskingPolicyTracker struct {
+	ColumnName string
+	ToCreate   []string
+	ToDelete   []string
+}
+
+type MaskingPolicyHandle struct {
+	mcSQLExecutor McSQLExecutor
+	mcTable       McTables
+}
+
+func NewMaskingPolicyHandle(mcSQLExecutor McSQLExecutor, mcTables McTables) TableMaskingPolicyHandle {
+	return &MaskingPolicyHandle{
+		mcSQLExecutor: mcSQLExecutor,
+		mcTable:       mcTables,
+	}
+}
+
+func (h MaskingPolicyHandle) Process(table *Table) error {
+	newMaskPolicies := h.getNewMaskPolicies(table)
+	existingMaskPolicies, err := h.getExistingMaskPolicies(table.FullName())
+	if err != nil {
+		return err
+	}
+
+	tracker := compareMaskPolicies(newMaskPolicies, existingMaskPolicies)
+
+	return h.applyMaskPolicyChanges(tracker, table.Name)
+}
+
+func (MaskingPolicyHandle) getNewMaskPolicies(table *Table) []odps.ColumnMaskInfo {
+	newMaskPolicies := []odps.ColumnMaskInfo{}
+	for _, column := range table.Schema {
+		if column.MaskPolicy == "" && column.UnmaskPolicy == "" {
+			continue
+		}
+
+		maskPolicyNames := []string{}
+		if column.MaskPolicy != "" {
+			maskPolicyNames = append(maskPolicyNames, column.MaskPolicy)
+		}
+		if column.UnmaskPolicy != "" {
+			maskPolicyNames = append(maskPolicyNames, column.UnmaskPolicy)
+		}
+
+		newMaskPolicies = append(newMaskPolicies, odps.ColumnMaskInfo{
+			Name:           column.Name,
+			PolicyNameList: maskPolicyNames,
+		})
+	}
+
+	return newMaskPolicies
+}
+
+func (h MaskingPolicyHandle) getExistingMaskPolicies(tableName string) ([]odps.ColumnMaskInfo, error) {
+	tables, err := h.mcTable.BatchLoadTables([]string{tableName})
+	if err != nil {
+		return nil, errors.InternalError(EntityTable, "error while get table on maxcompute", err)
+	}
+	existing := tables[0]
+
+	err = existing.Load()
+	if err != nil {
+		return nil, errors.InternalError(EntityTable, "error while loading table from maxcompute", err)
+	}
+
+	existingMaskPolicies, err := existing.ColumnMaskInfos()
+	if err != nil {
+		return nil, errors.InternalError(EntityTable, "error while getting column mask info from maxcompute", err)
+	}
+	return existingMaskPolicies, nil
+}
+
+func (h MaskingPolicyHandle) applyMaskPolicyChanges(trackers []maskingPolicyTracker, tableName string) error {
+	sqlTasks := []string{}
+	schemaName := h.mcSQLExecutor.CurrentSchemaName()
+
+	for _, t := range trackers {
+		for _, policy := range t.ToDelete {
+			sqlTasks = append(sqlTasks, fmt.Sprintf("APPLY DATA MASKING POLICY %s UNBIND FROM TABLE %s.%s COLUMN %s;", policy, schemaName, tableName, t.ColumnName))
+		}
+
+		for _, policy := range t.ToCreate {
+			sqlTasks = append(sqlTasks, fmt.Sprintf("APPLY DATA MASKING POLICY %s BIND TO TABLE %s.%s COLUMN %s;", policy, schemaName, tableName, t.ColumnName))
+		}
+	}
+
+	me := errors.NewMultiError("error when applying masking policies")
+	for _, task := range sqlTasks {
+		ins, err := h.mcSQLExecutor.ExecSQlWithHints(task, nil)
+		if err != nil {
+			me.Append(err)
+			continue
+		}
+
+		err = ins.WaitForSuccess()
+		me.Append(err)
+	}
+
+	return me.ToErr()
+}
+
+func compareMaskPolicies(newColumnMasks, existingColumnMasks []odps.ColumnMaskInfo) []maskingPolicyTracker {
+	existingMap := make(map[string]odps.ColumnMaskInfo)
+	for _, column := range existingColumnMasks {
+		existingMap[column.Name] = column
+	}
+
+	var trackers []maskingPolicyTracker
+	for _, column := range newColumnMasks {
+		tracker := maskingPolicyTracker{ColumnName: column.Name}
+		if existing, found := existingMap[column.Name]; found {
+			tracker.ToCreate, tracker.ToDelete = utils.CompareStringSlices(column.PolicyNameList, existing.PolicyNameList)
+			delete(existingMap, column.Name)
+		} else {
+			tracker.ToCreate = column.PolicyNameList
+		}
+		trackers = append(trackers, tracker)
+	}
+
+	for _, column := range existingMap {
+		trackers = append(trackers, maskingPolicyTracker{
+			ColumnName: column.Name,
+			ToDelete:   column.PolicyNameList,
+		})
+	}
+
+	return trackers
+}

--- a/ext/store/maxcompute/masking_policy_test.go
+++ b/ext/store/maxcompute/masking_policy_test.go
@@ -1,0 +1,165 @@
+package maxcompute_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aliyun/aliyun-odps-go-sdk/odps"
+	"github.com/aliyun/aliyun-odps-go-sdk/odps/account"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/goto/optimus/ext/store/maxcompute"
+)
+
+func TestMaskingPolicyHandle(t *testing.T) {
+	accessID, accessKey, endpoint := "access_id", "access_key", "http://service.ap-southeast-5.maxcompute.aliyun.com/api"
+	projectName, schemaName, tableName := "proj", "schema", "test"
+	odpsInstance := odps.NewInstance(odps.NewOdps(account.NewAliyunAccount(accessID, accessKey), endpoint), projectName, "")
+	tableFullName := "proj.schema.test"
+
+	tbl := maxcompute.Table{
+		Name:     tableName,
+		Database: schemaName,
+		Project:  projectName,
+		Schema: maxcompute.Schema{
+			{Name: "column1", MaskPolicy: "mask_policy", UnmaskPolicy: "unmask_policy"},
+			{Name: "column2"},
+			{Name: "column3"},
+		},
+	}
+
+	t.Run("Process", func(t *testing.T) {
+		t.Run("returns error when not able to get table", func(t *testing.T) {
+			mockTables := new(mockMcTables)
+			mockTables.On("BatchLoadTables", []string{tableFullName}).Return(nil, errors.New("error fetching table detail"))
+			defer mockTables.AssertExpectations(t)
+
+			mockSQLExecutor := new(mockOdpsIns)
+
+			handle := maxcompute.NewMaskingPolicyHandle(mockSQLExecutor, mockTables)
+			err := handle.Process(&tbl)
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "error while get table on maxcompute")
+		})
+
+		t.Run("returns error when not able to load table", func(t *testing.T) {
+			mockTableIns := new(mockTableInstance)
+			mockTableIns.On("Load").Return(errors.New("error fetching table detail"))
+			defer mockTableIns.AssertExpectations(t)
+
+			mockTables := new(mockMcTables)
+			mockTables.On("BatchLoadTables", []string{tableFullName}).Return([]maxcompute.McTableInstance{mockTableIns}, nil)
+			defer mockTables.AssertExpectations(t)
+
+			mockSQLExecutor := new(mockOdpsIns)
+
+			handle := maxcompute.NewMaskingPolicyHandle(mockSQLExecutor, mockTables)
+			err := handle.Process(&tbl)
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "error while loading table from maxcompute")
+		})
+
+		t.Run("returns error when parsing masking information returns error", func(t *testing.T) {
+			mockTableIns := new(mockTableInstance)
+			mockTableIns.On("Load").Return(nil)
+			mockTableIns.On("ColumnMaskInfos").Return(nil, errors.New("error fetching column mask info"))
+			defer mockTableIns.AssertExpectations(t)
+
+			mockTables := new(mockMcTables)
+			mockTables.On("BatchLoadTables", []string{tableFullName}).Return([]maxcompute.McTableInstance{mockTableIns}, nil)
+			defer mockTables.AssertExpectations(t)
+
+			mockSQLExecutor := new(mockOdpsIns)
+
+			handle := maxcompute.NewMaskingPolicyHandle(mockSQLExecutor, mockTables)
+			err := handle.Process(&tbl)
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "error while getting column mask info from maxcompute")
+		})
+
+		t.Run("returns error when executing SQL to apply policy changes", func(t *testing.T) {
+			existingMaskingInfo := []odps.ColumnMaskInfo{
+				{Name: "column2", PolicyNameList: []string{"old_mask_policy", "old_unmask_policy"}},
+			}
+			mockTableIns := new(mockTableInstance)
+			mockTableIns.On("Load").Return(nil)
+			mockTableIns.On("ColumnMaskInfos").Return(existingMaskingInfo, nil)
+			defer mockTableIns.AssertExpectations(t)
+
+			mockTables := new(mockMcTables)
+			mockTables.On("BatchLoadTables", []string{tableFullName}).Return([]maxcompute.McTableInstance{mockTableIns}, nil)
+			defer mockTables.AssertExpectations(t)
+
+			mockSQLExecutor := new(mockOdpsIns)
+			mockSQLExecutor.On("CurrentSchemaName").Return(schemaName)
+			mockSQLExecutor.On("ExecSQlWithHints", mock.Anything, mock.Anything).Return(odpsInstance, errors.New("cannot apply"))
+			defer mockSQLExecutor.AssertExpectations(t)
+
+			handle := maxcompute.NewMaskingPolicyHandle(mockSQLExecutor, mockTables)
+			err := handle.Process(&tbl)
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "error when applying masking policies")
+		})
+
+		t.Run("returns error when waiting for masking policy updates", func(t *testing.T) {
+			existingMaskingInfo := []odps.ColumnMaskInfo{
+				{Name: "column2", PolicyNameList: []string{"old_mask_policy", "old_unmask_policy"}},
+			}
+			mockTableIns := new(mockTableInstance)
+			mockTableIns.On("Load").Return(nil)
+			mockTableIns.On("ColumnMaskInfos").Return(existingMaskingInfo, nil)
+			defer mockTableIns.AssertExpectations(t)
+
+			mockTables := new(mockMcTables)
+			mockTables.On("BatchLoadTables", []string{tableFullName}).Return([]maxcompute.McTableInstance{mockTableIns}, nil)
+			defer mockTables.AssertExpectations(t)
+
+			mockSQLExecutor := new(mockOdpsIns)
+			mockSQLExecutor.On("CurrentSchemaName").Return(schemaName)
+			mockSQLExecutor.On("ExecSQlWithHints", "APPLY DATA MASKING POLICY old_mask_policy UNBIND FROM TABLE schema.test COLUMN column2;", mock.Anything).Return(odpsInstance, nil)
+			mockSQLExecutor.On("ExecSQlWithHints", "APPLY DATA MASKING POLICY old_unmask_policy UNBIND FROM TABLE schema.test COLUMN column2;", mock.Anything).Return(odpsInstance, nil)
+			mockSQLExecutor.On("ExecSQlWithHints", "APPLY DATA MASKING POLICY mask_policy BIND TO TABLE schema.test COLUMN column1;", mock.Anything).Return(odpsInstance, nil)
+			mockSQLExecutor.On("ExecSQlWithHints", "APPLY DATA MASKING POLICY unmask_policy BIND TO TABLE schema.test COLUMN column1;", mock.Anything).Return(odpsInstance, nil)
+			defer mockSQLExecutor.AssertExpectations(t)
+
+			handle := maxcompute.NewMaskingPolicyHandle(mockSQLExecutor, mockTables)
+			err := handle.Process(&tbl)
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "error when applying masking policies")
+		})
+	})
+}
+
+type mockMcTables struct {
+	mock.Mock
+}
+
+func (m *mockMcTables) BatchLoadTables(tableNames []string) ([]maxcompute.McTableInstance, error) {
+	args := m.Called(tableNames)
+	if args.Get(0) != nil {
+		return args.Get(0).([]maxcompute.McTableInstance), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+type mockTableInstance struct {
+	mock.Mock
+}
+
+func (m *mockTableInstance) Load() error {
+	return m.Called().Error(0)
+}
+
+func (m *mockTableInstance) ColumnMaskInfos() ([]odps.ColumnMaskInfo, error) {
+	args := m.Called()
+	if args.Get(0) != nil {
+		return args.Get(0).([]odps.ColumnMaskInfo), args.Error(1)
+	}
+	return nil, args.Error(1)
+}

--- a/ext/store/maxcompute/masking_policy_test.go
+++ b/ext/store/maxcompute/masking_policy_test.go
@@ -16,7 +16,6 @@ func TestMaskingPolicyHandle(t *testing.T) {
 	accessID, accessKey, endpoint := "access_id", "access_key", "http://service.ap-southeast-5.maxcompute.aliyun.com/api"
 	projectName, schemaName, tableName := "proj", "schema", "test"
 	odpsInstance := odps.NewInstance(odps.NewOdps(account.NewAliyunAccount(accessID, accessKey), endpoint), projectName, "")
-	tableFullName := "proj.schema.test"
 
 	tbl := maxcompute.Table{
 		Name:     tableName,
@@ -32,7 +31,7 @@ func TestMaskingPolicyHandle(t *testing.T) {
 	t.Run("Process", func(t *testing.T) {
 		t.Run("returns error when not able to get table", func(t *testing.T) {
 			mockTables := new(mockMcTables)
-			mockTables.On("BatchLoadTables", []string{tableFullName}).Return(nil, errors.New("error fetching table detail"))
+			mockTables.On("BatchLoadTables", []string{tableName}).Return(nil, errors.New("error fetching table detail"))
 			defer mockTables.AssertExpectations(t)
 
 			mockSQLExecutor := new(mockOdpsIns)
@@ -50,7 +49,7 @@ func TestMaskingPolicyHandle(t *testing.T) {
 			defer mockTableIns.AssertExpectations(t)
 
 			mockTables := new(mockMcTables)
-			mockTables.On("BatchLoadTables", []string{tableFullName}).Return([]maxcompute.McTableInstance{mockTableIns}, nil)
+			mockTables.On("BatchLoadTables", []string{tableName}).Return([]maxcompute.McTableInstance{mockTableIns}, nil)
 			defer mockTables.AssertExpectations(t)
 
 			mockSQLExecutor := new(mockOdpsIns)
@@ -69,7 +68,7 @@ func TestMaskingPolicyHandle(t *testing.T) {
 			defer mockTableIns.AssertExpectations(t)
 
 			mockTables := new(mockMcTables)
-			mockTables.On("BatchLoadTables", []string{tableFullName}).Return([]maxcompute.McTableInstance{mockTableIns}, nil)
+			mockTables.On("BatchLoadTables", []string{tableName}).Return([]maxcompute.McTableInstance{mockTableIns}, nil)
 			defer mockTables.AssertExpectations(t)
 
 			mockSQLExecutor := new(mockOdpsIns)
@@ -91,7 +90,7 @@ func TestMaskingPolicyHandle(t *testing.T) {
 			defer mockTableIns.AssertExpectations(t)
 
 			mockTables := new(mockMcTables)
-			mockTables.On("BatchLoadTables", []string{tableFullName}).Return([]maxcompute.McTableInstance{mockTableIns}, nil)
+			mockTables.On("BatchLoadTables", []string{tableName}).Return([]maxcompute.McTableInstance{mockTableIns}, nil)
 			defer mockTables.AssertExpectations(t)
 
 			mockSQLExecutor := new(mockOdpsIns)
@@ -116,7 +115,7 @@ func TestMaskingPolicyHandle(t *testing.T) {
 			defer mockTableIns.AssertExpectations(t)
 
 			mockTables := new(mockMcTables)
-			mockTables.On("BatchLoadTables", []string{tableFullName}).Return([]maxcompute.McTableInstance{mockTableIns}, nil)
+			mockTables.On("BatchLoadTables", []string{tableName}).Return([]maxcompute.McTableInstance{mockTableIns}, nil)
 			defer mockTables.AssertExpectations(t)
 
 			mockSQLExecutor := new(mockOdpsIns)

--- a/ext/store/maxcompute/schema_test.go
+++ b/ext/store/maxcompute/schema_test.go
@@ -442,6 +442,29 @@ func TestFieldValidate(t *testing.T) {
 			assert.NotNil(t, err)
 			assert.ErrorContains(t, err, "unknown field type")
 		})
+		t.Run("returns error when mask policy has invalid characters", func(t *testing.T) {
+			f := maxcompute.Field{
+				Name:       "name",
+				Type:       "string",
+				MaskPolicy: "mask_policy@@",
+			}
+
+			err := f.Validate()
+			assert.NotNil(t, err)
+			assert.ErrorContains(t, err, "mask policy contains invalid characters")
+		})
+		t.Run("returns error when unmask policy has invalid characters", func(t *testing.T) {
+			f := maxcompute.Field{
+				Name:         "name",
+				Type:         "string",
+				MaskPolicy:   "mask_policy",
+				UnmaskPolicy: "unmask_policy@@",
+			}
+
+			err := f.Validate()
+			assert.NotNil(t, err)
+			assert.ErrorContains(t, err, "unmask policy contains invalid characters")
+		})
 	})
 	t.Run("return success when field schema is valid", func(t *testing.T) {
 		f := maxcompute.Field{

--- a/ext/store/maxcompute/table_test.go
+++ b/ext/store/maxcompute/table_test.go
@@ -67,6 +67,15 @@ func (m *mockOdpsIns) SetCurrentSchemaName(schemaName string) {
 	m.Called(schemaName)
 }
 
+type mockTableMaskingPolicyHandle struct {
+	mock.Mock
+}
+
+func (m *mockTableMaskingPolicyHandle) Process(table *maxcompute.Table) error {
+	args := m.Called(table)
+	return args.Error(0)
+}
+
 func TestTableHandle(t *testing.T) {
 	accessID, accessKey, endpoint := "LNRJ5tH1XMSINW5J3TjYAvfX", "lAZBJhdkNbwVj3bej5BuhjwbdV0nSp", "http://service.ap-southeast-5.maxcompute.aliyun.com/api"
 	projectName, schemaName, tableName := "proj", "schema", "test_table"
@@ -90,7 +99,9 @@ func TestTableHandle(t *testing.T) {
 			table := new(mockMaxComputeTable)
 			schema := new(mockMaxComputeSchema)
 			odpsIns := new(mockOdpsIns)
-			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table)
+
+			tableMaskingPolicyHandle := new(mockTableMaskingPolicyHandle)
+			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table, tableMaskingPolicyHandle)
 
 			spec := map[string]any{"description": []string{"test create"}}
 			res, err := resource.NewResource(fullName, maxcompute.KindTable, mcStore, tnnt, &metadata, spec)
@@ -109,7 +120,8 @@ func TestTableHandle(t *testing.T) {
 			odpsIns := new(mockOdpsIns)
 			odpsIns.On("CurrentSchemaName").Return(schemaName)
 			defer odpsIns.AssertExpectations(t)
-			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table)
+			tableMaskingPolicyHandle := new(mockTableMaskingPolicyHandle)
+			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table, tableMaskingPolicyHandle)
 
 			spec := map[string]any{
 				"name":        tableName,
@@ -138,7 +150,8 @@ func TestTableHandle(t *testing.T) {
 			odpsIns := new(mockOdpsIns)
 			odpsIns.On("CurrentSchemaName").Return(schemaName)
 			defer odpsIns.AssertExpectations(t)
-			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table)
+			tableMaskingPolicyHandle := new(mockTableMaskingPolicyHandle)
+			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table, tableMaskingPolicyHandle)
 
 			spec := map[string]any{
 				"name":        tableName,
@@ -173,7 +186,8 @@ func TestTableHandle(t *testing.T) {
 			odpsIns := new(mockOdpsIns)
 			odpsIns.On("CurrentSchemaName").Return(schemaName)
 			defer odpsIns.AssertExpectations(t)
-			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table)
+			tableMaskingPolicyHandle := new(mockTableMaskingPolicyHandle)
+			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table, tableMaskingPolicyHandle)
 
 			spec := map[string]any{
 				"name":        tableName,
@@ -207,7 +221,8 @@ func TestTableHandle(t *testing.T) {
 			odpsIns := new(mockOdpsIns)
 			odpsIns.On("CurrentSchemaName").Return(schemaName)
 			defer odpsIns.AssertExpectations(t)
-			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table)
+			tableMaskingPolicyHandle := new(mockTableMaskingPolicyHandle)
+			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table, tableMaskingPolicyHandle)
 
 			spec := map[string]any{
 				"name":        tableName,
@@ -235,13 +250,20 @@ func TestTableHandle(t *testing.T) {
 			table := new(mockMaxComputeTable)
 			table.On("Create", mock.Anything, false, emptyStringMap, emptyStringMap).Return(nil)
 			defer table.AssertExpectations(t)
+
 			schema := new(mockMaxComputeSchema)
 			schema.On("Create", schemaName, true, mock.Anything).Return(nil)
 			defer schema.AssertExpectations(t)
+
 			odpsIns := new(mockOdpsIns)
 			odpsIns.On("CurrentSchemaName").Return(schemaName)
 			defer odpsIns.AssertExpectations(t)
-			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table)
+
+			tableMaskingPolicyHandle := new(mockTableMaskingPolicyHandle)
+			tableMaskingPolicyHandle.On("Process", mock.Anything).Return(nil)
+			defer tableMaskingPolicyHandle.AssertExpectations(t)
+
+			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table, tableMaskingPolicyHandle)
 
 			spec := map[string]any{
 				"name":        tableName,
@@ -278,7 +300,8 @@ func TestTableHandle(t *testing.T) {
 		t.Run("returns error when cannot convert spec", func(t *testing.T) {
 			schema := new(mockMaxComputeSchema)
 			odpsIns := new(mockOdpsIns)
-			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, nil)
+			tableMaskingPolicyHandle := new(mockTableMaskingPolicyHandle)
+			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, nil, tableMaskingPolicyHandle)
 
 			spec := map[string]any{"description": []string{"test update"}}
 			res, err := resource.NewResource(fullName, maxcompute.KindTable, mcStore, tnnt, &metadata, spec)
@@ -294,7 +317,8 @@ func TestTableHandle(t *testing.T) {
 			defer table.AssertExpectations(t)
 			schema := new(mockMaxComputeSchema)
 			odpsIns := new(mockOdpsIns)
-			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table)
+			tableMaskingPolicyHandle := new(mockTableMaskingPolicyHandle)
+			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table, tableMaskingPolicyHandle)
 
 			spec := map[string]any{
 				"name":        tableName,
@@ -321,7 +345,8 @@ func TestTableHandle(t *testing.T) {
 			defer table.AssertExpectations(t)
 			schema := new(mockMaxComputeSchema)
 			odpsIns := new(mockOdpsIns)
-			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table)
+			tableMaskingPolicyHandle := new(mockTableMaskingPolicyHandle)
+			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table, tableMaskingPolicyHandle)
 
 			spec := map[string]any{
 				"name":        tableName,
@@ -377,7 +402,8 @@ func TestTableHandle(t *testing.T) {
 			odpsIns := new(mockOdpsIns)
 			odpsIns.On("ExecSQlWithHints", mock.Anything, mock.Anything).Return(odpsInstance, fmt.Errorf("sql task is invalid"))
 			defer odpsIns.AssertExpectations(t)
-			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table)
+			tableMaskingPolicyHandle := new(mockTableMaskingPolicyHandle)
+			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table, tableMaskingPolicyHandle)
 
 			spec := map[string]any{
 				"name":     tableName,
@@ -407,7 +433,8 @@ func TestTableHandle(t *testing.T) {
 			odpsIns := new(mockOdpsIns)
 			odpsIns.On("ExecSQlWithHints", mock.Anything, mock.Anything).Return(odpsInstance, nil)
 			defer odpsIns.AssertExpectations(t)
-			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table)
+			tableMaskingPolicyHandle := new(mockTableMaskingPolicyHandle)
+			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table, tableMaskingPolicyHandle)
 
 			spec := map[string]any{
 				"name":     tableName,
@@ -436,7 +463,8 @@ func TestTableHandle(t *testing.T) {
 			defer table.AssertExpectations(t)
 			schema := new(mockMaxComputeSchema)
 			odpsIns := new(mockOdpsIns)
-			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table)
+			tableMaskingPolicyHandle := new(mockTableMaskingPolicyHandle)
+			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table, tableMaskingPolicyHandle)
 
 			exists := tableHandle.Exists(tableName)
 			assert.False(t, exists)
@@ -447,7 +475,8 @@ func TestTableHandle(t *testing.T) {
 			defer table.AssertExpectations(t)
 			schema := new(mockMaxComputeSchema)
 			odpsIns := new(mockOdpsIns)
-			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table)
+			tableMaskingPolicyHandle := new(mockTableMaskingPolicyHandle)
+			tableHandle := maxcompute.NewTableHandle(odpsIns, schema, table, tableMaskingPolicyHandle)
 
 			exists := tableHandle.Exists(tableName)
 			assert.True(t, exists)

--- a/ext/store/maxcompute/wrapper.go
+++ b/ext/store/maxcompute/wrapper.go
@@ -1,0 +1,19 @@
+package maxcompute
+
+// McTableWrapper is a wrapper for McTable which only implements BatchLoadTables so that
+// the return value satisfies the McTableInstance interface
+type McTableWrapper struct {
+	McTable
+}
+
+func (t McTableWrapper) BatchLoadTables(tableNames []string) ([]McTableInstance, error) {
+	tables, err := t.McTable.BatchLoadTables(tableNames)
+	if err != nil {
+		return nil, err
+	}
+	instances := make([]McTableInstance, len(tables))
+	for i, table := range tables {
+		instances[i] = table
+	}
+	return instances, nil
+}

--- a/internal/utils/contains.go
+++ b/internal/utils/contains.go
@@ -9,3 +9,26 @@ func ContainsString(s []string, v string) bool {
 	}
 	return false
 }
+
+// CompareStringSlices compares two string slices, each guaranteed to be unique and
+// returns the items added to newItems & removed from existingItems
+func CompareStringSlices(newItems, existingItems []string) (toAdd, toRemove []string) {
+	existingSet := make(map[string]struct{}, len(existingItems))
+	for _, item := range existingItems {
+		existingSet[item] = struct{}{}
+	}
+
+	for _, item := range newItems {
+		if _, found := existingSet[item]; found {
+			delete(existingSet, item)
+		} else {
+			toAdd = append(toAdd, item)
+		}
+	}
+
+	for item := range existingSet {
+		toRemove = append(toRemove, item)
+	}
+
+	return
+}

--- a/internal/utils/contains_test.go
+++ b/internal/utils/contains_test.go
@@ -41,3 +41,81 @@ func TestContainsString(t *testing.T) {
 		})
 	}
 }
+
+func TestCompareStringSlices(t *testing.T) {
+	type args struct {
+		newItems      []string
+		existingItems []string
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantToAdd    []string
+		wantToRemove []string
+	}{
+		{
+			name: "should return items to add and remove correctly",
+			args: args{
+				newItems:      []string{"a", "b", "c"},
+				existingItems: []string{"b", "c", "d"},
+			},
+			wantToAdd:    []string{"a"},
+			wantToRemove: []string{"d"},
+		},
+		{
+			name: "should return empty slices if no changes",
+			args: args{
+				newItems:      []string{"a", "b", "c"},
+				existingItems: []string{"a", "b", "c"},
+			},
+			wantToAdd:    []string{},
+			wantToRemove: []string{},
+		},
+		{
+			name: "should return all new items if existing is empty",
+			args: args{
+				newItems:      []string{"a", "b", "c"},
+				existingItems: []string{},
+			},
+			wantToAdd:    []string{"a", "b", "c"},
+			wantToRemove: []string{},
+		},
+		{
+			name: "should return all existing items to remove if new is empty",
+			args: args{
+				newItems:      []string{},
+				existingItems: []string{"a", "b", "c"},
+			},
+			wantToAdd:    []string{},
+			wantToRemove: []string{"a", "b", "c"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			toAdd, toRemove := utils.CompareStringSlices(tt.args.newItems, tt.args.existingItems)
+			if !equalSlices(toAdd, tt.wantToAdd) {
+				t.Errorf("CompareStringSlices() gotToAdd = %v, want %v", toAdd, tt.wantToAdd)
+			}
+			if !equalSlices(toRemove, tt.wantToRemove) {
+				t.Errorf("CompareStringSlices() gotToRemove = %v, want %v", toRemove, tt.wantToRemove)
+			}
+		})
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := make(map[string]int)
+	for _, v := range a {
+		counts[v]++
+	}
+	for _, v := range b {
+		if counts[v] == 0 {
+			return false
+		}
+		counts[v]--
+	}
+	return true
+}


### PR DESCRIPTION
**Description**
Add a new functionality in Optimus Maxcompute resource management, specifically on the Maxcompute table creation, to apply data masking policy in the table columns.

**Spec Example**
Resulting spec supported for this functionality can be seen here:
```yaml
version: 2
name: maxcompute_project.schema.example_table
type: table
spec:
  description: This is a sample MaxCompute table
  project: maxcompute_project
  database: schema
  name: example_table
  schema:
    - name: order_id
      type: string 
    - name: order_name
      type: string
      mask_policy: example_masking_mask_policy
      unmask_policy: example_masking_unmask_policy
    - name: order_timestamp
      type: timestamp
    - name: order_date
      type: date
    - name: order_customer
      type: string
      mask_policy: customer_name_mask_policy
      unmask_policy: customer_name_unmask_policy
```