### PR TITLE
fix: redact secret template compilation for backfill dry run

### DIFF
--- a/core/scheduler/executor.go
+++ b/core/scheduler/executor.go
@@ -58,12 +58,20 @@ func ExecutorFromEnum(name, enum string) (Executor, error) {
 	return ExecutorFrom(name, _typ)
 }
 
+const (
+	DryRun    RunMode = "DryRun"
+	Execution RunMode = "Execution"
+)
+
+type RunMode string
+
 type RunConfig struct {
 	Executor Executor
 
 	ScheduledAt time.Time
 	JobRunID    JobRunID
 	DagRunID    string
+	RunMode     RunMode
 }
 
 func RunConfigFrom(executor Executor, scheduledAt time.Time, runID, dagRunID string) (RunConfig, error) {
@@ -77,7 +85,16 @@ func RunConfigFrom(executor Executor, scheduledAt time.Time, runID, dagRunID str
 		ScheduledAt: scheduledAt,
 		JobRunID:    jobRunID,
 		DagRunID:    dagRunID,
+		RunMode:     Execution,
 	}, nil
+}
+
+func (r *RunConfig) WithRunMode(m RunMode) {
+	r.RunMode = m
+}
+
+func (r *RunConfig) IsDryRun() bool {
+	return r.RunMode == DryRun
 }
 
 type ConfigMap map[string]string

--- a/core/scheduler/service/backfill_service.go
+++ b/core/scheduler/service/backfill_service.go
@@ -110,6 +110,7 @@ func (b *BackfillService) BackfillDryRun(ctx context.Context, backfillReq *sched
 		b.logger.Error("error creating run config for job [%s]: %s", jobName.String(), err)
 		return nil, errors.GRPCErr(err, "unable to get job run input for "+jobName.String())
 	}
+	runConfig.WithRunMode(scheduler.DryRun)
 	return b.compiler.Compile(ctx, jobWithDetails, runConfig, time.Now(), customOverrideConfig)
 }
 

--- a/core/scheduler/service/executor_input_compiler.go
+++ b/core/scheduler/service/executor_input_compiler.go
@@ -118,6 +118,14 @@ func (i InputCompiler) Compile(ctx context.Context, job *scheduler.JobWithDetail
 		compiler.From(systemDefinedVars).WithName(contextSystemDefined).AddToContext(),
 	)
 
+	if config.IsDryRun() {
+		redactedSecrets := make(map[string]string)
+		for key := range taskContext[contextSecret].(map[string]string) {
+			redactedSecrets[key] = fmt.Sprintf("\"<SECRET:%s>\"", key)
+		}
+		taskContext[contextSecret] = redactedSecrets
+	}
+
 	confs, secretConfs, err := i.compileConfigs(job.Job.Task.Config, taskContext)
 	if err != nil {
 		i.logger.Error("error compiling task config: %s", err)

--- a/core/scheduler/service/executor_input_compiler.go
+++ b/core/scheduler/service/executor_input_compiler.go
@@ -121,7 +121,7 @@ func (i InputCompiler) Compile(ctx context.Context, job *scheduler.JobWithDetail
 	if config.IsDryRun() {
 		redactedSecrets := make(map[string]string)
 		for key := range taskContext[contextSecret].(map[string]string) {
-			redactedSecrets[key] = fmt.Sprintf("\"<SECRET:%s>\"", key)
+			redactedSecrets[key] = fmt.Sprintf("<SECRET:%s>", key)
 		}
 		taskContext[contextSecret] = redactedSecrets
 	}


### PR DESCRIPTION
## Context

Backfill Dry Run responses currently return compiled queries and assets after template resolution. In cases where an asset configuration references secret-backed values, the resolved secret may be exposed in the dry run response.

Task configurations are not impacted, as secret values are already separated into secret configs and are not included in the Backfill Dry Run API response.

## Changes

- Added secret redaction to the Backfill Dry Run compilation flow for asset configurations.
- Any secret value detected in compiled queries or assets is replaced with a placeholder of the form:

  ```text
  <secret:key_name>
  ```

- Applies to compiled content generated from asset configurations returned as part of the dry run response.

### Example

Before:

```sql
WHERE api_key = 'actual-secret-value'
```

After:

```sql
WHERE api_key = '<secret:api_key>'
```

## Testing

- Verified that non-secret values continue to be rendered as-is.
- Verified that secret-backed values are redacted in compiled assets.
- Verified that task configs remain unaffected, as secret configs are already excluded from the API response.
- Verified that the response schema remains unchanged apart from secret value redaction.