### PR TITLE
fix: skip altering on partition columns

### DIFF
--- a/ext/store/maxcompute/table.go
+++ b/ext/store/maxcompute/table.go
@@ -171,10 +171,7 @@ func generateUpdateQuery(incoming, existing tableschema.TableSchema, schemaName 
 		}
 	}
 
-	_, incomingFlattenSchema := flattenSchema(incoming, false)
-	existingFlattenSchema, _ := flattenSchema(existing, true)
-
-	if err := getNormalColumnDifferences(existing.TableName, schemaName, incomingFlattenSchema, existingFlattenSchema, &sqlTasks); err != nil {
+	if err := getNormalColumnDifferences(existing.TableName, schemaName, incoming, existing, &sqlTasks); err != nil {
 		return []string{}, err
 	}
 
@@ -251,10 +248,19 @@ func specifyColumnStructure(parent, columnName string, isArrayStruct bool) strin
 	return fmt.Sprintf("%s.`%s`", parent, columnName)
 }
 
-func getNormalColumnDifferences(tableName, schemaName string, incoming []ColumnRecord, existing map[string]tableschema.Column, sqlTasks *[]string) error {
+func getNormalColumnDifferences(tableName, schemaName string, incoming, existing tableschema.TableSchema, sqlTasks *[]string) error {
+	_, incomingFlattenSchema := flattenSchema(incoming, false)
+	existingFlattenSchema, _ := flattenSchema(existing, true)
+
+	// keep track of partition columns for exclusion during column altering, because maxcompute does not allow altering partition columns
+	autoPartitionColumnsMap := make(map[string]struct{})
+	for _, partitionColumn := range existing.PartitionColumns {
+		autoPartitionColumnsMap[partitionColumn.Name] = struct{}{}
+	}
+
 	var columnAddition []string
-	for _, incomingColumnRecord := range incoming {
-		columnFound, ok := existing[incomingColumnRecord.columnStructure]
+	for _, incomingColumnRecord := range incomingFlattenSchema {
+		columnFound, ok := existingFlattenSchema[incomingColumnRecord.columnStructure]
 		if !ok {
 			if incomingColumnRecord.columnValue.NotNull {
 				return fmt.Errorf("unable to add new required column")
@@ -274,18 +280,21 @@ func getNormalColumnDifferences(tableName, schemaName string, incoming []ColumnR
 		}
 
 		if columnFound.Type.ID() != incomingColumnRecord.columnValue.Type.ID() {
-			return fmt.Errorf("unable to modify column data type")
+			return fmt.Errorf("unable to modify column %s data type from %s to %s", columnFound.Name, columnFound.Type.Name(), incomingColumnRecord.columnValue.Type.Name())
 		}
 
-		if incomingColumnRecord.columnValue.Comment != columnFound.Comment {
+		// Skip altering comment for partition columns as maxcompute does not allow it
+		// can remove this logic if maxcompute supports it in future
+		_, isPartitionColumn := autoPartitionColumnsMap[columnFound.Name]
+		if incomingColumnRecord.columnValue.Comment != columnFound.Comment && !isPartitionColumn {
 			*sqlTasks = append(*sqlTasks, fmt.Sprintf("alter table %s.%s change column %s %s %s comment %s;",
 				schemaName, tableName, columnFound.Name, incomingColumnRecord.columnValue.Name, columnFound.Type, common.QuoteString(incomingColumnRecord.columnValue.Comment)))
 		}
-		delete(existing, incomingColumnRecord.columnStructure)
+		delete(existingFlattenSchema, incomingColumnRecord.columnStructure)
 	}
 
-	if len(existing) != 0 {
-		for column := range existing {
+	if len(existingFlattenSchema) != 0 {
+		for column := range existingFlattenSchema {
 			return fmt.Errorf("field %s is missing in new schema", column)
 		}
 	}

--- a/ext/store/maxcompute/table.go
+++ b/ext/store/maxcompute/table.go
@@ -283,8 +283,7 @@ func getNormalColumnDifferences(tableName, schemaName string, incoming, existing
 			return fmt.Errorf("unable to modify column %s data type from %s to %s", columnFound.Name, columnFound.Type.Name(), incomingColumnRecord.columnValue.Type.Name())
 		}
 
-		// Skip altering comment for partition columns as maxcompute does not allow it
-		// can remove this logic if maxcompute supports it in future
+		// TODO: Skip altering comment for partition columns as maxcompute does not allow modifications on autopartition columns. Remove this logic if maxcompute supports it in future
 		_, isPartitionColumn := autoPartitionColumnsMap[columnFound.Name]
 		if incomingColumnRecord.columnValue.Comment != columnFound.Comment && !isPartitionColumn {
 			*sqlTasks = append(*sqlTasks, fmt.Sprintf("alter table %s.%s change column %s %s %s comment %s;",


### PR DESCRIPTION
### Description
Automatically skip any updates on partitioned columns (specifically on column comment) as maxcompute currently does not support it, which currently will return error on resource update.

```
[namespace] update: resource maxcompute://test_project.test_schema.test_table ❌
	└─ cause: rpc error: code = Internal desc = error in update resource:
 internal error for entity resource_table: error while execute sql query on maxcompute: ODPS-0130071:[1,48] Semantic analysis exception - column auto_column_partition cannot be changed because it is referenced by AUTO PARTITION column
```

After evaluating options, it is better to keep the comment in resource.yaml but skip it only when updating the maxcompute table to avoid recurring issues.