### PR TITLE
refactor: allow no explicit columns in maxcompute views

### DIFF
--- a/ext/store/maxcompute/view.go
+++ b/ext/store/maxcompute/view.go
@@ -100,9 +100,9 @@ func ToViewSQL(v *View) (string, error) {
 		},
 	}
 
-	tplStr := `create or replace view {{ .Database }}.{{ .Name }} {{ if .Columns }}
-	({{ join ", " .Columns }}) {{ end }} {{ if .Description }} 
-	comment '{{ .Description}}' {{ end }} 
+	tplStr := `create or replace view {{ .Database }}.{{ .Name }}{{ if .Columns }}
+	({{ join ", " .Columns }}){{ end }}{{ if .Description }}
+	comment '{{ .Description}}'{{ end }}
 	as
 	{{ .ViewQuery}};`
 

--- a/ext/store/maxcompute/view.go
+++ b/ext/store/maxcompute/view.go
@@ -100,10 +100,10 @@ func ToViewSQL(v *View) (string, error) {
 		},
 	}
 
-	tplStr := `create or replace view {{ .Database }}.{{ .Name }}
-    ({{ join ", " .Columns }}) {{ if .Description }} 
-    comment '{{ .Description}}' {{ end }} 
-    as
+	tplStr := `create or replace view {{ .Database }}.{{ .Name }} {{ if .Columns }}
+	({{ join ", " .Columns }}) {{ end }} {{ if .Description }} 
+	comment '{{ .Description}}' {{ end }} 
+	as
 	{{ .ViewQuery}};`
 
 	tpl, err := template.New("DDL_UPSERT_VIEW").Funcs(fns).Parse(tplStr)

--- a/ext/store/maxcompute/view_spec.go
+++ b/ext/store/maxcompute/view_spec.go
@@ -29,9 +29,5 @@ func (v *View) Validate() error {
 		return errors.InvalidArgument(EntityView, "view query is empty for "+v.FullName())
 	}
 
-	if len(v.Columns) == 0 {
-		return errors.InvalidArgument(EntityView, "column names not provided for "+v.FullName())
-	}
-
 	return nil
 }

--- a/ext/store/maxcompute/view_spec_test.go
+++ b/ext/store/maxcompute/view_spec_test.go
@@ -21,7 +21,7 @@ func TestRelationalView(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.ErrorContains(t, err, "view query is empty for proj.playground.customer")
 	})
-	t.Run("return validation error when column names are empty", func(t *testing.T) {
+	t.Run("has no validation error for correct view with empty columns", func(t *testing.T) {
 		view := maxcompute.View{
 			Name:      "customer",
 			Project:   "proj",
@@ -30,10 +30,9 @@ func TestRelationalView(t *testing.T) {
 		}
 
 		err := view.Validate()
-		assert.NotNil(t, err)
-		assert.ErrorContains(t, err, "column names not provided for proj.playground.customer")
+		assert.Nil(t, err)
 	})
-	t.Run("has no validation error for correct view", func(t *testing.T) {
+	t.Run("has no validation error for correct view with columns", func(t *testing.T) {
 		view := maxcompute.View{
 			Name:      "customer",
 			Database:  "playground",

--- a/ext/store/maxcompute/view_test.go
+++ b/ext/store/maxcompute/view_test.go
@@ -253,9 +253,9 @@ func TestToViewSQL(t *testing.T) {
 				},
 			},
 			want: `create or replace view schema.test_view
-    (a, b, c)  
-    comment 'Create Test View'  
-    as
+	(a, b, c)
+	comment 'Create Test View'
+	as
 	select a, b, c from t1;`,
 			wantErr: nil,
 		},
@@ -271,8 +271,8 @@ func TestToViewSQL(t *testing.T) {
 				},
 			},
 			want: `create or replace view schema.test_view
-    (a, b, c)  
-    as
+	(a, b, c)
+	as
 	select a, b, c from t1;`,
 			wantErr: nil,
 		},


### PR DESCRIPTION
*Summary*
Refactor Maxcompute view creation query so that MaxCompute views can be created without having explicitly defined the columns.

Per Maxcompute documentation on the view creation query ([doc](https://www.alibabacloud.com/help/en/maxcompute/user-guide/create-view#section-91u-ogi-tzb)), view query can be executed without explicitly providing any columns. So this query
```sql
CREATE VIEW project.database.sample_view AS SELECT c1 FROM project.database.sample_table
```
is equal to
```sql
CREATE VIEW project.database.sample_view (c1) AS SELECT c1 FROM project.database.sample_table
```