### PR TITLE
fix(job-finishtime-predictor): do not fail if job detail return error but jobs are populated

### DIFF
--- a/core/scheduler/service/job_expectator_service_test.go
+++ b/core/scheduler/service/job_expectator_service_test.go
@@ -65,7 +65,7 @@ func TestGenerateExpectedFinishTimes(t *testing.T) {
 
 		jobAName := scheduler.JobName("job-A")
 
-		jobDetailsGetter.On("GetJobs", ctx, projectName, []string{jobAName.String()}).Return([]*scheduler.JobWithDetails{}, errors.New("some error"))
+		jobDetailsGetter.On("GetJobs", ctx, projectName, []string{jobAName.String()}).Return(nil, errors.New("some error"))
 
 		// when
 		expectedFinishTimes, err := jobExpectatorService.GenerateExpectedFinishTimes(ctx, projectName, []scheduler.JobName{jobAName}, map[string]string{}, referenceTime, scheduleRangeInHours)
@@ -93,7 +93,7 @@ func TestGenerateExpectedFinishTimes(t *testing.T) {
 
 		labels := map[string]string{"category": "some-category"}
 
-		jobDetailsGetter.On("GetJobsByLabels", ctx, projectName, labels).Return([]*scheduler.JobWithDetails{}, errors.New("some error"))
+		jobDetailsGetter.On("GetJobsByLabels", ctx, projectName, labels).Return(nil, errors.New("some error"))
 
 		// when
 		expectedFinishTimes, err := jobExpectatorService.GenerateExpectedFinishTimes(ctx, projectName, []scheduler.JobName{}, labels, referenceTime, scheduleRangeInHours)
@@ -317,6 +317,66 @@ func TestGenerateExpectedFinishTimes(t *testing.T) {
 		jobLineageFetcher.On("GetJobLineage", ctx, map[scheduler.JobName]*scheduler.JobSchedule{jobAName: {JobName: jobAName, ScheduledAt: scheduledAt}}).Return(map[scheduler.JobName]*scheduler.JobLineageSummary{jobAName: jobLineageSummary}, nil)
 		durationEstimator.On("GetPercentileDurationByJobNames", ctx, referenceTime, []scheduler.JobName{jobAName}).Return(map[scheduler.JobName]*time.Duration{jobAName: func() *time.Duration { d := 30 * time.Minute; return &d }()}, nil)
 		jobRunExpectationDetailsRepo.On("UpsertExpectedFinishTime", ctx, projectName, jobAName, scheduledAt, scheduledAt.Add(30*time.Minute)).Return(nil)
+
+		// when
+		expectedFinishTimes, err := jobExpectatorService.GenerateExpectedFinishTimes(ctx, projectName, []scheduler.JobName{jobAName}, map[string]string{}, referenceTime, scheduleRangeInHours)
+
+		// then
+		assert.NoError(t, err)
+		expectedExpectedFinishTime := scheduledAt.Add(30 * time.Minute)
+		assert.Equal(t, map[scheduler.JobSchedule]service.FinishTimeDetail{{JobName: jobAName, ScheduledAt: scheduledAt}: {FinishTime: expectedExpectedFinishTime, Status: service.FinishTimeStatusInprogress}}, expectedFinishTimes)
+	})
+
+	t.Run("given a complete job but with nonblocking error, should still return the expected finish time", func(t *testing.T) {
+		// given
+		jobRunExpectationDetailsRepo := NewJobRunExpectationDetailsRepository(t)
+		jobDetailsGetter := NewJobDetailsGetter(t)
+		jobLineageFetcher := NewJobLineageFetcher(t)
+		durationEstimator := NewDurationEstimator(t)
+
+		jobExpectatorService := service.NewJobExpectatorService(
+			l,
+			10,
+			jobRunExpectationDetailsRepo,
+			jobDetailsGetter,
+			jobLineageFetcher,
+			durationEstimator,
+		)
+
+		tenant, _ := tenant.NewTenant("project-a", "team-a")
+		jobAName := scheduler.JobName("job-A")
+		startDate := referenceTime.Add(-24 * time.Hour).Truncate(time.Hour)
+		scheduledAt := referenceTime.Add(scheduleRangeInHours - 1*time.Hour).Truncate(time.Hour)
+		interval := fmt.Sprintf("0 %d * * *", scheduledAt.Hour()) // daily
+
+		jobWithDetails := &scheduler.JobWithDetails{
+			Name: jobAName,
+			Job: &scheduler.Job{
+				Tenant: tenant,
+				Name:   jobAName,
+			},
+			Schedule: &scheduler.Schedule{
+				StartDate: startDate,
+				Interval:  interval,
+			},
+		}
+
+		jobLineageSummary := &scheduler.JobLineageSummary{
+			JobName:   jobAName,
+			IsEnabled: true,
+			JobRuns: map[scheduler.JobName]*scheduler.JobRunSummary{
+				jobAName: {
+					JobName:     jobAName,
+					ScheduledAt: scheduledAt,
+				},
+			},
+			Upstreams: []*scheduler.JobLineageSummary{},
+		}
+
+		jobDetailsGetter.On("GetJobs", ctx, projectName, []string{jobAName.String()}).Return([]*scheduler.JobWithDetails{jobWithDetails}, errors.New("nonblocking error")).Once()
+		jobLineageFetcher.On("GetJobLineage", ctx, map[scheduler.JobName]*scheduler.JobSchedule{jobAName: {JobName: jobAName, ScheduledAt: scheduledAt}}).Return(map[scheduler.JobName]*scheduler.JobLineageSummary{jobAName: jobLineageSummary}, nil).Once()
+		durationEstimator.On("GetPercentileDurationByJobNames", ctx, referenceTime, []scheduler.JobName{jobAName}).Return(map[scheduler.JobName]*time.Duration{jobAName: func() *time.Duration { d := 30 * time.Minute; return &d }()}, nil).Once()
+		jobRunExpectationDetailsRepo.On("UpsertExpectedFinishTime", ctx, projectName, jobAName, scheduledAt, scheduledAt.Add(30*time.Minute)).Return(nil).Once()
 
 		// when
 		expectedFinishTimes, err := jobExpectatorService.GenerateExpectedFinishTimes(ctx, projectName, []scheduler.JobName{jobAName}, map[string]string{}, referenceTime, scheduleRangeInHours)

--- a/core/scheduler/service/job_sla_predictor_service.go
+++ b/core/scheduler/service/job_sla_predictor_service.go
@@ -256,34 +256,40 @@ func getJobWithDetails(ctx context.Context, l log.Logger, jobDetailsGetter JobDe
 		}
 		jobsWithDetails, err := jobDetailsGetter.GetJobs(ctx, projectName, jobNameStr)
 		if err != nil {
-			return nil, err
+			if jobsWithDetails == nil {
+				return nil, err
+			}
+			l.Error("[getJobWithDetails] encountered non-blocking error when fetching jobs by names: %s", err.Error())
 		}
 		for _, job := range jobsWithDetails {
 			filteredJobsByName[job.Name] = job
 			filteredJobMerged[job.Name] = job
 		}
-		l.Info("fetched jobs by names", "count", len(filteredJobsByName))
-		l.Info("jobs fetched by names", "jobs", filteredJobsByName)
+		l.Info("[getJobWithDetails] fetched jobs by names", "count", len(filteredJobsByName))
+		l.Info("[getJobWithDetails] jobs fetched by names", "jobs", filteredJobsByName)
 	}
 
 	if len(labels) > 0 {
 		jobsWithDetails, err := jobDetailsGetter.GetJobsByLabels(ctx, projectName, labels)
 		if err != nil {
-			return nil, err
+			if jobsWithDetails == nil {
+				return nil, err
+			}
+			l.Error("[getJobWithDetails] encountered non-blocking error when fetching jobs by labels: %s", err.Error())
 		}
 		for _, job := range jobsWithDetails {
 			filteredJobByLabel[job.Name] = job
 			filteredJobMerged[job.Name] = job
 		}
-		l.Info("fetched jobs by labels", "count", len(filteredJobByLabel))
-		l.Info("jobs fetched by labels", "jobs", filteredJobByLabel)
+		l.Info("[getJobWithDetails] fetched jobs by labels", "count", len(filteredJobByLabel))
+		l.Info("[getJobWithDetails] jobs fetched by labels", "jobs", filteredJobByLabel)
 	}
 
 	filteredJobSchedules := []*scheduler.JobWithDetails{}
 	for _, job := range filteredJobMerged {
 		filteredJobSchedules = append(filteredJobSchedules, job)
 	}
-	l.Info("total jobs fetched after merging by names and labels", "count", len(filteredJobSchedules))
+	l.Info("[getJobWithDetails] total jobs fetched after merging by names and labels", "count", len(filteredJobSchedules))
 
 	return filteredJobSchedules, nil
 }

--- a/core/scheduler/service/job_sla_predictor_service_test.go
+++ b/core/scheduler/service/job_sla_predictor_service_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -941,6 +942,121 @@ func TestIdentifySLABreaches(t *testing.T) {
 		assert.Equal(t, scheduler.JobName("job-C"), jobBreachRootCause["job-A1"]["job-C"].JobName)
 		assert.Equal(t, 2, jobBreachRootCause["job-A1"]["job-C"].RelativeLevel)
 		assert.Equal(t, service.SLABreachCauseRunningLate, jobBreachRootCause["job-A1"]["job-C"].Status)
+	})
+
+	t.Run("given 1 job with nonblocking error, should still return the job SLA breach without error", func(t *testing.T) {
+		// job-C -> job-B -> job-A
+		// is the target job
+		// job-A contain error when fetching the job detail, but the error is non-blocking, so we should still return the potential SLA breach for job-A
+
+		// use same scenario as "given 1 job that is on time, return no breaches", since this only tests the error handling part
+
+		jobLineageFetcher := NewJobLineageFetcher(t)
+		durationEstimator := NewDurationEstimator(t)
+		jobDetailsGetter := NewJobDetailsGetter(t)
+		jobSLAPredictorService := service.NewJobSLAPredictorService(l, conf, nil, jobLineageFetcher, durationEstimator, jobDetailsGetter, nil, nil, scheduledChangeGetter)
+
+		projectName := tenant.ProjectName("project-a")
+		nextScheduledRangeInHours := 10 * time.Hour
+		referenceTime := time.Now().UTC()
+		jobNames := []scheduler.JobName{scheduler.JobName("job-A")}
+		labels := map[string]string{}
+
+		reqConfig := service.JobSLAPredictorRequestConfig{
+			ReferenceTime:        referenceTime,
+			ScheduleRangeInHours: nextScheduledRangeInHours,
+			EnableAlert:          false,
+			DamperCoeff:          conf.DamperCoeff,
+			Severity:             "",
+		}
+
+		tenant, _ := tenant.NewTenant("project-a", "team-a")
+		startDate := referenceTime.Add(-24 * time.Hour).Truncate(time.Hour)
+		// get hour from now for simulation purpose, we set scheduledAt to be now
+		scheduledAt := referenceTime.Add(1 * time.Minute).Truncate(time.Minute)
+		interval := fmt.Sprintf("%d %d * * *", scheduledAt.Minute(), scheduledAt.Hour()) // daily
+		jobA := &scheduler.JobWithDetails{
+			Name: "job-A",
+			Job: &scheduler.Job{
+				Tenant: tenant,
+				Name:   "job-A",
+			},
+			Schedule: &scheduler.Schedule{
+				StartDate: startDate,
+				Interval:  interval,
+			},
+			Alerts: []scheduler.Alert{
+				{
+					On:     scheduler.EventCategorySLAMiss,
+					Config: map[string]string{"duration": "30m"},
+				},
+			},
+		}
+
+		jobASchedule := &scheduler.JobSchedule{
+			JobName:     "job-A",
+			ScheduledAt: scheduledAt,
+		}
+		jobALineage := &scheduler.JobLineageSummary{
+			JobName:          "job-A",
+			ScheduleInterval: interval,
+			JobRuns: map[scheduler.JobName]*scheduler.JobRunSummary{
+				jobASchedule.JobName: {
+					ScheduledAt: scheduledAt,
+				},
+			},
+			Upstreams: []*scheduler.JobLineageSummary{},
+		}
+		jobBTaskStartTime := scheduledAt.Add(-10 * time.Minute)
+		jobBLineage := &scheduler.JobLineageSummary{
+			JobName:          "job-B",
+			ScheduleInterval: interval,
+			JobRuns: map[scheduler.JobName]*scheduler.JobRunSummary{
+				jobALineage.JobName: {
+					ScheduledAt:   scheduledAt.Add(-15 * time.Minute),
+					TaskStartTime: &jobBTaskStartTime,
+				},
+			},
+			Upstreams: []*scheduler.JobLineageSummary{},
+		}
+		jobCTaskStartTime := scheduledAt.Add(-20 * time.Minute)
+		jobCTaskEndTime := scheduledAt.Add(-10 * time.Minute)
+		jobCLineage := &scheduler.JobLineageSummary{
+			JobName:          "job-C",
+			ScheduleInterval: interval,
+			JobRuns: map[scheduler.JobName]*scheduler.JobRunSummary{
+				jobBLineage.JobName: {
+					ScheduledAt:   scheduledAt.Add(-25 * time.Minute),
+					TaskStartTime: &jobCTaskStartTime,
+					TaskEndTime:   &jobCTaskEndTime,
+					JobEndTime:    &jobCTaskEndTime,
+				},
+			},
+			Upstreams: []*scheduler.JobLineageSummary{},
+		}
+		jobALineage.Upstreams = []*scheduler.JobLineageSummary{jobBLineage}
+		jobBLineage.Upstreams = []*scheduler.JobLineageSummary{jobCLineage}
+
+		jobDetailsGetter.On("GetJobs", ctx, projectName, []string{"job-A"}).Return([]*scheduler.JobWithDetails{jobA}, errors.New("nonblocking error")).Once()
+		jobLineageFetcher.On("GetJobLineage", ctx, map[scheduler.JobName]*scheduler.JobSchedule{
+			jobASchedule.JobName: jobASchedule,
+		}).Return(map[scheduler.JobName]*scheduler.JobLineageSummary{
+			jobASchedule.JobName: jobALineage,
+		}, nil).Once()
+		durationEstimator.On("GetPercentileDurationByJobNames", ctx, referenceTime, mock.MatchedBy(func(jobNames []scheduler.JobName) bool {
+			return assert.ElementsMatch(t, []scheduler.JobName{"job-A", "job-B", "job-C"}, jobNames)
+		})).Return(map[scheduler.JobName]*time.Duration{
+			"job-A": func() *time.Duration { d := 20 * time.Minute; return &d }(),
+			"job-B": func() *time.Duration { d := 15 * time.Minute; return &d }(),
+			"job-C": func() *time.Duration { d := 10 * time.Minute; return &d }(),
+		}, nil).Once()
+
+		// when
+		jobBreachRootCause, err := jobSLAPredictorService.IdentifySLABreaches(ctx, projectName, jobNames, labels, reqConfig)
+
+		// then
+		assert.NoError(t, err)
+		assert.Len(t, jobBreachRootCause, 0)
 	})
 
 	t.Run("given targeted job that is running late, return that targeted job", func(t *testing.T) {

--- a/internal/store/postgres/scheduler/job_repository.go
+++ b/internal/store/postgres/scheduler/job_repository.go
@@ -513,7 +513,7 @@ func groupUpstreamsByJobName(jobUpstreams []*JobUpstreams) (map[string][]*schedu
 	jobUpstreamGroup := map[string][]*scheduler.JobUpstream{}
 
 	for _, upstream := range jobUpstreams {
-		if upstream.UpstreamState != "resolved" {
+		if upstream.UpstreamState != job.UpstreamStateResolved.String() {
 			if strings.EqualFold(upstream.UpstreamType, "static") {
 				multiError.Append(errors.NewError(errors.ErrInvalidState, scheduler.EntityJobRun, "unresolved upstream "+upstream.UpstreamJobName.String+" for "+upstream.JobName))
 			}


### PR DESCRIPTION
- [x] update unit test to reflect the behavior
- [x] do local testing