### PR TITLE
fix: max dex sensor lookback to 7 day

### DIFF
--- a/core/scheduler/handler/v1beta1/job_run.go
+++ b/core/scheduler/handler/v1beta1/job_run.go
@@ -247,6 +247,12 @@ func (h JobRunHandler) GetThirdPartySensorStatus(ctx context.Context, req *pb.Ge
 		startTime = endTime.Add(-24 * time.Hour)
 	}
 
+	if startTime.Before(logicalEndTime.Add(-7 * 24 * time.Hour)) {
+		h.l.Info(fmt.Sprintf("resetting the third party sensor window start time to "+
+			"max 7 day look back: %s, job: %s", logicalEndTime.Add(-7*24*time.Hour).Format(time.RFC3339), jobName))
+		startTime = logicalEndTime.Add(-7 * 24 * time.Hour)
+	}
+
 	thirdPartyType := req.GetThirdPartyType()
 	if thirdPartyType == job.ThirdPartyTypeDex {
 		dexSensorReq := req.GetDexSensorRequest()


### PR DESCRIPTION
to avoid unnecessary checking long before duration 