### PR TITLE
fix: identfy job downstreams cross projects

### DIFF
--- a/core/job/service/job_service.go
+++ b/core/job/service/job_service.go
@@ -142,7 +142,7 @@ type UpstreamRepository interface {
 }
 
 type DownstreamRepository interface {
-	GetDownstreamByDestination(ctx context.Context, projectName tenant.ProjectName, destination resource.URN) ([]*job.Downstream, error)
+	GetDownstreamByDestination(ctx context.Context, destination resource.URN) ([]*job.Downstream, error)
 	GetDownstreamByJobName(ctx context.Context, projectName tenant.ProjectName, jobName job.Name) ([]*job.Downstream, error)
 	GetDownstreamBySources(ctx context.Context, sources []resource.URN) ([]*job.Downstream, error)
 }
@@ -182,7 +182,7 @@ func (j *JobService) Add(ctx context.Context, jobTenant tenant.Tenant, specs []*
 	addedJobs, err := j.jobRepo.Add(ctx, jobs)
 	me.Append(err)
 
-	downstreamJobs, err := j.getDownstreamJobs(ctx, jobTenant.ProjectName(), jobs)
+	downstreamJobs, err := j.getDownstreamJobs(ctx, jobs)
 	me.Append(err)
 
 	var jobsToBeResolved []*job.Job
@@ -237,7 +237,7 @@ func (j *JobService) Update(ctx context.Context, jobTenant tenant.Tenant, specs 
 		existingJobs = append(existingJobs, existingJob)
 	}
 
-	downstreamExistingJobs, err := j.getDownstreamJobs(ctx, jobTenant.ProjectName(), existingJobs)
+	downstreamExistingJobs, err := j.getDownstreamJobs(ctx, existingJobs)
 	me.Append(err)
 
 	jobs, err := j.generateJobs(ctx, tenantWithDetails, specs, logWriter)
@@ -246,7 +246,7 @@ func (j *JobService) Update(ctx context.Context, jobTenant tenant.Tenant, specs 
 	updatedJobs, err := j.jobRepo.Update(ctx, jobs)
 	me.Append(err)
 
-	downstreamUpdatedJobs, err := j.getDownstreamJobs(ctx, jobTenant.ProjectName(), updatedJobs)
+	downstreamUpdatedJobs, err := j.getDownstreamJobs(ctx, updatedJobs)
 	me.Append(err)
 
 	var jobsToBeResolved []*job.Job
@@ -304,7 +304,7 @@ func (j *JobService) Upsert(ctx context.Context, jobTenant tenant.Tenant, specs 
 		}
 		existingJobs = append(existingJobs, existingJob)
 	}
-	downstreamExistingJobs, err := j.getDownstreamJobs(ctx, jobTenant.ProjectName(), existingJobs)
+	downstreamExistingJobs, err := j.getDownstreamJobs(ctx, existingJobs)
 	me.Append(err)
 
 	specsToAdd, specsToUpdate, _, specsUnmodified, specsDirty := j.differentiateSpecs(tenantWithDetails.ToTenant(), existingJobs, specs, nil)
@@ -314,9 +314,9 @@ func (j *JobService) Upsert(ctx context.Context, jobTenant tenant.Tenant, specs 
 	me.Append(err)
 	j.raiseUpdateEvents(existingJobs, addedJobs, updatedJobs)
 
-	downstreamUpdatedJobs, err := j.getDownstreamJobs(ctx, jobTenant.ProjectName(), updatedJobs)
+	downstreamUpdatedJobs, err := j.getDownstreamJobs(ctx, updatedJobs)
 	me.Append(err)
-	downstreamAddedJobs, err := j.getDownstreamJobs(ctx, jobTenant.ProjectName(), addedJobs)
+	downstreamAddedJobs, err := j.getDownstreamJobs(ctx, addedJobs)
 	me.Append(err)
 
 	var upsertedJobs []*job.Job
@@ -739,7 +739,7 @@ func (j *JobService) ReplaceAll(ctx context.Context, jobTenant tenant.Tenant, sp
 			toUpdateJobs = append(toUpdateJobs, currentJob)
 		}
 	}
-	downstreamExistingJobs, err := j.getDownstreamJobs(ctx, jobTenant.ProjectName(), toUpdateJobs)
+	downstreamExistingJobs, err := j.getDownstreamJobs(ctx, toUpdateJobs)
 	me.Append(err)
 
 	addedJobs, updatedJobs, err := j.bulkJobPersist(ctx, tenantWithDetails, toAdd, toUpdate, logWriter)
@@ -756,9 +756,9 @@ func (j *JobService) ReplaceAll(ctx context.Context, jobTenant tenant.Tenant, sp
 		return err
 	}
 
-	downstreamUpdatedJobs, err := j.getDownstreamJobs(ctx, jobTenant.ProjectName(), updatedJobs)
+	downstreamUpdatedJobs, err := j.getDownstreamJobs(ctx, updatedJobs)
 	me.Append(err)
-	downstreamAddedJobs, err := j.getDownstreamJobs(ctx, jobTenant.ProjectName(), addedJobs)
+	downstreamAddedJobs, err := j.getDownstreamJobs(ctx, addedJobs)
 	me.Append(err)
 
 	jobsToBeResolved := []*job.Job{}
@@ -1384,7 +1384,7 @@ func (j *JobService) GetUpstreamsToInspect(ctx context.Context, subjectJob *job.
 
 func (j *JobService) GetDownstream(ctx context.Context, subjectJob *job.Job, localJob bool) ([]*job.Downstream, error) {
 	if localJob {
-		return j.downstreamRepo.GetDownstreamByDestination(ctx, subjectJob.ProjectName(), subjectJob.Destination())
+		return j.downstreamRepo.GetDownstreamByDestination(ctx, subjectJob.Destination())
 	}
 	return j.downstreamRepo.GetDownstreamByJobName(ctx, subjectJob.ProjectName(), subjectJob.Spec().Name())
 }
@@ -2153,20 +2153,20 @@ func (j *JobService) GetDownstreamByResourceURN(ctx context.Context, tnnt tenant
 	return dependentJobs, nil
 }
 
-func (j *JobService) getDownstreamJobs(ctx context.Context, projectName tenant.ProjectName, jobs []*job.Job) ([]*job.Job, error) {
+func (j *JobService) getDownstreamJobs(ctx context.Context, jobs []*job.Job) ([]*job.Job, error) {
 	me := errors.NewMultiError("get downstream jobs errors")
 	downstreamJobs := []*job.Job{}
 	for _, currentJob := range jobs {
 		if currentJob.Destination() == resource.ZeroURN() {
 			continue
 		}
-		downstreams, err := j.downstreamRepo.GetDownstreamByDestination(ctx, projectName, currentJob.Destination())
+		downstreams, err := j.downstreamRepo.GetDownstreamByDestination(ctx, currentJob.Destination())
 		if err != nil {
 			me.Append(err)
 			continue
 		}
 		for _, d := range downstreams {
-			downstreamJob, err := j.jobRepo.GetByJobName(ctx, projectName, d.Name())
+			downstreamJob, err := j.jobRepo.GetByJobName(ctx, d.ProjectName(), d.Name())
 			if err != nil {
 				me.Append(err)
 				continue

--- a/core/job/service/job_service_test.go
+++ b/core/job/service/job_service_test.go
@@ -149,7 +149,7 @@ func TestJobService(t *testing.T) {
 			jobs := []*job.Job{jobA}
 			jobRepo.On("Add", ctx, mock.Anything).Return(jobs, nil, nil)
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, jobADestination).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, jobADestination).Return([]*job.Downstream{}, nil)
 
 			upstream := job.NewUpstreamResolved("job-B", "", resourceURNB, sampleTenant, "static", taskName, false)
 			jobWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{upstream})
@@ -216,7 +216,7 @@ func TestJobService(t *testing.T) {
 			jobRepo.On("Add", ctx, mock.Anything).Return(jobs, nil, nil)
 
 			jobBDownstream := job.NewDownstream("job-B", sampleTenant.ProjectName(), sampleTenant.NamespaceName(), jobTask.Name())
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, jobADestination).Return([]*job.Downstream{jobBDownstream}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, jobADestination).Return([]*job.Downstream{jobBDownstream}, nil)
 			jobRepo.On("GetByJobName", ctx, mock.Anything, jobBDownstream.Name()).Return(jobB, nil)
 
 			upstream := job.NewUpstreamResolved("job-A", "", resourceURNA, sampleTenant, "static", taskName, false)
@@ -486,7 +486,7 @@ func TestJobService(t *testing.T) {
 			savedJobs := []*job.Job{jobB}
 			jobRepo.On("Add", ctx, mock.Anything).Return(savedJobs, errors.New("unable to save job A"))
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			jobWithUpstreamB := job.NewWithUpstream(jobB, nil)
 			upstreamResolver.On("BulkResolve", ctx, project.Name(), savedJobs, mock.Anything).Return([]*job.WithUpstream{jobWithUpstreamB}, nil, nil)
@@ -530,7 +530,7 @@ func TestJobService(t *testing.T) {
 
 			tenantDetailsGetter.On("GetDetails", ctx, sampleTenant).Return(detailedTenant, nil)
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			upstreamResolver.On("BulkResolve", ctx, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 
@@ -592,7 +592,7 @@ func TestJobService(t *testing.T) {
 
 			jobRepo.On("Add", ctx, mock.Anything).Return(jobs, nil, nil)
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			jobWithUpstreamA := job.NewWithUpstream(jobA, nil)
 			upstreamResolver.On("BulkResolve", ctx, project.Name(), jobs, mock.Anything).Return([]*job.WithUpstream{jobWithUpstreamA}, nil, nil)
@@ -656,7 +656,7 @@ func TestJobService(t *testing.T) {
 			jobRepo.On("Add", ctx, mock.Anything).Return(jobs, nil, nil)
 
 			jobBDownstream := job.NewDownstream("job-B", sampleTenant.ProjectName(), sampleTenant.NamespaceName(), jobTask.Name())
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, jobADestination).Return([]*job.Downstream{jobBDownstream}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, jobADestination).Return([]*job.Downstream{jobBDownstream}, nil)
 			jobRepo.On("GetByJobName", ctx, mock.Anything, jobBDownstream.Name()).Return(jobB, nil)
 
 			upstream := job.NewUpstreamResolved("job-A", "", resourceURNA, sampleTenant, "static", taskName, false)
@@ -723,7 +723,7 @@ func TestJobService(t *testing.T) {
 			jobs := []*job.Job{jobA}
 			jobRepo.On("Add", ctx, mock.Anything).Return(jobs, nil, nil)
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			upstream := job.NewUpstreamResolved("job-B", "", resourceURNB, sampleTenant, "static", taskName, false)
 			jobWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{upstream})
@@ -785,7 +785,7 @@ func TestJobService(t *testing.T) {
 			jobAUpstreamName := []resource.URN{resourceURNB}
 			pluginService.On("IdentifyUpstreams", ctx, specA.Task().Name().String(), mock.Anything, mock.Anything).Return(jobAUpstreamName, nil)
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			jobA := job.NewJob(sampleTenant, specA, jobADestination, jobAUpstreamName, false)
 			jobs := []*job.Job{jobA}
@@ -860,13 +860,13 @@ func TestJobService(t *testing.T) {
 			jobRepo.On("GetByJobName", ctx, project.Name(), specA.Name()).Return(jobA, nil)
 
 			jobBDownstream := job.NewDownstream("job-B", sampleTenant.ProjectName(), sampleTenant.NamespaceName(), jobTask.Name())
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, jobADestination).Return([]*job.Downstream{jobBDownstream}, nil).Once()
+			downstreamRepo.On("GetDownstreamByDestination", ctx, jobADestination).Return([]*job.Downstream{jobBDownstream}, nil).Once()
 			jobRepo.On("GetByJobName", ctx, mock.Anything, jobBDownstream.Name()).Return(jobB, nil)
 
 			jobRepo.On("Update", ctx, mock.Anything).Return(jobs, nil, nil)
 
 			jobCDownstream := job.NewDownstream("job-C", sampleTenant.ProjectName(), sampleTenant.NamespaceName(), jobTask.Name())
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, jobADestination).Return([]*job.Downstream{jobCDownstream}, nil).Once()
+			downstreamRepo.On("GetDownstreamByDestination", ctx, jobADestination).Return([]*job.Downstream{jobCDownstream}, nil).Once()
 			jobRepo.On("GetByJobName", ctx, mock.Anything, jobCDownstream.Name()).Return(jobC, nil)
 
 			upstream := job.NewUpstreamResolved("job-A", "", resourceURNA, sampleTenant, "static", taskName, false)
@@ -987,7 +987,7 @@ func TestJobService(t *testing.T) {
 			jobRepo.On("GetByJobName", ctx, project.Name(), specB.Name()).Return(jobB, nil)
 			jobRepo.On("GetByJobName", ctx, project.Name(), specC.Name()).Return(jobC, nil)
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			upstream := job.NewUpstreamResolved("job-B", "", resourceURNB, sampleTenant, "static", taskName, false)
 			jobWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{upstream})
@@ -1042,7 +1042,7 @@ func TestJobService(t *testing.T) {
 			jobRepo.On("GetByJobName", ctx, project.Name(), specA.Name()).Return(jobA, nil)
 			jobRepo.On("GetByJobName", ctx, project.Name(), specB.Name()).Return(jobB, nil)
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			upstreamResolver.On("BulkResolve", ctx, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 
@@ -1175,7 +1175,7 @@ func TestJobService(t *testing.T) {
 			jobRepo.On("GetByJobName", ctx, project.Name(), specA.Name()).Return(jobA, nil)
 			jobRepo.On("GetByJobName", ctx, project.Name(), specB.Name()).Return(jobB, nil)
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			jobWithUpstreamB := job.NewWithUpstream(jobB, nil)
 			upstreamResolver.On("BulkResolve", ctx, project.Name(), savedJobs, mock.Anything).Return([]*job.WithUpstream{jobWithUpstreamB}, nil, nil)
@@ -1221,7 +1221,7 @@ func TestJobService(t *testing.T) {
 
 			tenantDetailsGetter.On("GetDetails", ctx, sampleTenant).Return(detailedTenant, nil)
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			upstreamResolver.On("BulkResolve", ctx, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 
@@ -1296,17 +1296,17 @@ func TestJobService(t *testing.T) {
 			jobRepo.On("GetByJobName", ctx, project.Name(), specB.Name()).Return(jobB, nil)
 
 			jobBDownstream := job.NewDownstream("job-B", sampleTenant.ProjectName(), sampleTenant.NamespaceName(), jobTask.Name())
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, jobADestination).Return([]*job.Downstream{jobBDownstream}, nil).Once()
+			downstreamRepo.On("GetDownstreamByDestination", ctx, jobADestination).Return([]*job.Downstream{jobBDownstream}, nil).Once()
 			jobRepo.On("GetByJobName", ctx, mock.Anything, jobBDownstream.Name()).Return(jobB, nil)
 
 			jobRepo.On("Update", ctx, mock.Anything).Return(jobs, nil, nil)
 
 			jobCDownstream := job.NewDownstream("job-C", sampleTenant.ProjectName(), sampleTenant.NamespaceName(), jobTask.Name())
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, jobADestination).Return([]*job.Downstream{jobCDownstream}, nil).Once()
+			downstreamRepo.On("GetDownstreamByDestination", ctx, jobADestination).Return([]*job.Downstream{jobCDownstream}, nil).Once()
 			jobRepo.On("GetByJobName", ctx, mock.Anything, jobCDownstream.Name()).Return(jobC, nil)
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, jobBDestination).Return([]*job.Downstream{}, nil).Once()
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, jobBDestination).Return([]*job.Downstream{}, nil).Once()
+			downstreamRepo.On("GetDownstreamByDestination", ctx, jobBDestination).Return([]*job.Downstream{}, nil).Once()
+			downstreamRepo.On("GetDownstreamByDestination", ctx, jobBDestination).Return([]*job.Downstream{}, nil).Once()
 
 			upstream := job.NewUpstreamResolved("job-A", "", resourceURNA, sampleTenant, "static", taskName, false)
 			jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{})
@@ -1377,7 +1377,7 @@ func TestJobService(t *testing.T) {
 			jobRepo.On("Update", ctx, mock.Anything).Return(jobs, nil, nil)
 			jobRepo.On("GetByJobName", ctx, project.Name(), specA.Name()).Return(jobA, nil)
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			jobWithUpstreamA := job.NewWithUpstream(jobA, nil)
 			upstreamResolver.On("BulkResolve", ctx, project.Name(), jobs, mock.Anything).Return([]*job.WithUpstream{jobWithUpstreamA}, nil, nil)
@@ -1439,7 +1439,7 @@ func TestJobService(t *testing.T) {
 			jobRepo.On("Update", ctx, mock.Anything).Return(jobs, nil, nil)
 			jobRepo.On("GetByJobName", ctx, project.Name(), specA.Name()).Return(jobA, nil)
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			upstream := job.NewUpstreamResolved("job-B", "", resourceURNB, sampleTenant, "static", taskName, false)
 			jobWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{upstream})
@@ -1529,7 +1529,7 @@ func TestJobService(t *testing.T) {
 			upstreamC := job.NewUpstreamResolved("job-C", "", resourceURNC, sampleTenant, "static", taskName, false)
 			jobBWithUpstream := job.NewWithUpstream(jobBToadd, []*job.Upstream{upstreamC})
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			jobsToUpsert := []*job.Job{jobBToadd, jobAToUpdate}
 			upstreamResolver.On("BulkResolve", ctx, project.Name(), mock.MatchedBy(func(elems []*job.Job) bool {
@@ -1751,7 +1751,7 @@ func TestJobService(t *testing.T) {
 			jobRepo.On("GetByJobName", ctx, project.Name(), specB.Name()).Return(nil, errors.New("internal error"))
 			jobRepo.On("GetByJobName", ctx, project.Name(), specC.Name()).Return(nil, errors.New("internal error"))
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			jobs := []*job.Job{jobA}
 			jobRepo.On("Add", ctx, mock.Anything).Return(jobs, nil)
@@ -1836,7 +1836,7 @@ func TestJobService(t *testing.T) {
 			jobRepo.On("GetByJobName", ctx, project.Name(), specAToUpdate.Name()).Return(jobAExisting, nil).Once()
 			jobRepo.On("GetByJobName", ctx, project.Name(), specBToUpdate.Name()).Return(jobBToUpdate, nil).Once()
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			upstreamB := job.NewUpstreamResolved("job-B", "", resourceURNB, sampleTenant, "static", taskName, false)
 			jobAWithUpstream := job.NewWithUpstream(jobAToUpdate, []*job.Upstream{upstreamB})
@@ -1929,7 +1929,7 @@ func TestJobService(t *testing.T) {
 
 			jobBWithUpstream := job.NewWithUpstream(jobBToUpdate, []*job.Upstream{})
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			jobsToUpsert := []*job.Job{jobBToUpdate, jobAToUpdate}
 			upstreamResolver.On("BulkResolve", ctx, project.Name(), mock.MatchedBy(func(elems []*job.Job) bool {
@@ -2309,7 +2309,7 @@ func TestJobService(t *testing.T) {
 
 			upstream := job.NewUpstreamResolved("job-B", "", resourceURNB, sampleTenant, "static", taskName, false)
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			jobWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{upstream})
 			upstreamResolver.On("BulkResolve", ctx, project.Name(), []*job.Job{jobA}, mock.Anything).Return([]*job.WithUpstream{jobWithUpstream}, nil, nil)
@@ -2385,7 +2385,7 @@ func TestJobService(t *testing.T) {
 
 			upstream := job.NewUpstreamResolved("job-B", "", resourceURNB, sampleTenant, "static", taskName, false)
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			jobWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{upstream})
 			upstreamResolver.On("BulkResolve", ctx, project.Name(), []*job.Job{jobA}, mock.Anything).Return([]*job.WithUpstream{jobWithUpstream}, nil, nil)
@@ -2614,7 +2614,7 @@ func TestJobService(t *testing.T) {
 			downstreamRepo.On("GetDownstreamByJobName", ctx, project.Name(), existingSpecC.Name()).Return(nil, nil)
 			jobRepo.On("Delete", ctx, project.Name(), existingSpecC.Name(), false).Return(nil)
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			upstream := job.NewUpstreamResolved("job-B", "", resourceURNB, sampleTenant, "static", taskName, false)
 			jobWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{upstream})
@@ -2712,7 +2712,7 @@ func TestJobService(t *testing.T) {
 
 			upstream := job.NewUpstreamResolved("job-B", "", resourceURNB, sampleTenant, "static", taskName, false)
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{upstream})
 			jobBWithUpstream := job.NewWithUpstream(jobB, []*job.Upstream{})
@@ -2807,7 +2807,7 @@ func TestJobService(t *testing.T) {
 			downstreamRepo.On("GetDownstreamByJobName", ctx, project.Name(), existingSpecC.Name()).Return(nil, nil)
 			jobRepo.On("Delete", ctx, project.Name(), existingSpecC.Name(), false).Return(nil)
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			upstream := job.NewUpstreamResolved("job-B", "", resourceURNB, sampleTenant, "static", taskName, false)
 			jobWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{upstream})
@@ -3149,7 +3149,7 @@ func TestJobService(t *testing.T) {
 			pluginService.On("ConstructDestinationURN", ctx, specA.Task().Name().String(), mock.Anything).Return(jobADestination, nil).Once()
 			pluginService.On("IdentifyUpstreams", ctx, specA.Task().Name().String(), mock.Anything, mock.Anything).Return(jobAUpstreamName, nil)
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			jobRepo.On("Update", ctx, mock.Anything).Return([]*job.Job{}, errors.New("internal error"))
 
@@ -3434,7 +3434,7 @@ func TestJobService(t *testing.T) {
 
 			upstream := job.NewUpstreamResolved("job-B", "", resourceURNB, sampleTenant, "static", taskName, false)
 
-			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything, mock.Anything).Return([]*job.Downstream{}, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, mock.Anything).Return([]*job.Downstream{}, nil)
 
 			jobWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{upstream})
 			upstreamResolver.On("BulkResolve", ctx, project.Name(), []*job.Job{jobA}, mock.Anything).Return([]*job.WithUpstream{jobWithUpstream}, nil, nil)
@@ -6041,7 +6041,7 @@ func TestJobService(t *testing.T) {
 			jobADownstream := []*job.Downstream{
 				job.NewDownstream("job-B", project.Name(), namespace.Name(), taskName),
 			}
-			downstreamRepo.On("GetDownstreamByDestination", ctx, project.Name(), jobA.Destination()).Return(jobADownstream, nil)
+			downstreamRepo.On("GetDownstreamByDestination", ctx, jobA.Destination()).Return(jobADownstream, nil)
 
 			jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, pluginService, upstreamResolver, tenantDetailsGetter, nil, log, nil, nil, nil, nil, nil, service.JobValidateConfig{})
 			result, err := jobService.GetDownstream(ctx, jobA, true)
@@ -6627,12 +6627,12 @@ type DownstreamRepository struct {
 }
 
 // GetDownstreamByDestination provides a mock function with given fields: ctx, projectName, destination
-func (_d *DownstreamRepository) GetDownstreamByDestination(ctx context.Context, projectName tenant.ProjectName, destination resource.URN) ([]*job.Downstream, error) {
-	ret := _d.Called(ctx, projectName, destination)
+func (_d *DownstreamRepository) GetDownstreamByDestination(ctx context.Context, destination resource.URN) ([]*job.Downstream, error) {
+	ret := _d.Called(ctx, destination)
 
 	var r0 []*job.Downstream
-	if rf, ok := ret.Get(0).(func(context.Context, tenant.ProjectName, resource.URN) []*job.Downstream); ok {
-		r0 = rf(ctx, projectName, destination)
+	if rf, ok := ret.Get(0).(func(context.Context, resource.URN) []*job.Downstream); ok {
+		r0 = rf(ctx, destination)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*job.Downstream)
@@ -6640,8 +6640,8 @@ func (_d *DownstreamRepository) GetDownstreamByDestination(ctx context.Context, 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, tenant.ProjectName, resource.URN) error); ok {
-		r1 = rf(ctx, projectName, destination)
+	if rf, ok := ret.Get(1).(func(context.Context, resource.URN) error); ok {
+		r1 = rf(ctx, destination)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/internal/store/postgres/job/job_repository.go
+++ b/internal/store/postgres/job/job_repository.go
@@ -1133,7 +1133,7 @@ func (j JobRepository) GetDownstreamByDestination(ctx context.Context, destinati
 SELECT
 	name as job_name, project_name, namespace_name, task_name
 FROM job
-WHERE $2 = ANY(sources)
+WHERE $1 = ANY(sources)
 AND deleted_at IS NULL;`
 
 	rows, err := j.db.Query(ctx, query, destination.String())

--- a/internal/store/postgres/job/job_repository.go
+++ b/internal/store/postgres/job/job_repository.go
@@ -1128,15 +1128,15 @@ WHERE project_name=$1 AND job_name=$2;`
 	return j.toUpstreams(storeJobsWithUpstreams)
 }
 
-func (j JobRepository) GetDownstreamByDestination(ctx context.Context, projectName tenant.ProjectName, destination resource.URN) ([]*job.Downstream, error) {
+func (j JobRepository) GetDownstreamByDestination(ctx context.Context, destination resource.URN) ([]*job.Downstream, error) {
 	query := `
 SELECT
 	name as job_name, project_name, namespace_name, task_name
 FROM job
-WHERE project_name = $1 AND $2 = ANY(sources)
+WHERE $2 = ANY(sources)
 AND deleted_at IS NULL;`
 
-	rows, err := j.db.Query(ctx, query, projectName, destination.String())
+	rows, err := j.db.Query(ctx, query, destination.String())
 	if err != nil {
 		return nil, errors.Wrap(job.EntityJob, "error while getting job downstream", err)
 	}

--- a/internal/store/postgres/job/job_repository_test.go
+++ b/internal/store/postgres/job/job_repository_test.go
@@ -1131,7 +1131,7 @@ func TestPostgresJobRepository(t *testing.T) {
 			expectedDownstream := []*job.Downstream{
 				job.NewDownstream(jobSpecA.Name(), proj.Name(), namespace.Name(), jobSpecA.Task().Name()),
 			}
-			result, err := jobRepo.GetDownstreamByDestination(ctx, proj.Name(), resourceURNC)
+			result, err := jobRepo.GetDownstreamByDestination(ctx, resourceURNC)
 			assert.NoError(t, err)
 			assert.EqualValues(t, expectedDownstream, result)
 		})

--- a/tests/bench/job/job_repo_test.go
+++ b/tests/bench/job/job_repo_test.go
@@ -423,7 +423,7 @@ func BenchmarkJobRepository(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			actualDownstreams, actualError := repo.GetDownstreamByDestination(ctx, tnnt.ProjectName(), rootJobDestination)
+			actualDownstreams, actualError := repo.GetDownstreamByDestination(ctx, rootJobDestination)
 			assert.Len(b, actualDownstreams, maxNumberOfDownstreams)
 			assert.NoError(b, actualError)
 		}


### PR DESCRIPTION
Currently, Job downstream discovery is limited to the incoming job's project. With this PR we intend to discover downstreams across projects