### PR TITLE
fix: treat empty file as empty specs, skip empty names in optimus plan

### DIFF
--- a/client/cmd/internal/plan/operation_namespace.go
+++ b/client/cmd/internal/plan/operation_namespace.go
@@ -9,6 +9,12 @@ type OperationByNamespaces[kind Kind] struct {
 
 // Add will decide where to add the plan, sourceName: latest state, targetName: current state
 func (o *OperationByNamespaces[Kind]) Add(namespace, sourceName, targetName string, plan Kind) {
+	// do not append to the plan if both sourceName and targetName are empty,
+	// which means there's nothing to track on the changes
+	if len(sourceName) == 0 && len(targetName) == 0 {
+		return
+	}
+
 	plan.SetName(targetName)
 
 	if len(sourceName) > 0 && len(targetName) == 0 {


### PR DESCRIPTION
### Summary
This fixes the ongoing bugs when specs are just created/deleted. Instead of returning error, treat it as empty spec but skip it in the optimus plan file generator.