### PR TITLE
chore: improve validateCyclic & fix on query parser & upstream resolver

### DIFF
--- a/core/job/cyclic_graph.go
+++ b/core/job/cyclic_graph.go
@@ -1,9 +1,5 @@
 package job
 
-// UpstreamGraph is a lightweight, install-wide job dependency graph keyed by FullName
-// ("project/job_name") on both sides
-type UpstreamGraph map[FullName][]FullName
-
 // FindCyclicPath performs a DFS over the graph starting at root, following outgoing (upstream)
 // edges. It returns the specific cycle path (root -> ... -> root) if root can reach itself
 // through the graph, or nil if no cycle involving root exists.

--- a/core/job/cyclic_graph.go
+++ b/core/job/cyclic_graph.go
@@ -1,0 +1,69 @@
+package job
+
+// UpstreamGraph is a lightweight, install-wide job dependency graph keyed by FullName
+// ("project/job_name") on both sides. It intentionally carries no other job data, so it can be
+// built cheaply from persisted upstream edges and patched with in-memory edges from an incoming
+// validate request, without needing full Job objects for every job in the graph.
+type UpstreamGraph map[FullName][]FullName
+
+// FindCyclicPath performs a DFS over the graph starting at root, following outgoing (upstream)
+// edges. It returns the specific cycle path (root -> ... -> root) if root can reach itself
+// through the graph, or nil if no cycle involving root exists.
+//
+// This is scoped per root rather than scanning the whole graph for "the first" cycle: each root
+// gets its own accurate answer, so validating job B still detects a cycle through B even if job A
+// sits on a separate, disjoint cycle elsewhere in the same graph.
+//
+// visited is a caller-provided cache of nodes already proven cycle-free by a previous call; it is
+// safe to share across multiple FindCyclicPath calls against the same graph, since a node found to
+// have no path back to any of its ancestors during one DFS will never have one in a later DFS
+// either (the graph does not change between calls).
+func FindCyclicPath(graph UpstreamGraph, root FullName, visited map[FullName]bool) []FullName {
+	visiting := map[FullName]bool{}
+	var path []FullName
+
+	var dfs func(node FullName) []FullName
+	dfs = func(node FullName) []FullName {
+		if visiting[node] {
+			for i, ancestor := range path {
+				if ancestor == node {
+					cycle := append([]FullName{}, path[i:]...)
+					return append(cycle, node)
+				}
+			}
+		}
+		if visited[node] {
+			return nil
+		}
+
+		visiting[node] = true
+		path = append(path, node)
+
+		for _, upstream := range graph[node] {
+			if cycle := dfs(upstream); cycle != nil {
+				return cycle
+			}
+		}
+
+		path = path[:len(path)-1]
+		visiting[node] = false
+		visited[node] = true
+		return nil
+	}
+
+	return dfs(root)
+}
+
+// FindCyclicPaths runs FindCyclicPath for each of the given roots against the same graph, sharing
+// the cycle-free cache across calls, and returns only the roots that participate in a cycle,
+// mapped to that cycle's path.
+func FindCyclicPaths(graph UpstreamGraph, roots []FullName) map[FullName][]FullName {
+	visited := map[FullName]bool{}
+	result := make(map[FullName][]FullName)
+	for _, root := range roots {
+		if cycle := FindCyclicPath(graph, root, visited); cycle != nil {
+			result[root] = cycle
+		}
+	}
+	return result
+}

--- a/core/job/cyclic_graph.go
+++ b/core/job/cyclic_graph.go
@@ -1,9 +1,7 @@
 package job
 
 // UpstreamGraph is a lightweight, install-wide job dependency graph keyed by FullName
-// ("project/job_name") on both sides. It intentionally carries no other job data, so it can be
-// built cheaply from persisted upstream edges and patched with in-memory edges from an incoming
-// validate request, without needing full Job objects for every job in the graph.
+// ("project/job_name") on both sides
 type UpstreamGraph map[FullName][]FullName
 
 // FindCyclicPath performs a DFS over the graph starting at root, following outgoing (upstream)
@@ -13,11 +11,6 @@ type UpstreamGraph map[FullName][]FullName
 // This is scoped per root rather than scanning the whole graph for "the first" cycle: each root
 // gets its own accurate answer, so validating job B still detects a cycle through B even if job A
 // sits on a separate, disjoint cycle elsewhere in the same graph.
-//
-// visited is a caller-provided cache of nodes already proven cycle-free by a previous call; it is
-// safe to share across multiple FindCyclicPath calls against the same graph, since a node found to
-// have no path back to any of its ancestors during one DFS will never have one in a later DFS
-// either (the graph does not change between calls).
 func FindCyclicPath(graph UpstreamGraph, root FullName, visited map[FullName]bool) []FullName {
 	visiting := map[FullName]bool{}
 	var path []FullName

--- a/core/job/cyclic_graph_test.go
+++ b/core/job/cyclic_graph_test.go
@@ -1,0 +1,114 @@
+package job_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goto/optimus/core/job"
+)
+
+func TestFindCyclicPath(t *testing.T) {
+	t.Run("returns nil when the graph has no cycle", func(t *testing.T) {
+		graph := job.UpstreamGraph{
+			"proj/a": {"proj/b"},
+			"proj/b": {"proj/c"},
+			"proj/c": {},
+		}
+
+		assert.Nil(t, job.FindCyclicPath(graph, "proj/a", map[job.FullName]bool{}))
+	})
+
+	t.Run("returns nil when root has no path back to itself, even if a cycle exists elsewhere", func(t *testing.T) {
+		graph := job.UpstreamGraph{
+			"proj/a": {"proj/b"},
+			"proj/b": {},
+			"proj/x": {"proj/y"},
+			"proj/y": {"proj/x"},
+		}
+
+		assert.Nil(t, job.FindCyclicPath(graph, "proj/a", map[job.FullName]bool{}))
+	})
+
+	t.Run("detects a direct self-cycle", func(t *testing.T) {
+		graph := job.UpstreamGraph{
+			"proj/a": {"proj/a"},
+		}
+
+		cycle := job.FindCyclicPath(graph, "proj/a", map[job.FullName]bool{})
+		assert.Equal(t, []job.FullName{"proj/a", "proj/a"}, cycle)
+	})
+
+	t.Run("detects a multi-hop cycle back to root", func(t *testing.T) {
+		graph := job.UpstreamGraph{
+			"proj/a": {"proj/b"},
+			"proj/b": {"proj/c"},
+			"proj/c": {"proj/a"},
+		}
+
+		cycle := job.FindCyclicPath(graph, "proj/a", map[job.FullName]bool{})
+		assert.Equal(t, []job.FullName{"proj/a", "proj/b", "proj/c", "proj/a"}, cycle)
+	})
+
+	t.Run("detects a cycle spanning multiple projects", func(t *testing.T) {
+		graph := job.UpstreamGraph{
+			"project-1/a": {"project-2/b"},
+			"project-2/b": {"project-3/c"},
+			"project-3/c": {"project-1/a"},
+		}
+
+		cycle := job.FindCyclicPath(graph, "project-1/a", map[job.FullName]bool{})
+		assert.Equal(t, []job.FullName{"project-1/a", "project-2/b", "project-3/c", "project-1/a"}, cycle)
+	})
+
+	t.Run("detects a cycle that root reaches but does not start", func(t *testing.T) {
+		// root -> b -> c -> b (root itself isn't part of the cycle, but it reaches one)
+		graph := job.UpstreamGraph{
+			"proj/root": {"proj/b"},
+			"proj/b":    {"proj/c"},
+			"proj/c":    {"proj/b"},
+		}
+
+		cycle := job.FindCyclicPath(graph, "proj/root", map[job.FullName]bool{})
+		assert.Equal(t, []job.FullName{"proj/b", "proj/c", "proj/b"}, cycle)
+	})
+
+	t.Run("does not loop forever on a diamond dependency (b and c both depend on d)", func(t *testing.T) {
+		graph := job.UpstreamGraph{
+			"proj/a": {"proj/b", "proj/c"},
+			"proj/b": {"proj/d"},
+			"proj/c": {"proj/d"},
+			"proj/d": {},
+		}
+
+		assert.Nil(t, job.FindCyclicPath(graph, "proj/a", map[job.FullName]bool{}))
+	})
+
+	t.Run("root not present in graph as a key is treated as having no upstreams", func(t *testing.T) {
+		graph := job.UpstreamGraph{
+			"proj/b": {"proj/c"},
+		}
+
+		assert.Nil(t, job.FindCyclicPath(graph, "proj/a", map[job.FullName]bool{}))
+	})
+}
+
+func TestFindCyclicPaths(t *testing.T) {
+	t.Run("reports each root independently, including disjoint cycles", func(t *testing.T) {
+		graph := job.UpstreamGraph{
+			"proj/a": {"proj/b"},
+			"proj/b": {"proj/a"},
+			"proj/x": {"proj/y"},
+			"proj/y": {"proj/x"},
+			"proj/m": {"proj/n"},
+			"proj/n": {},
+		}
+
+		result := job.FindCyclicPaths(graph, []job.FullName{"proj/a", "proj/x", "proj/m"})
+
+		assert.Equal(t, []job.FullName{"proj/a", "proj/b", "proj/a"}, result["proj/a"])
+		assert.Equal(t, []job.FullName{"proj/x", "proj/y", "proj/x"}, result["proj/x"])
+		_, hasM := result["proj/m"]
+		assert.False(t, hasM, "job-m is cycle-free and should not be present in the result")
+	})
+}

--- a/core/job/job.go
+++ b/core/job/job.go
@@ -192,8 +192,10 @@ func (j *Job) IsScheduledAfter(otherJob *Job, referenceTime time.Time) (bool, st
 		return true, fmt.Sprintf("other job has sub-daily schedule [%s]", otherCronStr)
 	}
 
-	subjectNextSchedule := subjectJobCron.Next(referenceTime)
-	otherNextSchedule := otherJobCron.Next(referenceTime)
+	refTimeUTC := referenceTime.UTC()
+
+	subjectNextSchedule := subjectJobCron.Next(refTimeUTC)
+	otherNextSchedule := otherJobCron.Next(refTimeUTC)
 
 	if subjectNextSchedule.Before(otherNextSchedule) {
 		return false, fmt.Sprintf("current job [%s] is scheduled before job %s [%s]",

--- a/core/job/job.go
+++ b/core/job/job.go
@@ -2,6 +2,7 @@ package job
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -758,4 +759,16 @@ type DeployState string
 
 func (d DeployState) String() string {
 	return string(d)
+}
+
+// UpstreamGraph is a lightweight, install-wide job dependency graph keyed by FullName
+// ("project/job_name") on both sides
+type UpstreamGraph map[FullName][]FullName
+
+func (ug UpstreamGraph) DeepClone() UpstreamGraph {
+	clone := make(UpstreamGraph, len(ug))
+	for k, v := range ug {
+		clone[k] = slices.Clone(v)
+	}
+	return clone
 }

--- a/core/job/job.go
+++ b/core/job/job.go
@@ -311,6 +311,28 @@ func (j Jobs) GetNameMap() map[Name]*Job {
 	return jobNameMap
 }
 
+func (j Jobs) GetDestinationToFullNameMap() map[resource.URN]FullName {
+	destinationToFullName := make(map[resource.URN]FullName)
+	for _, jb := range j {
+		fullName := FullNameFrom(jb.Tenant().ProjectName(), jb.Spec().Name())
+		if jb.Destination() != resource.ZeroURN() {
+			destinationToFullName[jb.Destination()] = fullName
+		}
+	}
+
+	return destinationToFullName
+}
+
+func (j Jobs) GetFullNameSet() map[FullName]bool {
+	fullNameSet := make(map[FullName]bool)
+	for _, jb := range j {
+		fullName := FullNameFrom(jb.Tenant().ProjectName(), jb.Spec().Name())
+		fullNameSet[fullName] = true
+	}
+
+	return fullNameSet
+}
+
 func (j Jobs) GetNamespaceNameAndJobsMap() map[tenant.NamespaceName][]*Job {
 	jobsPerNamespaceName := make(map[tenant.NamespaceName][]*Job, len(j))
 	for _, job := range j {
@@ -448,6 +470,14 @@ func (w WithUpstreams) GetSubjectJobNameStrings() []string {
 		names[i] = withUpstream.Name().String()
 	}
 	return names
+}
+
+func (w WithUpstreams) GetNameToWithUpstreamMap() map[Name]*WithUpstream {
+	m := make(map[Name]*WithUpstream, len(w))
+	for _, jwu := range w {
+		m[jwu.Name()] = jwu
+	}
+	return m
 }
 
 func (w WithUpstreams) MergeWithResolvedUpstreams(resolvedUpstreamsBySubjectJobMap map[Name][]*Upstream) []*WithUpstream {

--- a/core/job/resolver/internal_upstream_resolver.go
+++ b/core/job/resolver/internal_upstream_resolver.go
@@ -91,7 +91,17 @@ func (i internalUpstreamResolver) resolveStaticUpstream(ctx context.Context, pro
 			me.Append(err)
 			continue
 		}
-		jobUpstream, err := i.jobRepository.GetByJobName(ctx, projectName, upstreamJobName)
+
+		upstreamProjectName := projectName
+		if upstreamName.IsWithProjectName() {
+			upstreamProjectName, err = upstreamName.GetProjectName()
+			if err != nil {
+				me.Append(err)
+				continue
+			}
+		}
+
+		jobUpstream, err := i.jobRepository.GetByJobName(ctx, upstreamProjectName, upstreamJobName)
 		if err != nil || jobUpstream == nil {
 			me.Append(err)
 			continue

--- a/core/job/resolver/internal_upstream_resolver_test.go
+++ b/core/job/resolver/internal_upstream_resolver_test.go
@@ -143,6 +143,36 @@ func TestInternalUpstreamResolver(t *testing.T) {
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, expectedJobWithUpstream.Upstreams(), result.Upstreams())
 		})
+		t.Run("resolves static upstream declared with an explicit cross-project name against that project, not the subject job's own project", func(t *testing.T) {
+			jobRepo := new(JobRepository)
+			logWriter := new(mockWriter)
+			defer logWriter.AssertExpectations(t)
+
+			otherTenant, err := tenant.NewTenant("other-project", "namespace")
+			assert.NoError(t, err)
+
+			crossProjectUpstreamSpec, _ := job.NewSpecUpstreamBuilder().WithUpstreamNames([]job.SpecUpstreamName{"other-project/job-C"}).Build()
+			specX, _ := job.NewSpecBuilder(jobVersion, "job-X", "sample-owner", jobSchedule, jobWindow, jobTask).WithSpecUpstream(crossProjectUpstreamSpec).Build()
+			jobX := job.NewJob(sampleTenant, specX, resourceURNX, nil, false)
+
+			jobCInOtherProject := job.NewJob(otherTenant, specC, jobCDestination, nil, false)
+
+			// the subject job (jobX) belongs to sampleTenant's project, but the static upstream
+			// explicitly names "other-project" - the lookup must use that, not sampleTenant's project.
+			jobRepo.On("GetByJobName", ctx, otherTenant.ProjectName(), specC.Name()).Return(jobCInOtherProject, nil)
+
+			unresolvedUpstreamCCrossProject := job.NewUpstreamUnresolvedStatic("job-C", otherTenant.ProjectName())
+			expectedUpstreamCCrossProject := job.NewUpstreamResolved("job-C", "", resourceURNC, otherTenant, "static", taskName, false)
+
+			jobWithUnresolvedUpstream := job.NewWithUpstream(jobX, []*job.Upstream{unresolvedUpstreamCCrossProject})
+			expectedJobWithUpstream := job.NewWithUpstream(jobX, []*job.Upstream{expectedUpstreamCCrossProject})
+
+			internalUpstreamResolver := resolver.NewInternalUpstreamResolver(jobRepo)
+			result, err := internalUpstreamResolver.Resolve(ctx, jobWithUnresolvedUpstream)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, expectedJobWithUpstream.Upstreams(), result.Upstreams())
+			jobRepo.AssertNotCalled(t, "GetByJobName", ctx, sampleTenant.ProjectName(), specC.Name())
+		})
 		t.Run("should not stop the process but keep appending error when unable to resolve inferred upstream", func(t *testing.T) {
 			jobRepo := new(JobRepository)
 

--- a/core/job/service/build_global_upstream_graph_test.go
+++ b/core/job/service/build_global_upstream_graph_test.go
@@ -1,0 +1,300 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goto/optimus/core/job"
+	"github.com/goto/optimus/core/job/service"
+	"github.com/goto/optimus/core/resource"
+	"github.com/goto/optimus/core/tenant"
+	"github.com/goto/optimus/internal/lib/window"
+	"github.com/goto/optimus/internal/models"
+)
+
+func TestBuildGlobalUpstreamGraph(t *testing.T) {
+	ctx := context.Background()
+
+	sampleTenant, err := tenant.NewTenant("test-proj", "test-ns")
+	assert.NoError(t, err)
+	otherProjectTenant, err := tenant.NewTenant("other-proj", "other-ns")
+	assert.NoError(t, err)
+
+	resourceURNA, err := resource.ParseURN("store://resource-A")
+	assert.NoError(t, err)
+	resourceURNB, err := resource.ParseURN("store://resource-B")
+	assert.NoError(t, err)
+	resourceURNC, err := resource.ParseURN("store://resource-C")
+	assert.NoError(t, err)
+	resourceURND, err := resource.ParseURN("store://resource-D")
+	assert.NoError(t, err)
+
+	jobVersion := 1
+	startDate, err := job.ScheduleDateFrom("2022-10-01")
+	assert.NoError(t, err)
+	jobSchedule, err := job.NewScheduleBuilder(startDate).Build()
+	assert.NoError(t, err)
+	w, err := models.NewWindow(jobVersion, "d", "24h", "24h")
+	assert.NoError(t, err)
+	jobWindow := window.NewCustomConfig(w)
+	taskName, err := job.TaskNameFrom("sample-task")
+	assert.NoError(t, err)
+	jobTask := job.NewTask(taskName, map[string]string{"key": "value"}, "", nil)
+
+	newJobA := func(tnnt tenant.Tenant, destination resource.URN) *job.Job {
+		spec, buildErr := job.NewSpecBuilder(jobVersion, "jobA", "owner", jobSchedule, jobWindow, jobTask).Build()
+		assert.NoError(t, buildErr)
+		return job.NewJob(tnnt, spec, destination, nil, false)
+	}
+
+	fullNameA := job.FullNameFrom(sampleTenant.ProjectName(), "jobA")
+
+	t.Run("full-replaces an incoming job's edges with its freshly-resolved upstreams, keeping unrelated persisted edges", func(t *testing.T) {
+		jobRepo := new(JobRepository)
+		defer jobRepo.AssertExpectations(t)
+		upstreamRepo := new(UpstreamRepository)
+		defer upstreamRepo.AssertExpectations(t)
+		downstreamRepo := new(DownstreamRepository)
+		defer downstreamRepo.AssertExpectations(t)
+
+		jobA := newJobA(sampleTenant, resourceURNA)
+		resolvedUpstreamB := job.NewUpstreamResolved("jobB", "", resourceURNB, sampleTenant, "static", taskName, false)
+		jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{resolvedUpstreamB})
+
+		unrelatedFullName := job.FullNameFrom(sampleTenant.ProjectName(), "unrelatedJob")
+		fullNameB := job.FullNameFrom(sampleTenant.ProjectName(), "jobB")
+
+		// the persisted graph already has a stale edge for jobA (pointing somewhere else) plus an
+		// entirely unrelated edge - the stale jobA edge must be replaced, the unrelated one kept.
+		upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{
+			fullNameA:         {job.FullNameFrom(sampleTenant.ProjectName(), "staleUpstream")},
+			unrelatedFullName: {fullNameB},
+		}, nil)
+		downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNA).Return(nil, nil)
+
+		svc := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, service.JobValidateConfig{})
+
+		graph, err := svc.BuildGlobalUpstreamGraph(ctx, []*job.Job{jobA}, []*job.WithUpstream{jobAWithUpstream})
+
+		assert.NoError(t, err)
+		assert.Equal(t, job.UpstreamGraph{
+			fullNameA:         {fullNameB},
+			unrelatedFullName: {fullNameB},
+		}, graph)
+	})
+
+	t.Run("matches an unresolved inferred upstream against a sibling incoming job's destination", func(t *testing.T) {
+		jobRepo := new(JobRepository)
+		defer jobRepo.AssertExpectations(t)
+		upstreamRepo := new(UpstreamRepository)
+		defer upstreamRepo.AssertExpectations(t)
+		downstreamRepo := new(DownstreamRepository)
+		defer downstreamRepo.AssertExpectations(t)
+
+		jobA := newJobA(sampleTenant, resourceURNA)
+		specB, err := job.NewSpecBuilder(jobVersion, "jobB", "owner", jobSchedule, jobWindow, jobTask).Build()
+		assert.NoError(t, err)
+		jobB := job.NewJob(sampleTenant, specB, resourceURNB, nil, false)
+
+		// jobA's inferred upstream isn't resolved yet (no owning job found via BulkResolve), but
+		// its destination URN matches jobB, which is also part of this same incoming batch.
+		unresolvedUpstream := job.NewUpstreamUnresolvedInferred(resourceURNB)
+		jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{unresolvedUpstream})
+		jobBWithUpstream := job.NewWithUpstream(jobB, []*job.Upstream{})
+
+		fullNameB := job.FullNameFrom(sampleTenant.ProjectName(), "jobB")
+
+		upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{}, nil)
+		downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNA).Return(nil, nil)
+		downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNB).Return(nil, nil)
+
+		svc := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, service.JobValidateConfig{})
+
+		graph, err := svc.BuildGlobalUpstreamGraph(ctx, []*job.Job{jobA, jobB}, []*job.WithUpstream{jobAWithUpstream, jobBWithUpstream})
+
+		assert.NoError(t, err)
+		assert.Equal(t, []job.FullName{fullNameB}, graph[fullNameA])
+		// jobB itself has no upstreams, but must still appear (with an empty/no edge list) since
+		// it's part of the incoming batch and overlay 1 always sets its entry.
+		assert.Empty(t, graph[fullNameB])
+	})
+
+	t.Run("falls back to an existing job producing the destination when no sibling incoming job matches", func(t *testing.T) {
+		jobRepo := new(JobRepository)
+		defer jobRepo.AssertExpectations(t)
+		upstreamRepo := new(UpstreamRepository)
+		defer upstreamRepo.AssertExpectations(t)
+		downstreamRepo := new(DownstreamRepository)
+		defer downstreamRepo.AssertExpectations(t)
+
+		jobA := newJobA(sampleTenant, resourceURNA)
+		unresolvedUpstream := job.NewUpstreamUnresolvedInferred(resourceURNC)
+		jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{unresolvedUpstream})
+
+		specC, err := job.NewSpecBuilder(jobVersion, "jobC", "owner", jobSchedule, jobWindow, jobTask).Build()
+		assert.NoError(t, err)
+		jobC := job.NewJob(sampleTenant, specC, resourceURNC, nil, false)
+
+		upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{}, nil)
+		downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNA).Return(nil, nil)
+		jobRepo.On("GetAllByResourceDestination", ctx, resourceURNC).Return([]*job.Job{jobC}, nil)
+
+		svc := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, service.JobValidateConfig{})
+
+		graph, err := svc.BuildGlobalUpstreamGraph(ctx, []*job.Job{jobA}, []*job.WithUpstream{jobAWithUpstream})
+
+		assert.NoError(t, err)
+		assert.Equal(t, []job.FullName{job.FullNameFrom(sampleTenant.ProjectName(), "jobC")}, graph[fullNameA])
+	})
+
+	t.Run("drops an unresolved inferred upstream whose destination no job anywhere currently produces", func(t *testing.T) {
+		jobRepo := new(JobRepository)
+		defer jobRepo.AssertExpectations(t)
+		upstreamRepo := new(UpstreamRepository)
+		defer upstreamRepo.AssertExpectations(t)
+		downstreamRepo := new(DownstreamRepository)
+		defer downstreamRepo.AssertExpectations(t)
+
+		jobA := newJobA(sampleTenant, resourceURNA)
+		unresolvedUpstream := job.NewUpstreamUnresolvedInferred(resourceURND)
+		jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{unresolvedUpstream})
+
+		upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{}, nil)
+		downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNA).Return(nil, nil)
+		jobRepo.On("GetAllByResourceDestination", ctx, resourceURND).Return([]*job.Job{}, nil)
+
+		svc := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, service.JobValidateConfig{})
+
+		graph, err := svc.BuildGlobalUpstreamGraph(ctx, []*job.Job{jobA}, []*job.WithUpstream{jobAWithUpstream})
+
+		assert.NoError(t, err)
+		assert.Empty(t, graph[fullNameA])
+	})
+
+	t.Run("skips external upstreams entirely", func(t *testing.T) {
+		jobRepo := new(JobRepository)
+		defer jobRepo.AssertExpectations(t)
+		upstreamRepo := new(UpstreamRepository)
+		defer upstreamRepo.AssertExpectations(t)
+		downstreamRepo := new(DownstreamRepository)
+		defer downstreamRepo.AssertExpectations(t)
+
+		jobA := newJobA(sampleTenant, resourceURNA)
+		externalUpstream := job.NewUpstreamResolved("externalJob", "some-host", resourceURNB, otherProjectTenant, "static", taskName, true)
+		jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{externalUpstream})
+
+		upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{}, nil)
+		downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNA).Return(nil, nil)
+
+		svc := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, service.JobValidateConfig{})
+
+		graph, err := svc.BuildGlobalUpstreamGraph(ctx, []*job.Job{jobA}, []*job.WithUpstream{jobAWithUpstream})
+
+		assert.NoError(t, err)
+		assert.Empty(t, graph[fullNameA])
+	})
+
+	t.Run("adds a reverse-impact edge from an existing downstream job that is not part of the incoming batch", func(t *testing.T) {
+		jobRepo := new(JobRepository)
+		defer jobRepo.AssertExpectations(t)
+		upstreamRepo := new(UpstreamRepository)
+		defer upstreamRepo.AssertExpectations(t)
+		downstreamRepo := new(DownstreamRepository)
+		defer downstreamRepo.AssertExpectations(t)
+
+		jobA := newJobA(sampleTenant, resourceURNA)
+		jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{})
+
+		existingDownstreamC := job.NewDownstream("jobC", sampleTenant.ProjectName(), sampleTenant.NamespaceName(), taskName)
+
+		upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{}, nil)
+		downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNA).Return([]*job.Downstream{existingDownstreamC}, nil)
+
+		svc := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, service.JobValidateConfig{})
+
+		graph, err := svc.BuildGlobalUpstreamGraph(ctx, []*job.Job{jobA}, []*job.WithUpstream{jobAWithUpstream})
+
+		assert.NoError(t, err)
+		fullNameC := job.FullNameFrom(sampleTenant.ProjectName(), "jobC")
+		assert.Equal(t, []job.FullName{fullNameA}, graph[fullNameC])
+	})
+
+	t.Run("does not apply a reverse-impact edge onto a job that is itself part of the incoming batch", func(t *testing.T) {
+		jobRepo := new(JobRepository)
+		defer jobRepo.AssertExpectations(t)
+		upstreamRepo := new(UpstreamRepository)
+		defer upstreamRepo.AssertExpectations(t)
+		downstreamRepo := new(DownstreamRepository)
+		defer downstreamRepo.AssertExpectations(t)
+
+		jobA := newJobA(sampleTenant, resourceURNA)
+		specB, err := job.NewSpecBuilder(jobVersion, "jobB", "owner", jobSchedule, jobWindow, jobTask).Build()
+		assert.NoError(t, err)
+		jobB := job.NewJob(sampleTenant, specB, resourceURNB, nil, false)
+
+		jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{})
+		jobBWithUpstream := job.NewWithUpstream(jobB, []*job.Upstream{})
+
+		// jobB "gains" a downstream edge to jobA per GetDownstreamByDestination, but jobB is also
+		// part of the incoming batch - overlay 1 already gave it a complete edge list (empty), so
+		// overlay 2 must not additively touch it.
+		jobBAsDownstream := job.NewDownstream("jobB", sampleTenant.ProjectName(), sampleTenant.NamespaceName(), taskName)
+
+		upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{}, nil)
+		downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNA).Return([]*job.Downstream{jobBAsDownstream}, nil)
+		downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNB).Return(nil, nil)
+
+		svc := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, service.JobValidateConfig{})
+
+		graph, err := svc.BuildGlobalUpstreamGraph(ctx, []*job.Job{jobA, jobB}, []*job.WithUpstream{jobAWithUpstream, jobBWithUpstream})
+
+		assert.NoError(t, err)
+		fullNameB := job.FullNameFrom(sampleTenant.ProjectName(), "jobB")
+		assert.Empty(t, graph[fullNameB])
+	})
+
+	t.Run("skips the reverse-impact lookup entirely for an incoming job with no destination", func(t *testing.T) {
+		jobRepo := new(JobRepository)
+		defer jobRepo.AssertExpectations(t)
+		upstreamRepo := new(UpstreamRepository)
+		defer upstreamRepo.AssertExpectations(t)
+		downstreamRepo := new(DownstreamRepository)
+		defer downstreamRepo.AssertExpectations(t)
+
+		jobA := newJobA(sampleTenant, resource.ZeroURN())
+		jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{})
+
+		upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{}, nil)
+
+		svc := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, service.JobValidateConfig{})
+
+		graph, err := svc.BuildGlobalUpstreamGraph(ctx, []*job.Job{jobA}, []*job.WithUpstream{jobAWithUpstream})
+
+		assert.NoError(t, err)
+		assert.Empty(t, graph[fullNameA])
+	})
+
+	t.Run("propagates an error from the global persisted graph fetch", func(t *testing.T) {
+		jobRepo := new(JobRepository)
+		defer jobRepo.AssertExpectations(t)
+		upstreamRepo := new(UpstreamRepository)
+		defer upstreamRepo.AssertExpectations(t)
+		downstreamRepo := new(DownstreamRepository)
+		defer downstreamRepo.AssertExpectations(t)
+
+		jobA := newJobA(sampleTenant, resourceURNA)
+		jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{})
+
+		upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(nil, errors.New("db error"))
+
+		svc := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, service.JobValidateConfig{})
+
+		graph, err := svc.BuildGlobalUpstreamGraph(ctx, []*job.Job{jobA}, []*job.WithUpstream{jobAWithUpstream})
+
+		assert.Error(t, err)
+		assert.Nil(t, graph)
+	})
+}

--- a/core/job/service/job_service.go
+++ b/core/job/service/job_service.go
@@ -1746,28 +1746,29 @@ func (j *JobService) mergeUpstreamGraphWithIncomingSpecs(ctx context.Context, gr
 	jobs := job.Jobs(incomingJobs)
 	me := errors.NewMultiError("build global upstream graph errors")
 
-	err := j.rebuildIncomingUpstreamEdges(ctx, graph, jobs, jobsWithUpstream)
+	updatedGraph, err := j.resolveUpstreamsForIncomingJobs(ctx, graph, jobs, jobsWithUpstream)
 	me.Append(err)
 
-	err = j.patchExistingDownstreamEdges(ctx, graph, jobs)
+	updatedFullGraph, err := j.resolveDownstreamsForIncomingJobs(ctx, updatedGraph, jobs)
 	me.Append(err)
 
-	return graph, me.ToErr()
+	return updatedFullGraph, me.ToErr()
 }
 
-// rebuildIncomingUpstreamEdges replaces each incoming job's edges in the graph with the
+// resolveUpstreamsForIncomingJobs replaces each incoming job's edges in the graph with the
 // upstreams from its freshly-resolved spec
-func (j *JobService) rebuildIncomingUpstreamEdges(ctx context.Context, graph job.UpstreamGraph, incomingJobs job.Jobs, jobsWithUpstream []*job.WithUpstream) error {
+func (j *JobService) resolveUpstreamsForIncomingJobs(ctx context.Context, graph job.UpstreamGraph, incomingJobs job.Jobs, jobsWithUpstream []*job.WithUpstream) (job.UpstreamGraph, error) {
 	me := errors.NewMultiError("rebuild incoming upstream edges errors")
 	jobWithUpstreamByName := job.WithUpstreams(jobsWithUpstream).GetNameToWithUpstreamMap()
 	destinationToFullName := incomingJobs.GetDestinationToFullNameMap()
+	updatedGraph := graph.DeepClone()
 
 	for _, incomingJob := range incomingJobs {
 		fullName := job.FullNameFrom(incomingJob.Tenant().ProjectName(), incomingJob.Spec().Name())
 
 		jwu, ok := jobWithUpstreamByName[incomingJob.Spec().Name()]
 		if !ok {
-			graph[fullName] = nil
+			updatedGraph[fullName] = nil
 			continue
 		}
 
@@ -1806,17 +1807,18 @@ func (j *JobService) rebuildIncomingUpstreamEdges(ctx context.Context, graph job
 			}
 		}
 
-		graph[fullName] = edges
+		updatedGraph[fullName] = edges
 	}
 
-	return me.ToErr()
+	return updatedGraph, me.ToErr()
 }
 
-// patchExistingDownstreamEdges adds edges from already-persisted jobs that consume an incoming
+// resolveDownstreamsForIncomingJobs adds edges from already-persisted jobs that consume an incoming
 // job's destination, so the graph reflects the new inbound connections the incoming spec creates.
-func (j *JobService) patchExistingDownstreamEdges(ctx context.Context, graph job.UpstreamGraph, incomingJobs job.Jobs) error {
+func (j *JobService) resolveDownstreamsForIncomingJobs(ctx context.Context, graph job.UpstreamGraph, incomingJobs job.Jobs) (job.UpstreamGraph, error) {
 	me := errors.NewMultiError("patch existing downstream edges errors")
 	incomingJobMap := incomingJobs.GetFullNameSet()
+	updatedGraph := graph.DeepClone()
 
 	for _, incomingJob := range incomingJobs {
 		if incomingJob.Destination() == resource.ZeroURN() {
@@ -1836,11 +1838,11 @@ func (j *JobService) patchExistingDownstreamEdges(ctx context.Context, graph job
 			if incomingJobMap[downstreamFullName] {
 				continue
 			}
-			graph[downstreamFullName] = append(graph[downstreamFullName], incomingFullName)
+			updatedGraph[downstreamFullName] = append(updatedGraph[downstreamFullName], incomingFullName)
 		}
 	}
 
-	return me.ToErr()
+	return updatedGraph, me.ToErr()
 }
 
 func (j *JobService) validateUpstream(ctx context.Context, subjectJob *job.Job, jobsToValidateMap map[job.Name]*job.Job) dto.ValidateResult {

--- a/core/job/service/job_service.go
+++ b/core/job/service/job_service.go
@@ -19,7 +19,6 @@ import (
 	"github.com/goto/optimus/core/tenant"
 	"github.com/goto/optimus/internal/compiler"
 	"github.com/goto/optimus/internal/errors"
-	"github.com/goto/optimus/internal/lib/tree"
 	"github.com/goto/optimus/internal/lib/window"
 	"github.com/goto/optimus/internal/utils/filter"
 	"github.com/goto/optimus/internal/writer"
@@ -139,6 +138,7 @@ type UpstreamRepository interface {
 	ResolveUpstreams(context.Context, tenant.ProjectName, []job.Name) (map[job.Name][]*job.Upstream, error)
 	ReplaceUpstreams(context.Context, []*job.WithUpstream) error
 	GetUpstreams(ctx context.Context, projectName tenant.ProjectName, jobName job.Name) ([]*job.Upstream, error)
+	GetAllResolvedUpstreamEdges(ctx context.Context) (map[job.FullName][]job.FullName, error)
 }
 
 type DownstreamRepository interface {
@@ -958,23 +958,6 @@ func (j *JobService) getAllDownstreams(ctx context.Context, projectName tenant.P
 	return downstreamsPerLevel, nil
 }
 
-func (*JobService) getIdentifierToJobsMap(jobsToValidateMap map[job.Name]*job.WithUpstream) map[string][]*job.WithUpstream {
-	identifierToJobsMap := make(map[string][]*job.WithUpstream)
-	for _, jobEntity := range jobsToValidateMap {
-		jobIdentifiers := []string{jobEntity.Job().FullName()}
-		if jobDestination := jobEntity.Job().Destination().String(); jobDestination != "" {
-			jobIdentifiers = append(jobIdentifiers, jobDestination)
-		}
-		for _, jobIdentifier := range jobIdentifiers {
-			if _, ok := identifierToJobsMap[jobIdentifier]; !ok {
-				identifierToJobsMap[jobIdentifier] = []*job.WithUpstream{}
-			}
-			identifierToJobsMap[jobIdentifier] = append(identifierToJobsMap[jobIdentifier], jobEntity)
-		}
-	}
-	return identifierToJobsMap
-}
-
 func (j *JobService) resolveAndSaveUpstreams(ctx context.Context, logWriter writer.LogWriter, jobsToResolve ...[]*job.Job) error {
 	var allJobsToResolve []*job.Job
 	for _, group := range jobsToResolve {
@@ -1271,51 +1254,6 @@ func (j *JobService) generateJob(ctx context.Context, tenantWithDetails *tenant.
 	}
 
 	return job.NewJob(tenantWithDetails.ToTenant(), spec, destination, sources, false), nil
-}
-
-func (*JobService) buildDAGTree(rootName job.Name, jobMap map[job.Name]*job.WithUpstream, identifierToJobMap map[string][]*job.WithUpstream) *tree.MultiRootTree {
-	rootJob := jobMap[rootName]
-
-	dagTree := tree.NewMultiRootTree()
-	dagTree.AddNode(tree.NewTreeNode(rootJob))
-
-	for _, childJob := range jobMap {
-		childNode := findOrCreateDAGNode(dagTree, childJob)
-		for _, upstream := range childJob.Upstreams() {
-			identifier := upstream.Resource().String()
-			if _, ok := identifierToJobMap[identifier]; !ok {
-				identifier = upstream.FullName()
-				if _, ok := identifierToJobMap[identifier]; !ok {
-					// resource maybe from external optimus or outside project,
-					// as of now, we're not providing the capability to build tree from external optimus or outside project. skip
-					continue
-				}
-			}
-
-			parents := identifierToJobMap[identifier]
-			for _, parentJob := range parents {
-				parentNode := findOrCreateDAGNode(dagTree, parentJob)
-				parentNode.AddDependent(childNode)
-				dagTree.AddNode(parentNode)
-			}
-		}
-
-		if len(childJob.Upstreams()) == 0 {
-			dagTree.MarkRoot(childNode)
-		}
-	}
-
-	return dagTree
-}
-
-// sources: https://github.com/goto/optimus/blob/a6dafbc1fbeb8e1f1eb8d4a6e9582ada4a7f639e/job/replay.go#L101
-func findOrCreateDAGNode(dagTree *tree.MultiRootTree, dag tree.TreeData) *tree.TreeNode {
-	node, ok := dagTree.GetNodeByName(dag.GetName())
-	if !ok {
-		node = tree.NewTreeNode(dag)
-		dagTree.AddNode(node)
-	}
-	return node
 }
 
 func (j *JobService) GetJobBasicInfo(ctx context.Context, jobTenant tenant.Tenant, jobName job.Name, spec *job.Spec) (*job.Job, writer.BufferedLogger) {
@@ -1729,85 +1667,162 @@ func (j *JobService) validateOneJob(ctx context.Context, tenantDetails *tenant.W
 	return output
 }
 
-// todo: ensure cycles are validated across projects
+// validateCyclic checks whether any of the incoming jobs, once applied, would sit on a cyclic
+// dependency. The check is global, not scoped to the request's tenant or project: it starts from
+// a resolved-upstream graph spanning the whole install (BuildGlobalUpstreamGraph), patched with
+// the delta this request would introduce, then runs cycle detection per incoming job so a cycle
+// affecting one job doesn't mask a separate, disjoint cycle affecting another.
+//
+// NOTE: only internal upstreams are considered - external upstreams are out of scope, same as before this change.
 func (j *JobService) validateCyclic(ctx context.Context, tnnt tenant.Tenant, incomingJobs []*job.Job) (map[job.Name][]dto.ValidateResult, error) {
-	existingJobs, err := j.jobRepo.GetAllByTenant(ctx, tnnt)
-	if err != nil {
-		return nil, err
-	}
-
 	if err := j.upstreamResolver.CheckStaticResolvable(ctx, tnnt, incomingJobs, writer.NewSafeBufferedLogger()); err != nil {
 		return nil, err
 	}
 
-	jobsToValidate := j.getCombinedJobsToValidate(incomingJobs, existingJobs)
-
-	jobsWithUpstream, err := j.upstreamResolver.BulkResolve(ctx, jobsToValidate, writer.NewSafeBufferedLogger())
+	jobsWithUpstream, err := j.upstreamResolver.BulkResolve(ctx, incomingJobs, writer.NewSafeBufferedLogger())
 	if err != nil {
 		return nil, err
 	}
 
-	// NOTE: only check cyclic deps across internal upstreams (sources), need further discussion to check cyclic deps for external upstream
-	// assumption, all job specs from input are also the job within same project
-	jobWithUpstreamPerJobName := j.getJobWithUpstreamPerJobName(jobsWithUpstream)
-	identifierToJobsMap := j.getIdentifierToJobsMap(jobWithUpstreamPerJobName)
+	graph, err := j.BuildGlobalUpstreamGraph(ctx, incomingJobs, jobsWithUpstream)
+	if err != nil {
+		return nil, err
+	}
+
+	roots := make([]job.FullName, len(incomingJobs))
+	for i, subjectJob := range incomingJobs {
+		roots[i] = job.FullNameFrom(subjectJob.Tenant().ProjectName(), subjectJob.Spec().Name())
+	}
+	cycles := job.FindCyclicPaths(graph, roots)
 
 	output := make(map[job.Name][]dto.ValidateResult)
-
-	isJobNameCyclic := make(map[string]bool)
-	for _, subjectJob := range incomingJobs {
-		dagTree := j.buildDAGTree(subjectJob.Spec().Name(), jobWithUpstreamPerJobName, identifierToJobsMap)
-		cyclicNames, err := dagTree.ValidateCyclic()
-
-		for _, name := range cyclicNames {
-			isJobNameCyclic[name] = true
-		}
-
-		if err != nil && isJobNameCyclic[subjectJob.GetName()] {
-			output[subjectJob.Spec().Name()] = []dto.ValidateResult{
-				{
-					Stage: dto.StageCyclicValidation,
-					Messages: append([]string{
-						"cyclic dependency is detected",
-					}, cyclicNames...),
-					Success: false,
-				},
-			}
-
-			registerJobValidationMetric(tnnt, dto.StageCyclicValidation, false)
-		} else {
+	for i, subjectJob := range incomingJobs {
+		cycle, isCyclic := cycles[roots[i]]
+		if !isCyclic {
 			registerJobValidationMetric(tnnt, dto.StageCyclicValidation, true)
+			continue
 		}
+
+		messages := make([]string, 0, len(cycle)+1)
+		messages = append(messages, "cyclic dependency is detected")
+		for _, name := range cycle {
+			messages = append(messages, name.String())
+		}
+
+		output[subjectJob.Spec().Name()] = []dto.ValidateResult{
+			{
+				Stage:    dto.StageCyclicValidation,
+				Messages: messages,
+				Success:  false,
+			},
+		}
+		registerJobValidationMetric(tnnt, dto.StageCyclicValidation, false)
 	}
 
 	return output, nil
 }
 
-func (*JobService) getCombinedJobsToValidate(incoming, existing []*job.Job) []*job.Job {
-	uniqueJobs := make(map[job.Name]*job.Job)
-	for _, j := range existing {
-		uniqueJobs[j.Spec().Name()] = j
+// BuildGlobalUpstreamGraph assembles the job-dependency graph used for cyclic-dependency
+// detection. It starts from every resolved, internal upstream edge already persisted anywhere in
+// the install (job.FullName-keyed, so edges naturally span projects and namespaces), then patches
+// in the delta this validate request would introduce once applied:
+//
+//  1. Incoming jobs will have its upstreams/edges refreshed, because the incoming specs are the newly
+//     proposed state
+//  2. Existing jobs with sources referencing an incoming job's destination gain an additive
+//     edge to that incoming job, via the same GetDownstreamByDestination lookup
+func (j *JobService) BuildGlobalUpstreamGraph(ctx context.Context, incomingJobs []*job.Job, jobsWithUpstream []*job.WithUpstream) (job.UpstreamGraph, error) {
+	graph, err := j.upstreamRepo.GetAllResolvedUpstreamEdges(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	for _, j := range incoming {
-		uniqueJobs[j.Spec().Name()] = j
+	me := errors.NewMultiError("build global upstream graph errors")
+
+	incomingFullNames := make(map[job.FullName]bool, len(incomingJobs))
+	destinationToFullName := make(map[resource.URN]job.FullName, len(incomingJobs))
+	for _, incomingJob := range incomingJobs {
+		fullName := job.FullNameFrom(incomingJob.Tenant().ProjectName(), incomingJob.Spec().Name())
+		incomingFullNames[fullName] = true
+		if incomingJob.Destination() != resource.ZeroURN() {
+			destinationToFullName[incomingJob.Destination()] = fullName
+		}
 	}
 
-	var output []*job.Job
-	for _, j := range uniqueJobs {
-		output = append(output, j)
+	jobWithUpstreamByName := make(map[job.Name]*job.WithUpstream, len(jobsWithUpstream))
+	for _, jwu := range jobsWithUpstream {
+		jobWithUpstreamByName[jwu.Name()] = jwu
 	}
 
-	return output
-}
+	// 1st Phase: incoming jobs' upstreams are rebuilt based on the incoming spec
+	for _, incomingJob := range incomingJobs {
+		fullName := job.FullNameFrom(incomingJob.Tenant().ProjectName(), incomingJob.Spec().Name())
 
-func (*JobService) getJobWithUpstreamPerJobName(jobsWithUpstream []*job.WithUpstream) map[job.Name]*job.WithUpstream {
-	jobsToValidateMap := make(map[job.Name]*job.WithUpstream)
-	for _, jobWithUpstream := range jobsWithUpstream {
-		jobsToValidateMap[jobWithUpstream.Name()] = jobWithUpstream
+		jwu, ok := jobWithUpstreamByName[incomingJob.Spec().Name()]
+		if !ok {
+			graph[fullName] = nil
+			continue
+		}
+
+		var edges []job.FullName
+		for _, upstream := range jwu.Upstreams() {
+			if upstream.External() {
+				// out of scope: external optimus dependencies aren't tracked here
+				continue
+			}
+
+			if upstream.Name() != "" && upstream.ProjectName() != "" {
+				edges = append(edges, job.FullNameFrom(upstream.ProjectName(), upstream.Name()))
+				continue
+			}
+
+			// unresolved inferred upstream: only a destination URN is known, no job
+			if upstream.Resource() == resource.ZeroURN() {
+				continue
+			}
+			if target, ok := destinationToFullName[upstream.Resource()]; ok {
+				edges = append(edges, target)
+				continue
+			}
+
+			existingUpstreamJobs, err := j.jobRepo.GetAllByResourceDestination(ctx, upstream.Resource())
+			if err != nil {
+				me.Append(err)
+				continue
+			}
+			if len(existingUpstreamJobs) > 0 {
+				owner := existingUpstreamJobs[0]
+				edges = append(edges, job.FullNameFrom(owner.Tenant().ProjectName(), owner.Spec().Name()))
+			}
+			// else: no job anywhere currently produces this resource - nothing to link yet.
+		}
+
+		graph[fullName] = edges
 	}
 
-	return jobsToValidateMap
+	// Overlay 2: existing jobs gaining a new edge into an incoming job (additive).
+	for _, incomingJob := range incomingJobs {
+		if incomingJob.Destination() == resource.ZeroURN() {
+			continue
+		}
+		incomingFullName := job.FullNameFrom(incomingJob.Tenant().ProjectName(), incomingJob.Spec().Name())
+
+		downstreams, err := j.downstreamRepo.GetDownstreamByDestination(ctx, incomingJob.Destination())
+		if err != nil {
+			me.Append(err)
+			continue
+		}
+
+		for _, downstream := range downstreams {
+			downstreamFullName := downstream.FullName()
+			if incomingFullNames[downstreamFullName] {
+				continue
+			}
+			graph[downstreamFullName] = append(graph[downstreamFullName], incomingFullName)
+		}
+	}
+
+	return graph, me.ToErr()
 }
 
 func (j *JobService) validateUpstream(ctx context.Context, subjectJob *job.Job, jobsToValidateMap map[job.Name]*job.Job) dto.ValidateResult {
@@ -1988,11 +2003,7 @@ func (j *JobService) validateResourceURN(ctx context.Context, tnnt tenant.Tenant
 		return "resource exists in db but not in store", false
 	}
 
-	// TODO there are issues related to the upstream checker which we use.
-	// for example, resource checker can return nested struct columns (which is not a table) and return validation error
-	// because the referenced table name won't exist in both DB & store.
-	// revert the return value back to "false" if we already fixed the upstream checker issue
-	return "resource does not exist in both db and store", true
+	return "resource does not exist in both db and store", false
 }
 
 func (j *JobService) validateRun(ctx context.Context, subjectJob *job.Job, destination resource.URN) dto.ValidateResult {

--- a/core/job/service/job_service.go
+++ b/core/job/service/job_service.go
@@ -1739,24 +1739,29 @@ func (j *JobService) BuildGlobalUpstreamGraph(ctx context.Context, incomingJobs 
 		return nil, err
 	}
 
+	return j.mergeUpstreamGraphWithIncomingSpecs(ctx, graph, incomingJobs, jobsWithUpstream)
+}
+
+func (j *JobService) mergeUpstreamGraphWithIncomingSpecs(ctx context.Context, graph job.UpstreamGraph, incomingJobs []*job.Job, jobsWithUpstream []*job.WithUpstream) (job.UpstreamGraph, error) {
+	jobs := job.Jobs(incomingJobs)
 	me := errors.NewMultiError("build global upstream graph errors")
 
-	incomingFullNames := make(map[job.FullName]bool, len(incomingJobs))
-	destinationToFullName := make(map[resource.URN]job.FullName, len(incomingJobs))
-	for _, incomingJob := range incomingJobs {
-		fullName := job.FullNameFrom(incomingJob.Tenant().ProjectName(), incomingJob.Spec().Name())
-		incomingFullNames[fullName] = true
-		if incomingJob.Destination() != resource.ZeroURN() {
-			destinationToFullName[incomingJob.Destination()] = fullName
-		}
-	}
+	err := j.rebuildIncomingUpstreamEdges(ctx, graph, jobs, jobsWithUpstream)
+	me.Append(err)
 
-	jobWithUpstreamByName := make(map[job.Name]*job.WithUpstream, len(jobsWithUpstream))
-	for _, jwu := range jobsWithUpstream {
-		jobWithUpstreamByName[jwu.Name()] = jwu
-	}
+	err = j.patchExistingDownstreamEdges(ctx, graph, jobs)
+	me.Append(err)
 
-	// 1st Phase: incoming jobs' upstreams are rebuilt based on the incoming spec
+	return graph, me.ToErr()
+}
+
+// rebuildIncomingUpstreamEdges replaces each incoming job's edges in the graph with the
+// upstreams from its freshly-resolved spec
+func (j *JobService) rebuildIncomingUpstreamEdges(ctx context.Context, graph job.UpstreamGraph, incomingJobs job.Jobs, jobsWithUpstream []*job.WithUpstream) error {
+	me := errors.NewMultiError("rebuild incoming upstream edges errors")
+	jobWithUpstreamByName := job.WithUpstreams(jobsWithUpstream).GetNameToWithUpstreamMap()
+	destinationToFullName := incomingJobs.GetDestinationToFullNameMap()
+
 	for _, incomingJob := range incomingJobs {
 		fullName := job.FullNameFrom(incomingJob.Tenant().ProjectName(), incomingJob.Spec().Name())
 
@@ -1768,25 +1773,28 @@ func (j *JobService) BuildGlobalUpstreamGraph(ctx context.Context, incomingJobs 
 
 		var edges []job.FullName
 		for _, upstream := range jwu.Upstreams() {
+			// 1. external upstreams are out of scope
 			if upstream.External() {
-				// out of scope: external optimus dependencies aren't tracked here
 				continue
 			}
 
+			// 2. already resolved upstreams we directly add it as edge
 			if upstream.Name() != "" && upstream.ProjectName() != "" {
 				edges = append(edges, job.FullNameFrom(upstream.ProjectName(), upstream.Name()))
 				continue
 			}
 
-			// unresolved inferred upstream: only a destination URN is known, no job
+			// 3. unresolved upstreams: only resource URN is known
 			if upstream.Resource() == resource.ZeroURN() {
 				continue
 			}
+			// 3.a. unresolved upstreams are jobs which are part of the request but not persisted yet
 			if target, ok := destinationToFullName[upstream.Resource()]; ok {
 				edges = append(edges, target)
 				continue
 			}
 
+			// 3.b. handle edge cases where the previous resolve does not consider this upstream as resolved
 			existingUpstreamJobs, err := j.jobRepo.GetAllByResourceDestination(ctx, upstream.Resource())
 			if err != nil {
 				me.Append(err)
@@ -1796,13 +1804,20 @@ func (j *JobService) BuildGlobalUpstreamGraph(ctx context.Context, incomingJobs 
 				owner := existingUpstreamJobs[0]
 				edges = append(edges, job.FullNameFrom(owner.Tenant().ProjectName(), owner.Spec().Name()))
 			}
-			// else: no job anywhere currently produces this resource - nothing to link yet.
 		}
 
 		graph[fullName] = edges
 	}
 
-	// Overlay 2: existing jobs gaining a new edge into an incoming job (additive).
+	return me.ToErr()
+}
+
+// patchExistingDownstreamEdges adds edges from already-persisted jobs that consume an incoming
+// job's destination, so the graph reflects the new inbound connections the incoming spec creates.
+func (j *JobService) patchExistingDownstreamEdges(ctx context.Context, graph job.UpstreamGraph, incomingJobs job.Jobs) error {
+	me := errors.NewMultiError("patch existing downstream edges errors")
+	incomingJobMap := incomingJobs.GetFullNameSet()
+
 	for _, incomingJob := range incomingJobs {
 		if incomingJob.Destination() == resource.ZeroURN() {
 			continue
@@ -1817,14 +1832,15 @@ func (j *JobService) BuildGlobalUpstreamGraph(ctx context.Context, incomingJobs 
 
 		for _, downstream := range downstreams {
 			downstreamFullName := downstream.FullName()
-			if incomingFullNames[downstreamFullName] {
+			// if it is already a part of the incoming jobs, do not update
+			if incomingJobMap[downstreamFullName] {
 				continue
 			}
 			graph[downstreamFullName] = append(graph[downstreamFullName], incomingFullName)
 		}
 	}
 
-	return graph, me.ToErr()
+	return me.ToErr()
 }
 
 func (j *JobService) validateUpstream(ctx context.Context, subjectJob *job.Job, jobsToValidateMap map[job.Name]*job.Job) dto.ValidateResult {

--- a/core/job/service/job_service.go
+++ b/core/job/service/job_service.go
@@ -162,7 +162,7 @@ type JobRunInputCompiler interface {
 }
 
 type ResourceExistenceChecker interface {
-	GetByURN(ctx context.Context, tnnt tenant.Tenant, urn resource.URN) (*resource.Resource, error)
+	GetByURN(ctx context.Context, urn resource.URN) (*resource.Resource, error)
 	ExistInStore(ctx context.Context, tnnt tenant.Tenant, urn resource.URN) (bool, error)
 }
 
@@ -1679,10 +1679,8 @@ func (j *JobService) validateCyclic(ctx context.Context, tnnt tenant.Tenant, inc
 		return nil, err
 	}
 
-	jobsWithUpstream, err := j.upstreamResolver.BulkResolve(ctx, incomingJobs, writer.NewSafeBufferedLogger())
-	if err != nil {
-		return nil, err
-	}
+	// disregard any error in this stage
+	jobsWithUpstream, _ := j.upstreamResolver.BulkResolve(ctx, incomingJobs, writer.NewSafeBufferedLogger())
 
 	graph, err := j.BuildGlobalUpstreamGraph(ctx, incomingJobs, jobsWithUpstream)
 	if err != nil {
@@ -1976,7 +1974,8 @@ func (j *JobService) validateSource(ctx context.Context, tenantWithDetails *tena
 
 func (j *JobService) validateResourceURN(ctx context.Context, tnnt tenant.Tenant, urn resource.URN) (string, bool) {
 	activeInDB := true
-	if rsc, err := j.resourceChecker.GetByURN(ctx, tnnt, urn); err != nil {
+	rsc, err := j.resourceChecker.GetByURN(ctx, urn)
+	if err != nil {
 		j.logger.Warn("suppress error is encountered when reading resource from db: %v", err)
 		activeInDB = false
 	} else {

--- a/core/job/service/job_service.go
+++ b/core/job/service/job_service.go
@@ -1451,13 +1451,17 @@ func (j *JobService) Validate(ctx context.Context, request dto.ValidateRequest) 
 		return j.validateJobsForDeletion(ctx, request.Tenant, jobsToValidate), nil
 	}
 
-	if result, err := j.validateCyclic(ctx, request.Tenant, jobsToValidate); err != nil {
+	cyclicResults, err := j.validateCyclic(ctx, request.Tenant, jobsToValidate)
+	if err != nil {
 		return nil, err
-	} else if len(result) > 0 {
-		return result, nil
 	}
 
-	return j.validateJobs(ctx, tenantDetails, jobsToValidate)
+	results := j.validateJobs(ctx, tenantDetails, jobsToValidate)
+	for name, cyclicResult := range cyclicResults {
+		results[name] = append(cyclicResult, results[name]...)
+	}
+
+	return results, nil
 }
 
 func (*JobService) validateRequest(request dto.ValidateRequest) error {
@@ -1613,7 +1617,7 @@ func (*JobService) validateTenantOnEachJob(rootTnnt tenant.Tenant, jobsToValidat
 	return output
 }
 
-func (j *JobService) validateJobs(ctx context.Context, tenantDetails *tenant.WithDetails, jobsToValidate []*job.Job) (map[job.Name][]dto.ValidateResult, error) {
+func (j *JobService) validateJobs(ctx context.Context, tenantDetails *tenant.WithDetails, jobsToValidate []*job.Job) map[job.Name][]dto.ValidateResult {
 	jobsToValidateMap := make(map[job.Name]*job.Job)
 	for _, job := range jobsToValidate {
 		jobsToValidateMap[job.Spec().Name()] = job
@@ -1624,7 +1628,7 @@ func (j *JobService) validateJobs(ctx context.Context, tenantDetails *tenant.Wit
 		output[subjectJob.Spec().Name()] = j.validateOneJob(ctx, tenantDetails, subjectJob, jobsToValidateMap)
 	}
 
-	return output, nil
+	return output
 }
 
 func (j *JobService) validateOneJob(ctx context.Context, tenantDetails *tenant.WithDetails, subjectJob *job.Job, jobsToValidateMap map[job.Name]*job.Job) []dto.ValidateResult {

--- a/core/job/service/job_service_test.go
+++ b/core/job/service/job_service_test.go
@@ -4721,8 +4721,9 @@ func TestJobService(t *testing.T) {
 
 					jobRunInputCompiler := NewJobRunInputCompiler(t)
 					resourceExistenceChecker := NewResourceExistenceChecker(t)
+					pluginService := NewPluginService(t)
 
-					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, nil, upstreamResolver, tenantDetailsGetter, nil, log, nil, compiler.NewEngine(), jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{})
+					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, pluginService, upstreamResolver, tenantDetailsGetter, nil, log, nil, compiler.NewEngine(), jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{})
 
 					jobSpecA, err := job.NewSpecBuilder(1, "jobA", "optimus@goto", jobSchedule, jobWindow, jobTask).Build()
 					assert.NoError(t, err)
@@ -4754,8 +4755,22 @@ func TestJobService(t *testing.T) {
 
 					upstreamResolver.On("CheckStaticResolvable", ctx, sampleTenant, mock.Anything, mock.Anything).Return(nil)
 					upstreamResolver.On("BulkResolve", ctx, mock.Anything, mock.Anything).Return([]*job.WithUpstream{jobAWithUpstream, jobBWithUpstream, jobCWithUpstream}, nil)
+					// used by the (now unconditionally-run) other validation stages, not by the
+					// cyclic check itself - schedule validation is disabled (zero JobValidateConfig)
+					// so the resolved upstream content doesn't matter here.
+					upstreamResolver.On("Resolve", ctx, mock.Anything, mock.Anything).Return(nil, nil)
 
 					tenantDetailsGetter.On("GetDetails", ctx, sampleTenant).Return(detailedTenant, nil)
+
+					// trivial, uniform mocks so the other validation stages (destination, source,
+					// window, plugin, run) run to completion and succeed for all three jobs,
+					// keeping the focus of this test on the cyclic-vs-other-stages merge behavior
+					// rather than exercising every other stage's own logic (already covered by
+					// other tests in this file).
+					pluginService.On("Info", ctx, jobTask.Name().String()).Return(&pluginSpec, nil)
+					pluginService.On("ConstructDestinationURN", ctx, jobTask.Name().String(), mock.Anything).Return(resource.ZeroURN(), nil)
+					pluginService.On("IdentifyUpstreams", ctx, jobTask.Name().String(), mock.Anything, mock.Anything).Return([]resource.URN{}, nil)
+					jobRunInputCompiler.On("Compile", ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(executorInput, nil)
 
 					request := dto.ValidateRequest{
 						Tenant:       sampleTenant,
@@ -4769,31 +4784,44 @@ func TestJobService(t *testing.T) {
 					// FullName-qualified identifiers), rather than the single shared, arbitrarily
 					// ordered path the old tenant-scoped tree-based implementation produced for
 					// every job in the batch regardless of which one was actually being checked.
+					//
+					// A cyclic-dependency failure no longer short-circuits the other validation
+					// stages: each job's result now leads with its cyclic-validation failure,
+					// followed by the (here, trivially successful) destination/source/window/
+					// plugin/run/upstream stage results.
 					fullNameA := "test-proj/jobA"
 					fullNameB := "test-proj/jobB"
 					fullNameC := "test-proj/jobC"
+					otherStageResults := []dto.ValidateResult{
+						{Stage: "destination validation", Messages: []string{"no issue"}, Success: true},
+						{Stage: "source validation", Messages: []string{"no issue"}, Success: true},
+						{Stage: "window validation", Messages: []string{"no issue"}, Success: true},
+						{Stage: "plugin validation", Messages: []string{"no issue"}, Success: true},
+						{Stage: "compile validation for run", Messages: []string{"compiling [bq2bq] with type [task] contains no issue"}, Success: true},
+						{Stage: "upstream validation", Messages: []string{"no issue"}, Success: true},
+					}
 					expectedResult := map[job.Name][]dto.ValidateResult{
-						"jobA": {
+						"jobA": append([]dto.ValidateResult{
 							{
 								Stage:    "cyclic validation",
 								Messages: []string{"cyclic dependency is detected", fullNameA, fullNameB, fullNameC, fullNameA},
 								Success:  false,
 							},
-						},
-						"jobB": {
+						}, otherStageResults...),
+						"jobB": append([]dto.ValidateResult{
 							{
 								Stage:    "cyclic validation",
 								Messages: []string{"cyclic dependency is detected", fullNameB, fullNameC, fullNameA, fullNameB},
 								Success:  false,
 							},
-						},
-						"jobC": {
+						}, otherStageResults...),
+						"jobC": append([]dto.ValidateResult{
 							{
 								Stage:    "cyclic validation",
 								Messages: []string{"cyclic dependency is detected", fullNameC, fullNameA, fullNameB, fullNameC},
 								Success:  false,
 							},
-						},
+						}, otherStageResults...),
 					}
 
 					actualResult, actualError := jobService.Validate(ctx, request)
@@ -4822,8 +4850,9 @@ func TestJobService(t *testing.T) {
 
 					jobRunInputCompiler := NewJobRunInputCompiler(t)
 					resourceExistenceChecker := NewResourceExistenceChecker(t)
+					pluginService := NewPluginService(t)
 
-					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, nil, upstreamResolver, tenantDetailsGetter, nil, log, nil, compiler.NewEngine(), jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{})
+					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, pluginService, upstreamResolver, tenantDetailsGetter, nil, log, nil, compiler.NewEngine(), jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{})
 
 					// jobA is being validated in sampleTenant's namespace. jobB - its upstream -
 					// lives in otherTenant, a different namespace of the SAME project. jobB is not
@@ -4849,6 +4878,14 @@ func TestJobService(t *testing.T) {
 
 					upstreamResolver.On("CheckStaticResolvable", ctx, sampleTenant, mock.Anything, mock.Anything).Return(nil)
 					upstreamResolver.On("BulkResolve", ctx, mock.Anything, mock.Anything).Return([]*job.WithUpstream{jobAWithUpstream}, nil)
+					upstreamResolver.On("Resolve", ctx, mock.Anything, mock.Anything).Return(nil, nil)
+
+					// trivial mocks so the other (now unconditionally-run) validation stages
+					// succeed - this test's focus is on the cyclic-check scope, not those stages.
+					pluginService.On("Info", ctx, jobTask.Name().String()).Return(&pluginSpec, nil)
+					pluginService.On("ConstructDestinationURN", ctx, jobTask.Name().String(), mock.Anything).Return(resource.ZeroURN(), nil)
+					pluginService.On("IdentifyUpstreams", ctx, jobTask.Name().String(), mock.Anything, mock.Anything).Return([]resource.URN{}, nil)
+					jobRunInputCompiler.On("Compile", ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(executorInput, nil)
 
 					request := dto.ValidateRequest{
 						Tenant:   sampleTenant,
@@ -4858,8 +4895,11 @@ func TestJobService(t *testing.T) {
 					actualResult, actualError := jobService.Validate(ctx, request)
 
 					assert.NoError(t, actualError)
-					if assert.Len(t, actualResult["jobA"], 1) {
+					// cyclic failure leads, followed by the (trivially successful) other stages -
+					// a cyclic failure no longer short-circuits the rest of the validation.
+					if assert.Len(t, actualResult["jobA"], 7) {
 						assert.False(t, actualResult["jobA"][0].Success)
+						assert.Equal(t, dto.StageCyclicValidation, actualResult["jobA"][0].Stage)
 						assert.Equal(t, []string{"cyclic dependency is detected", fullNameA.String(), fullNameB.String(), fullNameA.String()}, actualResult["jobA"][0].Messages)
 					}
 				})
@@ -4882,8 +4922,9 @@ func TestJobService(t *testing.T) {
 
 					jobRunInputCompiler := NewJobRunInputCompiler(t)
 					resourceExistenceChecker := NewResourceExistenceChecker(t)
+					pluginService := NewPluginService(t)
 
-					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, nil, upstreamResolver, tenantDetailsGetter, nil, log, nil, compiler.NewEngine(), jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{})
+					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, pluginService, upstreamResolver, tenantDetailsGetter, nil, log, nil, compiler.NewEngine(), jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{})
 
 					otherProjectTenant, err := tenant.NewTenant("other-project-xyz", "some-ns")
 					assert.NoError(t, err)
@@ -4912,6 +4953,12 @@ func TestJobService(t *testing.T) {
 
 					upstreamResolver.On("CheckStaticResolvable", ctx, sampleTenant, mock.Anything, mock.Anything).Return(nil)
 					upstreamResolver.On("BulkResolve", ctx, mock.Anything, mock.Anything).Return([]*job.WithUpstream{jobAWithUpstream}, nil)
+					upstreamResolver.On("Resolve", ctx, mock.Anything, mock.Anything).Return(nil, nil)
+
+					pluginService.On("Info", ctx, jobTask.Name().String()).Return(&pluginSpec, nil)
+					pluginService.On("ConstructDestinationURN", ctx, jobTask.Name().String(), mock.Anything).Return(resource.ZeroURN(), nil)
+					pluginService.On("IdentifyUpstreams", ctx, jobTask.Name().String(), mock.Anything, mock.Anything).Return([]resource.URN{}, nil)
+					jobRunInputCompiler.On("Compile", ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(executorInput, nil)
 
 					request := dto.ValidateRequest{
 						Tenant:   sampleTenant,
@@ -4921,8 +4968,9 @@ func TestJobService(t *testing.T) {
 					actualResult, actualError := jobService.Validate(ctx, request)
 
 					assert.NoError(t, actualError)
-					if assert.Len(t, actualResult["jobA"], 1) {
+					if assert.Len(t, actualResult["jobA"], 7) {
 						assert.False(t, actualResult["jobA"][0].Success)
+						assert.Equal(t, dto.StageCyclicValidation, actualResult["jobA"][0].Stage)
 						assert.Equal(t, []string{"cyclic dependency is detected", fullNameA.String(), fullNameD.String(), fullNameA.String()}, actualResult["jobA"][0].Messages)
 					}
 				})
@@ -4945,8 +4993,9 @@ func TestJobService(t *testing.T) {
 
 					jobRunInputCompiler := NewJobRunInputCompiler(t)
 					resourceExistenceChecker := NewResourceExistenceChecker(t)
+					pluginService := NewPluginService(t)
 
-					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, nil, upstreamResolver, tenantDetailsGetter, nil, log, nil, compiler.NewEngine(), jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{})
+					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, pluginService, upstreamResolver, tenantDetailsGetter, nil, log, nil, compiler.NewEngine(), jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{})
 
 					jobSpecX, err := job.NewSpecBuilder(1, "jobX", "optimus@goto", jobSchedule, jobWindow, jobTask).Build()
 					assert.NoError(t, err)
@@ -4976,6 +5025,12 @@ func TestJobService(t *testing.T) {
 
 					upstreamResolver.On("CheckStaticResolvable", ctx, sampleTenant, mock.Anything, mock.Anything).Return(nil)
 					upstreamResolver.On("BulkResolve", ctx, mock.Anything, mock.Anything).Return([]*job.WithUpstream{jobXWithUpstream, jobYWithUpstream}, nil)
+					upstreamResolver.On("Resolve", ctx, mock.Anything, mock.Anything).Return(nil, nil)
+
+					pluginService.On("Info", ctx, jobTask.Name().String()).Return(&pluginSpec, nil)
+					pluginService.On("ConstructDestinationURN", ctx, jobTask.Name().String(), mock.Anything).Return(resource.ZeroURN(), nil)
+					pluginService.On("IdentifyUpstreams", ctx, jobTask.Name().String(), mock.Anything, mock.Anything).Return([]resource.URN{}, nil)
+					jobRunInputCompiler.On("Compile", ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(executorInput, nil)
 
 					request := dto.ValidateRequest{
 						Tenant:   sampleTenant,
@@ -4988,12 +5043,14 @@ func TestJobService(t *testing.T) {
 					actualResult, actualError := jobService.Validate(ctx, request)
 
 					assert.NoError(t, actualError)
-					if assert.Len(t, actualResult["jobX"], 1) {
+					if assert.Len(t, actualResult["jobX"], 7) {
 						assert.False(t, actualResult["jobX"][0].Success)
+						assert.Equal(t, dto.StageCyclicValidation, actualResult["jobX"][0].Stage)
 						assert.Equal(t, []string{"cyclic dependency is detected", fullNameX.String(), fullNameY.String(), fullNameX.String()}, actualResult["jobX"][0].Messages)
 					}
-					if assert.Len(t, actualResult["jobY"], 1) {
+					if assert.Len(t, actualResult["jobY"], 7) {
 						assert.False(t, actualResult["jobY"][0].Success)
+						assert.Equal(t, dto.StageCyclicValidation, actualResult["jobY"][0].Stage)
 						assert.Equal(t, []string{"cyclic dependency is detected", fullNameY.String(), fullNameX.String(), fullNameY.String()}, actualResult["jobY"][0].Messages)
 					}
 				})
@@ -5016,8 +5073,9 @@ func TestJobService(t *testing.T) {
 
 					jobRunInputCompiler := NewJobRunInputCompiler(t)
 					resourceExistenceChecker := NewResourceExistenceChecker(t)
+					pluginService := NewPluginService(t)
 
-					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, nil, upstreamResolver, tenantDetailsGetter, nil, log, nil, compiler.NewEngine(), jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{})
+					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, pluginService, upstreamResolver, tenantDetailsGetter, nil, log, nil, compiler.NewEngine(), jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{})
 
 					// jobA is new/incoming and statically depends on jobC, which already exists.
 					jobSpecA, err := job.NewSpecBuilder(1, "jobA", "optimus@goto", jobSchedule, jobWindow, jobTask).Build()
@@ -5042,6 +5100,12 @@ func TestJobService(t *testing.T) {
 
 					upstreamResolver.On("CheckStaticResolvable", ctx, sampleTenant, mock.Anything, mock.Anything).Return(nil)
 					upstreamResolver.On("BulkResolve", ctx, mock.Anything, mock.Anything).Return([]*job.WithUpstream{jobAWithUpstream}, nil)
+					upstreamResolver.On("Resolve", ctx, mock.Anything, mock.Anything).Return(nil, nil)
+
+					pluginService.On("Info", ctx, jobTask.Name().String()).Return(&pluginSpec, nil)
+					pluginService.On("ConstructDestinationURN", ctx, jobTask.Name().String(), mock.Anything).Return(resource.ZeroURN(), nil)
+					pluginService.On("IdentifyUpstreams", ctx, jobTask.Name().String(), mock.Anything, mock.Anything).Return([]resource.URN{}, nil)
+					jobRunInputCompiler.On("Compile", ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(executorInput, nil)
 
 					request := dto.ValidateRequest{
 						Tenant:   sampleTenant,
@@ -5054,8 +5118,9 @@ func TestJobService(t *testing.T) {
 					actualResult, actualError := jobService.Validate(ctx, request)
 
 					assert.NoError(t, actualError)
-					if assert.Len(t, actualResult["jobA"], 1) {
+					if assert.Len(t, actualResult["jobA"], 7) {
 						assert.False(t, actualResult["jobA"][0].Success)
+						assert.Equal(t, dto.StageCyclicValidation, actualResult["jobA"][0].Stage)
 						assert.Equal(t, []string{"cyclic dependency is detected", fullNameA.String(), fullNameC.String(), fullNameA.String()}, actualResult["jobA"][0].Messages)
 					}
 				})

--- a/core/job/service/job_service_test.go
+++ b/core/job/service/job_service_test.go
@@ -5186,11 +5186,11 @@ func TestJobService(t *testing.T) {
 
 					jobRunInputCompiler.On("Compile", ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(executorInput, nil)
 
-					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNA).Return(nil, errors.New("not found"))
+					resourceExistenceChecker.On("GetByURN", ctx, resourceURNA).Return(nil, errors.New("not found"))
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNA).Return(true, nil)
 
 					// resourceURNC (the only upstream source) exists in neither db nor store.
-					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNC).Return(nil, errors.New("not found"))
+					resourceExistenceChecker.On("GetByURN", ctx, resourceURNC).Return(nil, errors.New("not found"))
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNC).Return(false, nil)
 
 					upstreamResolver.On("CheckStaticResolvable", ctx, sampleTenant, mock.Anything, mock.Anything).Return(nil)
@@ -5268,7 +5268,7 @@ func TestJobService(t *testing.T) {
 
 					jobRunInputCompiler.On("Compile", ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(executorInput, nil)
 
-					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNA).Return(nil, errors.New("unexpected get by urn error"))
+					resourceExistenceChecker.On("GetByURN", ctx, resourceURNA).Return(nil, errors.New("unexpected get by urn error"))
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNA).Return(false, errors.New("unexpected exist in store error"))
 
 					rsc, err := resource.NewResource("resource_1", "table", resource.Bigquery, sampleTenant, &resource.Metadata{Description: "table for test"}, map[string]any{"version": 1})
@@ -5281,13 +5281,13 @@ func TestJobService(t *testing.T) {
 					// resolved-upstream graph fetch happens.
 					upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{}, nil)
 
-					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNB).Return(deletedRsc, nil)
+					resourceExistenceChecker.On("GetByURN", ctx, resourceURNB).Return(deletedRsc, nil)
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNB).Return(false, nil)
 
-					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNC).Return(rsc, nil)
+					resourceExistenceChecker.On("GetByURN", ctx, resourceURNC).Return(rsc, nil)
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNC).Return(false, nil)
 
-					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURND).Return(rsc, nil)
+					resourceExistenceChecker.On("GetByURN", ctx, resourceURND).Return(rsc, nil)
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURND).Return(true, nil)
 
 					upstreamResolver.On("CheckStaticResolvable", ctx, sampleTenant, mock.Anything, mock.Anything).Return(nil)
@@ -5449,19 +5449,19 @@ func TestJobService(t *testing.T) {
 					rsc, err := resource.NewResource("resource_1", "table", resource.Bigquery, sampleTenant, &resource.Metadata{Description: "table for test"}, map[string]any{"version": 1})
 					assert.NoError(t, err)
 
-					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNA).Return(rsc, nil)
+					resourceExistenceChecker.On("GetByURN", ctx, resourceURNA).Return(rsc, nil)
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNA).Return(true, nil)
 
-					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNB).Return(rsc, nil)
+					resourceExistenceChecker.On("GetByURN", ctx, resourceURNB).Return(rsc, nil)
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNB).Return(true, nil)
 
-					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNC).Return(rsc, nil)
+					resourceExistenceChecker.On("GetByURN", ctx, resourceURNC).Return(rsc, nil)
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNC).Return(true, nil)
 
 					upstreamResolver.On("CheckStaticResolvable", ctx, sampleTenant, mock.Anything, mock.Anything).Return(nil)
 					upstreamResolver.On("BulkResolve", ctx, mock.Anything, mock.Anything).Return([]*job.WithUpstream{jobAWithUpstream, jobBWithUpstream}, nil)
 
-					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURND).Return(rsc, nil)
+					resourceExistenceChecker.On("GetByURN", ctx, resourceURND).Return(rsc, nil)
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURND).Return(true, nil)
 
 					upstreamResolver.On("Resolve", ctx, mock.Anything, mock.Anything).Return(nil, nil)
@@ -5622,13 +5622,13 @@ func TestJobService(t *testing.T) {
 					rsc, err := resource.NewResource("resource_1", "table", resource.Bigquery, sampleTenant, &resource.Metadata{Description: "table for test"}, map[string]any{"version": 1})
 					assert.NoError(t, err)
 
-					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNA).Return(rsc, nil)
+					resourceExistenceChecker.On("GetByURN", ctx, resourceURNA).Return(rsc, nil)
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNA).Return(true, nil)
 
-					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNB).Return(rsc, nil)
+					resourceExistenceChecker.On("GetByURN", ctx, resourceURNB).Return(rsc, nil)
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNB).Return(true, nil)
 
-					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNC).Return(rsc, nil)
+					resourceExistenceChecker.On("GetByURN", ctx, resourceURNC).Return(rsc, nil)
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNC).Return(true, nil)
 
 					upstreamResolver.On("CheckStaticResolvable", ctx, sampleTenant, mock.Anything, mock.Anything).Return(nil)
@@ -5754,13 +5754,13 @@ func TestJobService(t *testing.T) {
 					rsc, err := resource.NewResource("resource_1", "table", resource.Bigquery, sampleTenant, &resource.Metadata{Description: "table for test"}, map[string]any{"version": 1})
 					assert.NoError(t, err)
 
-					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNA).Return(rsc, nil)
+					resourceExistenceChecker.On("GetByURN", ctx, resourceURNA).Return(rsc, nil)
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNA).Return(true, nil)
 
-					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNB).Return(rsc, nil)
+					resourceExistenceChecker.On("GetByURN", ctx, resourceURNB).Return(rsc, nil)
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNB).Return(true, nil)
 
-					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNC).Return(rsc, nil)
+					resourceExistenceChecker.On("GetByURN", ctx, resourceURNC).Return(rsc, nil)
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNC).Return(true, nil)
 
 					upstreamResolver.On("CheckStaticResolvable", ctx, sampleTenant, mock.Anything, mock.Anything).Return(nil)
@@ -5890,13 +5890,13 @@ func TestJobService(t *testing.T) {
 					rsc, err := resource.NewResource("resource_1", "table", resource.Bigquery, sampleTenant, &resource.Metadata{Description: "table for test"}, map[string]any{"version": 1})
 					assert.NoError(t, err)
 
-					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNA).Return(rsc, nil)
+					resourceExistenceChecker.On("GetByURN", ctx, resourceURNA).Return(rsc, nil)
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNA).Return(true, nil)
 
-					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNB).Return(rsc, nil)
+					resourceExistenceChecker.On("GetByURN", ctx, resourceURNB).Return(rsc, nil)
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNB).Return(true, nil)
 
-					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNC).Return(rsc, nil)
+					resourceExistenceChecker.On("GetByURN", ctx, resourceURNC).Return(rsc, nil)
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNC).Return(true, nil)
 
 					upstreamResolver.On("CheckStaticResolvable", ctx, sampleTenant, mock.Anything, mock.Anything).Return(nil)
@@ -7477,8 +7477,8 @@ func (_m *ResourceExistenceChecker) ExistInStore(ctx context.Context, tnnt tenan
 }
 
 // GetByURN provides a mock function with given fields: ctx, tnnt, urn
-func (_m *ResourceExistenceChecker) GetByURN(ctx context.Context, tnnt tenant.Tenant, urn resource.URN) (*resource.Resource, error) {
-	ret := _m.Called(ctx, tnnt, urn)
+func (_m *ResourceExistenceChecker) GetByURN(ctx context.Context, urn resource.URN) (*resource.Resource, error) {
+	ret := _m.Called(ctx, urn)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetByURN")
@@ -7486,19 +7486,19 @@ func (_m *ResourceExistenceChecker) GetByURN(ctx context.Context, tnnt tenant.Te
 
 	var r0 *resource.Resource
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, tenant.Tenant, resource.URN) (*resource.Resource, error)); ok {
-		return rf(ctx, tnnt, urn)
+	if rf, ok := ret.Get(0).(func(context.Context, resource.URN) (*resource.Resource, error)); ok {
+		return rf(ctx, urn)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, tenant.Tenant, resource.URN) *resource.Resource); ok {
-		r0 = rf(ctx, tnnt, urn)
+	if rf, ok := ret.Get(0).(func(context.Context, resource.URN) *resource.Resource); ok {
+		r0 = rf(ctx, urn)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*resource.Resource)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, tenant.Tenant, resource.URN) error); ok {
-		r1 = rf(ctx, tnnt, urn)
+	if rf, ok := ret.Get(1).(func(context.Context, resource.URN) error); ok {
+		r1 = rf(ctx, urn)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/job/service/job_service_test.go
+++ b/core/job/service/job_service_test.go
@@ -4710,6 +4710,9 @@ func TestJobService(t *testing.T) {
 					jobRepo := new(JobRepository)
 					defer jobRepo.AssertExpectations(t)
 
+					upstreamRepo := new(UpstreamRepository)
+					defer upstreamRepo.AssertExpectations(t)
+
 					upstreamResolver := new(UpstreamResolver)
 					defer upstreamResolver.AssertExpectations(t)
 
@@ -4719,7 +4722,7 @@ func TestJobService(t *testing.T) {
 					jobRunInputCompiler := NewJobRunInputCompiler(t)
 					resourceExistenceChecker := NewResourceExistenceChecker(t)
 
-					jobService := service.NewJobService(jobRepo, nil, downstreamRepo, nil, upstreamResolver, tenantDetailsGetter, nil, log, nil, compiler.NewEngine(), jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{})
+					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, nil, upstreamResolver, tenantDetailsGetter, nil, log, nil, compiler.NewEngine(), jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{})
 
 					jobSpecA, err := job.NewSpecBuilder(1, "jobA", "optimus@goto", jobSchedule, jobWindow, jobTask).Build()
 					assert.NoError(t, err)
@@ -4739,11 +4742,15 @@ func TestJobService(t *testing.T) {
 					upstreamA := job.NewUpstreamResolved(jobSpecA.Name(), "", resourceURNA, sampleTenant, "static", taskName, false)
 					jobCWithUpstream := job.NewWithUpstream(jobC, []*job.Upstream{upstreamA})
 
-					jobRepo.On("GetAllByTenant", ctx, sampleTenant).Return([]*job.Job{jobA, jobB, jobC}, nil)
-
 					jobRepo.On("GetByJobName", ctx, sampleTenant.ProjectName(), job.Name("jobA")).Return(jobA, nil)
 					jobRepo.On("GetByJobName", ctx, sampleTenant.ProjectName(), job.Name("jobB")).Return(jobB, nil)
 					jobRepo.On("GetByJobName", ctx, sampleTenant.ProjectName(), job.Name("jobC")).Return(jobC, nil)
+
+					upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{}, nil)
+
+					downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNA).Return(nil, nil)
+					downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNB).Return(nil, nil)
+					downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNC).Return(nil, nil)
 
 					upstreamResolver.On("CheckStaticResolvable", ctx, sampleTenant, mock.Anything, mock.Anything).Return(nil)
 					upstreamResolver.On("BulkResolve", ctx, mock.Anything, mock.Anything).Return([]*job.WithUpstream{jobAWithUpstream, jobBWithUpstream, jobCWithUpstream}, nil)
@@ -4757,25 +4764,33 @@ func TestJobService(t *testing.T) {
 						DeletionMode: false,
 					}
 
+					// jobA depends on jobB, jobB depends on jobC, jobC depends on jobA - the cycle
+					// is now reported starting from whichever job is being validated (global,
+					// FullName-qualified identifiers), rather than the single shared, arbitrarily
+					// ordered path the old tenant-scoped tree-based implementation produced for
+					// every job in the batch regardless of which one was actually being checked.
+					fullNameA := "test-proj/jobA"
+					fullNameB := "test-proj/jobB"
+					fullNameC := "test-proj/jobC"
 					expectedResult := map[job.Name][]dto.ValidateResult{
 						"jobA": {
 							{
 								Stage:    "cyclic validation",
-								Messages: []string{"cyclic dependency is detected", "jobA", "jobC", "jobB", "jobA"},
+								Messages: []string{"cyclic dependency is detected", fullNameA, fullNameB, fullNameC, fullNameA},
 								Success:  false,
 							},
 						},
 						"jobB": {
 							{
 								Stage:    "cyclic validation",
-								Messages: []string{"cyclic dependency is detected", "jobA", "jobC", "jobB", "jobA"},
+								Messages: []string{"cyclic dependency is detected", fullNameB, fullNameC, fullNameA, fullNameB},
 								Success:  false,
 							},
 						},
 						"jobC": {
 							{
 								Stage:    "cyclic validation",
-								Messages: []string{"cyclic dependency is detected", "jobA", "jobC", "jobB", "jobA"},
+								Messages: []string{"cyclic dependency is detected", fullNameC, fullNameA, fullNameB, fullNameC},
 								Success:  false,
 							},
 						},
@@ -4788,6 +4803,262 @@ func TestJobService(t *testing.T) {
 					assert.EqualValues(t, expectedResult["jobC"], actualResult["jobC"])
 					assert.NoError(t, actualError)
 				})
+
+				t.Run("detects a cycle spanning namespaces within the same project (previously invisible to a tenant-scoped check)", func(t *testing.T) {
+					tenantDetailsGetter := new(TenantDetailsGetter)
+					defer tenantDetailsGetter.AssertExpectations(t)
+
+					jobRepo := new(JobRepository)
+					defer jobRepo.AssertExpectations(t)
+
+					upstreamRepo := new(UpstreamRepository)
+					defer upstreamRepo.AssertExpectations(t)
+
+					upstreamResolver := new(UpstreamResolver)
+					defer upstreamResolver.AssertExpectations(t)
+
+					downstreamRepo := new(DownstreamRepository)
+					defer downstreamRepo.AssertExpectations(t)
+
+					jobRunInputCompiler := NewJobRunInputCompiler(t)
+					resourceExistenceChecker := NewResourceExistenceChecker(t)
+
+					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, nil, upstreamResolver, tenantDetailsGetter, nil, log, nil, compiler.NewEngine(), jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{})
+
+					// jobA is being validated in sampleTenant's namespace. jobB - its upstream -
+					// lives in otherTenant, a different namespace of the SAME project. jobB is not
+					// part of this request at all; its persisted edge back to jobA comes purely
+					// from the global upstream graph.
+					jobSpecA, err := job.NewSpecBuilder(1, "jobA", "optimus@goto", jobSchedule, jobWindow, jobTask).Build()
+					assert.NoError(t, err)
+
+					jobA := job.NewJob(sampleTenant, jobSpecA, resourceURNA, []resource.URN{resourceURNB}, false)
+					upstreamB := job.NewUpstreamResolved("jobB", "", resourceURNB, otherTenant, "static", taskName, false)
+					jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{upstreamB})
+
+					jobRepo.On("GetByJobName", ctx, sampleTenant.ProjectName(), job.Name("jobA")).Return(jobA, nil)
+
+					fullNameA := job.FullNameFrom(sampleTenant.ProjectName(), "jobA")
+					fullNameB := job.FullNameFrom(otherTenant.ProjectName(), "jobB")
+					upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{
+						fullNameB: {fullNameA},
+					}, nil)
+					downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNA).Return(nil, nil)
+
+					tenantDetailsGetter.On("GetDetails", ctx, sampleTenant).Return(detailedTenant, nil)
+
+					upstreamResolver.On("CheckStaticResolvable", ctx, sampleTenant, mock.Anything, mock.Anything).Return(nil)
+					upstreamResolver.On("BulkResolve", ctx, mock.Anything, mock.Anything).Return([]*job.WithUpstream{jobAWithUpstream}, nil)
+
+					request := dto.ValidateRequest{
+						Tenant:   sampleTenant,
+						JobNames: []string{"jobA"},
+					}
+
+					actualResult, actualError := jobService.Validate(ctx, request)
+
+					assert.NoError(t, actualError)
+					if assert.Len(t, actualResult["jobA"], 1) {
+						assert.False(t, actualResult["jobA"][0].Success)
+						assert.Equal(t, []string{"cyclic dependency is detected", fullNameA.String(), fullNameB.String(), fullNameA.String()}, actualResult["jobA"][0].Messages)
+					}
+				})
+
+				t.Run("detects a cycle spanning projects", func(t *testing.T) {
+					tenantDetailsGetter := new(TenantDetailsGetter)
+					defer tenantDetailsGetter.AssertExpectations(t)
+
+					jobRepo := new(JobRepository)
+					defer jobRepo.AssertExpectations(t)
+
+					upstreamRepo := new(UpstreamRepository)
+					defer upstreamRepo.AssertExpectations(t)
+
+					upstreamResolver := new(UpstreamResolver)
+					defer upstreamResolver.AssertExpectations(t)
+
+					downstreamRepo := new(DownstreamRepository)
+					defer downstreamRepo.AssertExpectations(t)
+
+					jobRunInputCompiler := NewJobRunInputCompiler(t)
+					resourceExistenceChecker := NewResourceExistenceChecker(t)
+
+					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, nil, upstreamResolver, tenantDetailsGetter, nil, log, nil, compiler.NewEngine(), jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{})
+
+					otherProjectTenant, err := tenant.NewTenant("other-project-xyz", "some-ns")
+					assert.NoError(t, err)
+
+					// jobA is being validated in sampleTenant's project. jobD - its upstream -
+					// lives in an entirely different project. jobD is not part of this request;
+					// its persisted edge back to jobA comes purely from the global upstream graph,
+					// which (unlike the old per-tenant lookup) is not scoped to any single project.
+					jobSpecA, err := job.NewSpecBuilder(1, "jobA", "optimus@goto", jobSchedule, jobWindow, jobTask).Build()
+					assert.NoError(t, err)
+
+					jobA := job.NewJob(sampleTenant, jobSpecA, resourceURNA, []resource.URN{resourceURND}, false)
+					upstreamD := job.NewUpstreamResolved("jobD", "", resourceURND, otherProjectTenant, "static", taskName, false)
+					jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{upstreamD})
+
+					jobRepo.On("GetByJobName", ctx, sampleTenant.ProjectName(), job.Name("jobA")).Return(jobA, nil)
+
+					fullNameA := job.FullNameFrom(sampleTenant.ProjectName(), "jobA")
+					fullNameD := job.FullNameFrom(otherProjectTenant.ProjectName(), "jobD")
+					upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{
+						fullNameD: {fullNameA},
+					}, nil)
+					downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNA).Return(nil, nil)
+
+					tenantDetailsGetter.On("GetDetails", ctx, sampleTenant).Return(detailedTenant, nil)
+
+					upstreamResolver.On("CheckStaticResolvable", ctx, sampleTenant, mock.Anything, mock.Anything).Return(nil)
+					upstreamResolver.On("BulkResolve", ctx, mock.Anything, mock.Anything).Return([]*job.WithUpstream{jobAWithUpstream}, nil)
+
+					request := dto.ValidateRequest{
+						Tenant:   sampleTenant,
+						JobNames: []string{"jobA"},
+					}
+
+					actualResult, actualError := jobService.Validate(ctx, request)
+
+					assert.NoError(t, actualError)
+					if assert.Len(t, actualResult["jobA"], 1) {
+						assert.False(t, actualResult["jobA"][0].Success)
+						assert.Equal(t, []string{"cyclic dependency is detected", fullNameA.String(), fullNameD.String(), fullNameA.String()}, actualResult["jobA"][0].Messages)
+					}
+				})
+
+				t.Run("detects a cycle between two jobs validated in the same request via inferred upstream matching, before either is persisted", func(t *testing.T) {
+					tenantDetailsGetter := new(TenantDetailsGetter)
+					defer tenantDetailsGetter.AssertExpectations(t)
+
+					jobRepo := new(JobRepository)
+					defer jobRepo.AssertExpectations(t)
+
+					upstreamRepo := new(UpstreamRepository)
+					defer upstreamRepo.AssertExpectations(t)
+
+					upstreamResolver := new(UpstreamResolver)
+					defer upstreamResolver.AssertExpectations(t)
+
+					downstreamRepo := new(DownstreamRepository)
+					defer downstreamRepo.AssertExpectations(t)
+
+					jobRunInputCompiler := NewJobRunInputCompiler(t)
+					resourceExistenceChecker := NewResourceExistenceChecker(t)
+
+					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, nil, upstreamResolver, tenantDetailsGetter, nil, log, nil, compiler.NewEngine(), jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{})
+
+					jobSpecX, err := job.NewSpecBuilder(1, "jobX", "optimus@goto", jobSchedule, jobWindow, jobTask).Build()
+					assert.NoError(t, err)
+					jobSpecY, err := job.NewSpecBuilder(1, "jobY", "optimus@goto", jobSchedule, jobWindow, jobTask).Build()
+					assert.NoError(t, err)
+
+					jobX := job.NewJob(sampleTenant, jobSpecX, resourceURNA, []resource.URN{resourceURNB}, false)
+					jobY := job.NewJob(sampleTenant, jobSpecY, resourceURNB, []resource.URN{resourceURNA}, false)
+
+					// neither job's inferred upstream has ever resolved/persisted - only a
+					// destination URN is known for each. The DB has no row for either job yet, so
+					// the only way to catch this cycle is to match each one's unresolved
+					// destination against the OTHER incoming job's destination in-memory.
+					unresolvedX := job.NewUpstreamUnresolvedInferred(resourceURNB)
+					unresolvedY := job.NewUpstreamUnresolvedInferred(resourceURNA)
+					jobXWithUpstream := job.NewWithUpstream(jobX, []*job.Upstream{unresolvedX})
+					jobYWithUpstream := job.NewWithUpstream(jobY, []*job.Upstream{unresolvedY})
+
+					jobRepo.On("GetByJobName", ctx, sampleTenant.ProjectName(), job.Name("jobX")).Return(jobX, nil)
+					jobRepo.On("GetByJobName", ctx, sampleTenant.ProjectName(), job.Name("jobY")).Return(jobY, nil)
+
+					upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{}, nil)
+					downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNA).Return(nil, nil)
+					downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNB).Return(nil, nil)
+
+					tenantDetailsGetter.On("GetDetails", ctx, sampleTenant).Return(detailedTenant, nil)
+
+					upstreamResolver.On("CheckStaticResolvable", ctx, sampleTenant, mock.Anything, mock.Anything).Return(nil)
+					upstreamResolver.On("BulkResolve", ctx, mock.Anything, mock.Anything).Return([]*job.WithUpstream{jobXWithUpstream, jobYWithUpstream}, nil)
+
+					request := dto.ValidateRequest{
+						Tenant:   sampleTenant,
+						JobNames: []string{"jobX", "jobY"},
+					}
+
+					fullNameX := job.FullNameFrom(sampleTenant.ProjectName(), "jobX")
+					fullNameY := job.FullNameFrom(sampleTenant.ProjectName(), "jobY")
+
+					actualResult, actualError := jobService.Validate(ctx, request)
+
+					assert.NoError(t, actualError)
+					if assert.Len(t, actualResult["jobX"], 1) {
+						assert.False(t, actualResult["jobX"][0].Success)
+						assert.Equal(t, []string{"cyclic dependency is detected", fullNameX.String(), fullNameY.String(), fullNameX.String()}, actualResult["jobX"][0].Messages)
+					}
+					if assert.Len(t, actualResult["jobY"], 1) {
+						assert.False(t, actualResult["jobY"][0].Success)
+						assert.Equal(t, []string{"cyclic dependency is detected", fullNameY.String(), fullNameX.String(), fullNameY.String()}, actualResult["jobY"][0].Messages)
+					}
+				})
+
+				t.Run("detects a cycle created by reverse impact: an existing job's SQL already references the incoming job's destination", func(t *testing.T) {
+					tenantDetailsGetter := new(TenantDetailsGetter)
+					defer tenantDetailsGetter.AssertExpectations(t)
+
+					jobRepo := new(JobRepository)
+					defer jobRepo.AssertExpectations(t)
+
+					upstreamRepo := new(UpstreamRepository)
+					defer upstreamRepo.AssertExpectations(t)
+
+					upstreamResolver := new(UpstreamResolver)
+					defer upstreamResolver.AssertExpectations(t)
+
+					downstreamRepo := new(DownstreamRepository)
+					defer downstreamRepo.AssertExpectations(t)
+
+					jobRunInputCompiler := NewJobRunInputCompiler(t)
+					resourceExistenceChecker := NewResourceExistenceChecker(t)
+
+					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, nil, upstreamResolver, tenantDetailsGetter, nil, log, nil, compiler.NewEngine(), jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{})
+
+					// jobA is new/incoming and statically depends on jobC, which already exists.
+					jobSpecA, err := job.NewSpecBuilder(1, "jobA", "optimus@goto", jobSchedule, jobWindow, jobTask).Build()
+					assert.NoError(t, err)
+
+					jobA := job.NewJob(sampleTenant, jobSpecA, resourceURNA, nil, false)
+					upstreamC := job.NewUpstreamResolved("jobC", "", resourceURNC, sampleTenant, "static", taskName, false)
+					jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{upstreamC})
+
+					jobRepo.On("GetByJobName", ctx, sampleTenant.ProjectName(), job.Name("jobA")).Return(jobA, nil)
+
+					// jobC is not part of this request at all. Its SQL already references jobA's
+					// destination - discovered via the reverse-impact lookup, not via any
+					// persisted job_upstream row, since jobA did not exist the last time jobC's
+					// upstreams were resolved and saved.
+					jobCDownstream := job.NewDownstream("jobC", sampleTenant.ProjectName(), sampleTenant.NamespaceName(), taskName)
+					downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNA).Return([]*job.Downstream{jobCDownstream}, nil)
+
+					upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{}, nil)
+
+					tenantDetailsGetter.On("GetDetails", ctx, sampleTenant).Return(detailedTenant, nil)
+
+					upstreamResolver.On("CheckStaticResolvable", ctx, sampleTenant, mock.Anything, mock.Anything).Return(nil)
+					upstreamResolver.On("BulkResolve", ctx, mock.Anything, mock.Anything).Return([]*job.WithUpstream{jobAWithUpstream}, nil)
+
+					request := dto.ValidateRequest{
+						Tenant:   sampleTenant,
+						JobNames: []string{"jobA"},
+					}
+
+					fullNameA := job.FullNameFrom(sampleTenant.ProjectName(), "jobA")
+					fullNameC := job.FullNameFrom(sampleTenant.ProjectName(), "jobC")
+
+					actualResult, actualError := jobService.Validate(ctx, request)
+
+					assert.NoError(t, actualError)
+					if assert.Len(t, actualResult["jobA"], 1) {
+						assert.False(t, actualResult["jobA"][0].Success)
+						assert.Equal(t, []string{"cyclic dependency is detected", fullNameA.String(), fullNameC.String(), fullNameA.String()}, actualResult["jobA"][0].Messages)
+					}
+				})
 			})
 
 			t.Run("validate jobs", func(t *testing.T) {
@@ -4797,6 +5068,9 @@ func TestJobService(t *testing.T) {
 
 					jobRepo := new(JobRepository)
 					defer jobRepo.AssertExpectations(t)
+
+					upstreamRepo := new(UpstreamRepository)
+					defer upstreamRepo.AssertExpectations(t)
 
 					upstreamResolver := new(UpstreamResolver)
 					defer upstreamResolver.AssertExpectations(t)
@@ -4809,7 +5083,7 @@ func TestJobService(t *testing.T) {
 					jobRunInputCompiler := NewJobRunInputCompiler(t)
 					resourceExistenceChecker := NewResourceExistenceChecker(t)
 
-					jobService := service.NewJobService(jobRepo, nil, downstreamRepo, pluginService, upstreamResolver, tenantDetailsGetter, nil, log, nil, compiler.NewEngine(), jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{})
+					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, pluginService, upstreamResolver, tenantDetailsGetter, nil, log, nil, compiler.NewEngine(), jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{})
 
 					jobSpecA, err := job.NewSpecBuilder(1, "jobA", "optimus@goto", jobSchedule, jobWindow, jobTask).WithAsset(jobAsset).Build()
 					assert.NoError(t, err)
@@ -4825,7 +5099,9 @@ func TestJobService(t *testing.T) {
 
 					jobRepo.On("GetByJobName", ctx, sampleTenant.ProjectName(), job.Name("jobA")).Return(jobA, nil)
 					jobRepo.On("GetByJobName", ctx, sampleTenant.ProjectName(), job.Name("jobB")).Return(jobB, nil)
-					jobRepo.On("GetAllByTenant", ctx, sampleTenant).Return([]*job.Job{jobA, jobB}, nil)
+					upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{}, nil)
+					downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNA).Return(nil, nil)
+					downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNB).Return(nil, nil)
 
 					tenantDetailsGetter.On("GetDetails", ctx, sampleTenant).Return(detailedTenant, nil)
 
@@ -4865,12 +5141,91 @@ func TestJobService(t *testing.T) {
 					assert.NoError(t, actualError)
 				})
 
+				t.Run("returns unsuccessful source validation when an upstream resource is genuinely missing from both db and store", func(t *testing.T) {
+					// this specifically guards the revert of the validateResourceURN workaround:
+					// a resource missing from both db and store must fail validation now that the
+					// query parser no longer misidentifies struct/record field access as upstream
+					// tables (the workaround existed only to suppress that false-positive noise).
+					tenantDetailsGetter := new(TenantDetailsGetter)
+					defer tenantDetailsGetter.AssertExpectations(t)
+
+					jobRepo := new(JobRepository)
+					defer jobRepo.AssertExpectations(t)
+
+					upstreamRepo := new(UpstreamRepository)
+					defer upstreamRepo.AssertExpectations(t)
+
+					upstreamResolver := new(UpstreamResolver)
+					defer upstreamResolver.AssertExpectations(t)
+
+					downstreamRepo := new(DownstreamRepository)
+					defer downstreamRepo.AssertExpectations(t)
+
+					pluginService := NewPluginService(t)
+
+					jobRunInputCompiler := NewJobRunInputCompiler(t)
+					resourceExistenceChecker := NewResourceExistenceChecker(t)
+
+					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo, pluginService, upstreamResolver, tenantDetailsGetter, nil, log, nil, compiler.NewEngine(), jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{})
+
+					jobSpecA, err := job.NewSpecBuilder(1, "jobA", "optimus@goto", jobSchedule, jobWindow, jobTask).WithAsset(jobAsset).Build()
+					assert.NoError(t, err)
+
+					jobA := job.NewJob(sampleTenant, jobSpecA, resourceURNA, []resource.URN{resourceURNC}, false)
+					jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{})
+
+					jobRepo.On("GetByJobName", ctx, sampleTenant.ProjectName(), job.Name("jobA")).Return(jobA, nil)
+					upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{}, nil)
+					downstreamRepo.On("GetDownstreamByDestination", ctx, resourceURNA).Return(nil, nil)
+
+					tenantDetailsGetter.On("GetDetails", ctx, sampleTenant).Return(detailedTenant, nil)
+
+					pluginService.On("Info", ctx, jobTask.Name().String()).Return(&pluginSpec, nil)
+					pluginService.On("ConstructDestinationURN", ctx, jobTask.Name().String(), mock.Anything).Return(resourceURNA, nil)
+					pluginService.On("IdentifyUpstreams", ctx, jobTask.Name().String(), mock.Anything, mock.Anything).Return([]resource.URN{resourceURNC}, nil)
+
+					jobRunInputCompiler.On("Compile", ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(executorInput, nil)
+
+					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNA).Return(nil, errors.New("not found"))
+					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNA).Return(true, nil)
+
+					// resourceURNC (the only upstream source) exists in neither db nor store.
+					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNC).Return(nil, errors.New("not found"))
+					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNC).Return(false, nil)
+
+					upstreamResolver.On("CheckStaticResolvable", ctx, sampleTenant, mock.Anything, mock.Anything).Return(nil)
+					upstreamResolver.On("BulkResolve", ctx, mock.Anything, mock.Anything).Return([]*job.WithUpstream{jobAWithUpstream}, nil)
+					upstreamResolver.On("Resolve", ctx, mock.Anything, mock.Anything).Return(nil, nil)
+
+					request := dto.ValidateRequest{
+						Tenant:   sampleTenant,
+						JobNames: []string{"jobA"},
+					}
+
+					actualResult, actualError := jobService.Validate(ctx, request)
+
+					assert.NoError(t, actualError)
+					var sourceResult *dto.ValidateResult
+					for i := range actualResult["jobA"] {
+						if actualResult["jobA"][i].Stage == dto.StageSourceValidation {
+							sourceResult = &actualResult["jobA"][i]
+						}
+					}
+					if assert.NotNil(t, sourceResult) {
+						assert.False(t, sourceResult.Success)
+						assert.Contains(t, sourceResult.Messages, "bigquery://project:dataset.tableC: resource does not exist in both db and store")
+					}
+				})
+
 				t.Run("returns unsuccessful result and nil if one or more validations failed", func(t *testing.T) {
 					tenantDetailsGetter := new(TenantDetailsGetter)
 					defer tenantDetailsGetter.AssertExpectations(t)
 
 					jobRepo := new(JobRepository)
 					defer jobRepo.AssertExpectations(t)
+
+					upstreamRepo := new(UpstreamRepository)
+					defer upstreamRepo.AssertExpectations(t)
 
 					downstreamRepo := new(DownstreamRepository)
 					defer downstreamRepo.AssertExpectations(t)
@@ -4883,7 +5238,7 @@ func TestJobService(t *testing.T) {
 					jobRunInputCompiler := NewJobRunInputCompiler(t)
 					resourceExistenceChecker := NewResourceExistenceChecker(t)
 
-					jobService := service.NewJobService(jobRepo, nil, downstreamRepo,
+					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo,
 						pluginService, upstreamResolver, tenantDetailsGetter, nil,
 						log, nil, compiler.NewEngine(),
 						jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{},
@@ -4920,7 +5275,11 @@ func TestJobService(t *testing.T) {
 					assert.NoError(t, err)
 					deletedRsc := resource.FromExisting(rsc, resource.ReplaceStatus(resource.StatusDeleted))
 
-					jobRepo.On("GetAllByTenant", ctx, sampleTenant).Return([]*job.Job{jobA, jobB}, nil)
+					// jobA/jobB's real destination is generated via generateJobs/ConstructDestinationURN
+					// (mocked to ZeroURN above), so BuildGlobalUpstreamGraph's reverse-impact
+					// lookup (GetDownstreamByDestination) is skipped for both - only the global
+					// resolved-upstream graph fetch happens.
+					upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{}, nil)
 
 					resourceExistenceChecker.On("GetByURN", ctx, sampleTenant, resourceURNB).Return(deletedRsc, nil)
 					resourceExistenceChecker.On("ExistInStore", ctx, sampleTenant, resourceURNB).Return(false, nil)
@@ -5038,6 +5397,9 @@ func TestJobService(t *testing.T) {
 					jobRepo := new(JobRepository)
 					defer jobRepo.AssertExpectations(t)
 
+					upstreamRepo := new(UpstreamRepository)
+					defer upstreamRepo.AssertExpectations(t)
+
 					downstreamRepo := new(DownstreamRepository)
 					defer downstreamRepo.AssertExpectations(t)
 
@@ -5049,7 +5411,7 @@ func TestJobService(t *testing.T) {
 					jobRunInputCompiler := NewJobRunInputCompiler(t)
 					resourceExistenceChecker := NewResourceExistenceChecker(t)
 
-					jobService := service.NewJobService(jobRepo, nil, downstreamRepo,
+					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo,
 						pluginService, upstreamResolver, tenantDetailsGetter, nil,
 						log, nil, compiler.NewEngine(),
 						jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{},
@@ -5070,7 +5432,10 @@ func TestJobService(t *testing.T) {
 					jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{upstreamB})
 					jobBWithUpstream := job.NewWithUpstream(jobB, []*job.Upstream{})
 
-					jobRepo.On("GetAllByTenant", ctx, sampleTenant).Return([]*job.Job{jobA, jobB}, nil)
+					// jobA/jobB's real destination is generated via generateJobs/ConstructDestinationURN
+					// (mocked to ZeroURN below), so BuildGlobalUpstreamGraph's reverse-impact
+					// lookup (GetDownstreamByDestination) is skipped for both.
+					upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{}, nil)
 
 					tenantDetailsGetter.On("GetDetails", ctx, sampleTenant).Return(detailedTenant, nil)
 
@@ -5201,6 +5566,9 @@ func TestJobService(t *testing.T) {
 					jobRepo := new(JobRepository)
 					defer jobRepo.AssertExpectations(t)
 
+					upstreamRepo := new(UpstreamRepository)
+					defer upstreamRepo.AssertExpectations(t)
+
 					downstreamRepo := new(DownstreamRepository)
 					defer downstreamRepo.AssertExpectations(t)
 
@@ -5212,7 +5580,7 @@ func TestJobService(t *testing.T) {
 					jobRunInputCompiler := NewJobRunInputCompiler(t)
 					resourceExistenceChecker := NewResourceExistenceChecker(t)
 
-					jobService := service.NewJobService(jobRepo, nil, downstreamRepo,
+					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo,
 						pluginService, upstreamResolver, tenantDetailsGetter, nil,
 						log, nil, compiler.NewEngine(),
 						jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{
@@ -5238,7 +5606,9 @@ func TestJobService(t *testing.T) {
 					upstreamB := job.NewUpstreamResolved(jobSpecB.Name(), "", resourceURNB, sampleTenant, "static", taskName, false)
 					jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{upstreamB})
 
-					jobRepo.On("GetAllByTenant", ctx, sampleTenant).Return([]*job.Job{jobB}, nil)
+					// jobA's real destination is generated via generateJobs/ConstructDestinationURN
+					// (mocked to ZeroURN below), so the reverse-impact lookup is skipped.
+					upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{}, nil)
 
 					tenantDetailsGetter.On("GetDetails", ctx, sampleTenant).Return(detailedTenant, nil)
 
@@ -5328,6 +5698,9 @@ func TestJobService(t *testing.T) {
 					jobRepo := new(JobRepository)
 					defer jobRepo.AssertExpectations(t)
 
+					upstreamRepo := new(UpstreamRepository)
+					defer upstreamRepo.AssertExpectations(t)
+
 					downstreamRepo := new(DownstreamRepository)
 					defer downstreamRepo.AssertExpectations(t)
 
@@ -5339,7 +5712,7 @@ func TestJobService(t *testing.T) {
 					jobRunInputCompiler := NewJobRunInputCompiler(t)
 					resourceExistenceChecker := NewResourceExistenceChecker(t)
 
-					jobService := service.NewJobService(jobRepo, nil, downstreamRepo,
+					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo,
 						pluginService, upstreamResolver, tenantDetailsGetter, nil,
 						log, nil, compiler.NewEngine(),
 						jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{
@@ -5365,7 +5738,9 @@ func TestJobService(t *testing.T) {
 					upstreamB := job.NewUpstreamResolved(jobSpecB.Name(), "", resourceURNB, sampleTenant, "static", taskName, false)
 					jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{upstreamB})
 
-					jobRepo.On("GetAllByTenant", ctx, sampleTenant).Return([]*job.Job{jobB}, nil)
+					// jobA's real destination is generated via generateJobs/ConstructDestinationURN
+					// (mocked to ZeroURN below), so the reverse-impact lookup is skipped.
+					upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{}, nil)
 
 					tenantDetailsGetter.On("GetDetails", ctx, sampleTenant).Return(detailedTenant, nil)
 
@@ -5453,6 +5828,9 @@ func TestJobService(t *testing.T) {
 					jobRepo := new(JobRepository)
 					defer jobRepo.AssertExpectations(t)
 
+					upstreamRepo := new(UpstreamRepository)
+					defer upstreamRepo.AssertExpectations(t)
+
 					downstreamRepo := new(DownstreamRepository)
 					defer downstreamRepo.AssertExpectations(t)
 
@@ -5464,7 +5842,7 @@ func TestJobService(t *testing.T) {
 					jobRunInputCompiler := NewJobRunInputCompiler(t)
 					resourceExistenceChecker := NewResourceExistenceChecker(t)
 
-					jobService := service.NewJobService(jobRepo, nil, downstreamRepo,
+					jobService := service.NewJobService(jobRepo, upstreamRepo, downstreamRepo,
 						pluginService, upstreamResolver, tenantDetailsGetter, nil,
 						log, nil, compiler.NewEngine(),
 						jobRunInputCompiler, resourceExistenceChecker, nil, service.JobValidateConfig{
@@ -5496,7 +5874,9 @@ func TestJobService(t *testing.T) {
 					jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{upstreamB})
 					jobBWithUpstream := job.NewWithUpstream(jobB, []*job.Upstream{})
 
-					jobRepo.On("GetAllByTenant", ctx, sampleTenant).Return([]*job.Job{jobB}, nil)
+					// jobA/jobB's real destination is generated via generateJobs/ConstructDestinationURN
+					// (mocked to ZeroURN below), so the reverse-impact lookup is skipped for both.
+					upstreamRepo.On("GetAllResolvedUpstreamEdges", ctx).Return(map[job.FullName][]job.FullName{}, nil)
 
 					tenantDetailsGetter.On("GetDetails", ctx, sampleTenant).Return(detailedTenant, nil)
 
@@ -6771,6 +7151,29 @@ func (_u *UpstreamRepository) ReplaceUpstreams(_a0 context.Context, _a1 []*job.W
 	}
 
 	return r0
+}
+
+// GetAllResolvedUpstreamEdges provides a mock function with given fields: ctx
+func (_u *UpstreamRepository) GetAllResolvedUpstreamEdges(ctx context.Context) (map[job.FullName][]job.FullName, error) {
+	ret := _u.Called(ctx)
+
+	var r0 map[job.FullName][]job.FullName
+	if rf, ok := ret.Get(0).(func(context.Context) map[job.FullName][]job.FullName); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[job.FullName][]job.FullName)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // PluginService is an autogenerated mock type for the PluginService type

--- a/core/resource/service/resource_service.go
+++ b/core/resource/service/resource_service.go
@@ -35,7 +35,7 @@ type ResourceRepository interface {
 	GetExternal(ctx context.Context, projName tenant.ProjectName, store resource.Store, filters []filter.FilterOpt) ([]*resource.Resource, error)
 	GetAllExternal(ctx context.Context, store resource.Store) ([]*resource.Resource, error)
 	GetResources(ctx context.Context, tnnt tenant.Tenant, store resource.Store, names []string) ([]*resource.Resource, error)
-	ReadByURN(ctx context.Context, tnnt tenant.Tenant, urn resource.URN) (*resource.Resource, error)
+	ReadByURN(ctx context.Context, urn resource.URN) (*resource.Resource, error)
 	GetExternalCreateFailures(ctx context.Context) ([]*resource.Resource, error)
 }
 
@@ -525,13 +525,13 @@ func (rs ResourceService) SyncResources(ctx context.Context, tnnt tenant.Tenant,
 	return synced, nil
 }
 
-func (rs ResourceService) GetByURN(ctx context.Context, tnnt tenant.Tenant, urn resource.URN) (*resource.Resource, error) {
+func (rs ResourceService) GetByURN(ctx context.Context, urn resource.URN) (*resource.Resource, error) {
 	if urn.IsZero() {
 		rs.logger.Error("urn is zero value")
 		return nil, errors.InvalidArgument(resource.EntityResource, "urn is zero value")
 	}
 
-	return rs.repo.ReadByURN(ctx, tnnt, urn)
+	return rs.repo.ReadByURN(ctx, urn)
 }
 
 func (rs ResourceService) ExistInStore(ctx context.Context, tnnt tenant.Tenant, urn resource.URN) (bool, error) {

--- a/core/resource/service/resource_service_test.go
+++ b/core/resource/service/resource_service_test.go
@@ -1729,7 +1729,7 @@ func TestResourceService(t *testing.T) {
 
 			rscService := service.NewResourceService(logger, repo, nil, mgr, nil, nil, nil, nil, nil, nil, nil)
 
-			_, err := rscService.GetByURN(ctx, tnnt, resource.ZeroURN())
+			_, err := rscService.GetByURN(ctx, resource.ZeroURN())
 			assert.Error(t, err)
 			assert.ErrorContains(t, err, "urn is zero value")
 		})
@@ -1742,11 +1742,11 @@ func TestResourceService(t *testing.T) {
 			urn, err := resource.ParseURN("bigquery://project:dataset.table")
 			assert.NoError(t, err)
 
-			repo.On("ReadByURN", ctx, tnnt, urn).Return(nil, errors.New("unknown error"))
+			repo.On("ReadByURN", ctx, urn).Return(nil, errors.New("unknown error"))
 
 			rscService := service.NewResourceService(logger, repo, nil, mgr, nil, nil, nil, nil, nil, nil, nil)
 
-			_, err = rscService.GetByURN(ctx, tnnt, urn)
+			_, err = rscService.GetByURN(ctx, urn)
 			assert.Error(t, err)
 			assert.ErrorContains(t, err, "unknown error")
 		})
@@ -1762,11 +1762,11 @@ func TestResourceService(t *testing.T) {
 			expectedResource, err := resource.NewResource("project.dataset", "dataset", resource.Bigquery, tnnt, meta, spec)
 			assert.NoError(t, err)
 
-			repo.On("ReadByURN", ctx, tnnt, urn).Return(expectedResource, nil)
+			repo.On("ReadByURN", ctx, urn).Return(expectedResource, nil)
 
 			rscService := service.NewResourceService(logger, repo, nil, mgr, nil, nil, nil, nil, nil, nil, nil)
 
-			actualResource, err := rscService.GetByURN(ctx, tnnt, urn)
+			actualResource, err := rscService.GetByURN(ctx, urn)
 			assert.NoError(t, err)
 			assert.Equal(t, expectedResource, actualResource)
 		})
@@ -1835,8 +1835,8 @@ func (m *mockResourceRepository) Delete(ctx context.Context, res *resource.Resou
 	return m.Called(ctx, res).Error(0)
 }
 
-func (m *mockResourceRepository) ReadByURN(ctx context.Context, tnnt tenant.Tenant, urn resource.URN) (*resource.Resource, error) {
-	args := m.Called(ctx, tnnt, urn)
+func (m *mockResourceRepository) ReadByURN(ctx context.Context, urn resource.URN) (*resource.Resource, error) {
+	args := m.Called(ctx, urn)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/internal/store/postgres/job/job_repository.go
+++ b/internal/store/postgres/job/job_repository.go
@@ -1128,6 +1128,43 @@ WHERE project_name=$1 AND job_name=$2;`
 	return j.toUpstreams(storeJobsWithUpstreams)
 }
 
+// GetAllResolvedUpstreamEdges return all cross-project upstream edges. Supposed to be lightweight only
+func (j JobRepository) GetAllResolvedUpstreamEdges(ctx context.Context) (map[job.FullName][]job.FullName, error) {
+	query := `
+SELECT
+	ju.project_name, ju.job_name, ju.upstream_project_name, ju.upstream_job_name
+FROM job_upstream ju
+JOIN job j ON (ju.job_name = j.name AND ju.project_name = j.project_name)
+JOIN job uj ON (ju.upstream_job_name = uj.name AND ju.upstream_project_name = uj.project_name)
+WHERE ju.upstream_state = 'resolved'
+AND ju.upstream_external = false
+AND j.deleted_at IS NULL
+AND uj.deleted_at IS NULL;`
+
+	rows, err := j.db.Query(ctx, query)
+	if err != nil {
+		return nil, errors.Wrap(job.EntityJob, "error while getting all resolved upstream edges", err)
+	}
+	defer rows.Close()
+
+	edges := make(map[job.FullName][]job.FullName)
+	for rows.Next() {
+		var projectName, jobName, upstreamProjectName, upstreamJobName string
+		if err := rows.Scan(&projectName, &jobName, &upstreamProjectName, &upstreamJobName); err != nil {
+			return nil, errors.Wrap(job.EntityJob, "error while scanning resolved upstream edge", err)
+		}
+
+		subject := job.FullName(projectName + "/" + jobName)
+		upstream := job.FullName(upstreamProjectName + "/" + upstreamJobName)
+		edges[subject] = append(edges[subject], upstream)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(job.EntityJob, "error while iterating resolved upstream edges", err)
+	}
+
+	return edges, nil
+}
+
 func (j JobRepository) GetDownstreamByDestination(ctx context.Context, destination resource.URN) ([]*job.Downstream, error) {
 	query := `
 SELECT

--- a/internal/store/postgres/job/job_repository_test.go
+++ b/internal/store/postgres/job/job_repository_test.go
@@ -1168,6 +1168,63 @@ func TestPostgresJobRepository(t *testing.T) {
 		})
 	})
 
+	t.Run("GetAllResolvedUpstreamEdges", func(t *testing.T) {
+		t.Run("returns only resolved, internal edges across all projects, excluding soft-deleted jobs", func(t *testing.T) {
+			db := dbSetup()
+			jobRepo := postgres.NewJobRepository(db)
+
+			otherTenant, err := tenant.NewTenant(otherProj.Name().String(), otherNamespace2.Name().String())
+			assert.NoError(t, err)
+
+			// job-A (this project) resolved-depends on job-B (this project): should be included.
+			jobSpecA, err := job.NewSpecBuilder(jobVersion, "sample-job-A", jobOwner, jobSchedule, customConfig, jobTask).WithDescription(jobDescription).Build()
+			assert.NoError(t, err)
+			jobA := job.NewJob(sampleTenant, jobSpecA, resourceURNA, []resource.URN{resourceURNB, resourceURNC}, false)
+			jobAUpstreamResolved := job.NewUpstreamResolved("sample-job-B", "", resourceURNB, sampleTenant, "inferred", taskName, false)
+			jobAUpstreamUnresolved := job.NewUpstreamUnresolvedInferred(resourceURNC)
+			jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{jobAUpstreamResolved, jobAUpstreamUnresolved})
+
+			jobSpecB, err := job.NewSpecBuilder(jobVersion, "sample-job-B", jobOwner, jobSchedule, customConfig, jobTask).WithDescription(jobDescription).Build()
+			assert.NoError(t, err)
+			jobB := job.NewJob(sampleTenant, jobSpecB, resourceURNB, nil, false)
+
+			// job-D (other project) resolved-depends on job-B (this project): a cross-project edge, should be included.
+			jobSpecD, err := job.NewSpecBuilder(jobVersion, "sample-job-D", jobOwner, jobSchedule, customConfig, jobTask).WithDescription(jobDescription).Build()
+			assert.NoError(t, err)
+			jobD := job.NewJob(otherTenant, jobSpecD, resourceURND, []resource.URN{resourceURNB}, false)
+			jobDUpstreamResolved := job.NewUpstreamResolved("sample-job-B", "", resourceURNB, sampleTenant, "inferred", taskName, false)
+			jobDWithUpstream := job.NewWithUpstream(jobD, []*job.Upstream{jobDUpstreamResolved})
+
+			// job-E (this project) resolved-depends on job-F (this project), but job-F will be soft-deleted: should be excluded.
+			jobSpecE, err := job.NewSpecBuilder(jobVersion, "sample-job-E", jobOwner, jobSchedule, customConfig, jobTask).WithDescription(jobDescription).Build()
+			assert.NoError(t, err)
+			jobE := job.NewJob(sampleTenant, jobSpecE, resourceURNE, []resource.URN{resourceURNF}, false)
+			jobEUpstreamResolved := job.NewUpstreamResolved("sample-job-F", "", resourceURNF, sampleTenant, "inferred", taskName, false)
+			jobEWithUpstream := job.NewWithUpstream(jobE, []*job.Upstream{jobEUpstreamResolved})
+
+			jobSpecF, err := job.NewSpecBuilder(jobVersion, "sample-job-F", jobOwner, jobSchedule, customConfig, jobTask).WithDescription(jobDescription).Build()
+			assert.NoError(t, err)
+			jobF := job.NewJob(sampleTenant, jobSpecF, resourceURNF, nil, false)
+
+			_, err = jobRepo.Add(ctx, []*job.Job{jobA, jobB, jobD, jobE, jobF})
+			assert.NoError(t, err)
+			assert.NoError(t, jobRepo.ReplaceUpstreams(ctx, []*job.WithUpstream{jobAWithUpstream, jobDWithUpstream, jobEWithUpstream}))
+			assert.NoError(t, jobRepo.Delete(ctx, proj.Name(), jobSpecF.Name(), false))
+
+			result, err := jobRepo.GetAllResolvedUpstreamEdges(ctx)
+			assert.NoError(t, err)
+
+			jobAFullName := job.FullName(proj.Name().String() + "/" + jobSpecA.Name().String())
+			jobDFullName := job.FullName(otherProj.Name().String() + "/" + jobSpecD.Name().String())
+			jobBFullName := job.FullName(proj.Name().String() + "/" + jobSpecB.Name().String())
+			jobEFullName := job.FullName(proj.Name().String() + "/" + jobSpecE.Name().String())
+
+			assert.ElementsMatch(t, []job.FullName{jobBFullName}, result[jobAFullName], "resolved edge to job-B should be present, unresolved edge to job-C should not")
+			assert.ElementsMatch(t, []job.FullName{jobBFullName}, result[jobDFullName], "cross-project resolved edge should be present")
+			assert.Empty(t, result[jobEFullName], "edge to a soft-deleted upstream job should be excluded")
+		})
+	})
+
 	t.Run("GetDownstreamBySources", func(t *testing.T) {
 		t.Run("returns empty downstream if resource urns are empty", func(t *testing.T) {
 			db := dbSetup()

--- a/internal/store/postgres/resource/repository.go
+++ b/internal/store/postgres/resource/repository.go
@@ -460,13 +460,13 @@ func (r Repository) GetChangelogs(ctx context.Context, projectName tenant.Projec
 	return changeLog, me.ToErr()
 }
 
-func (r Repository) ReadByURN(ctx context.Context, tnnt tenant.Tenant, urn resource.URN) (*resource.Resource, error) {
+func (r Repository) ReadByURN(ctx context.Context, urn resource.URN) (*resource.Resource, error) {
 	query := `
 		SELECT ` + resourceColumns + ` FROM resource
-		WHERE urn = $1 AND project_name = $2 AND namespace_name = $3 AND status NOT IN ($4, $5)
+		WHERE urn = $1 AND status NOT IN ($2, $3)
 		LIMIT 1
 	`
-	args := []any{urn.String(), tnnt.ProjectName(), tnnt.NamespaceName(), resource.StatusDeleted, resource.StatusToDelete}
+	args := []any{urn.String(), resource.StatusDeleted, resource.StatusToDelete}
 
 	var res Resource
 	err := r.db.QueryRow(ctx, query, args...).
@@ -474,10 +474,10 @@ func (r Repository) ReadByURN(ctx context.Context, tnnt tenant.Tenant, urn resou
 			&res.ProjectName, &res.NamespaceName, &res.Metadata, &res.Spec, &res.CreatedAt, &res.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, errors.NotFound(resource.EntityResource, fmt.Sprintf("no resource with urn: '%s' found for project:%s, namespace:%s ", urn, tnnt.ProjectName(), tnnt.NamespaceName()))
+			return nil, errors.NotFound(resource.EntityResource, fmt.Sprintf("no resource with urn: '%s' found", urn))
 		}
 
-		return nil, errors.Wrap(resource.EntityResource, fmt.Sprintf("error reading resource with urn: '%s' found for project:%s, namespace:%s ", urn, tnnt.ProjectName(), tnnt.NamespaceName()), err)
+		return nil, errors.Wrap(resource.EntityResource, fmt.Sprintf("error reading resource with urn: '%s' found", urn), err)
 	}
 
 	return FromModelToResource(&res)

--- a/internal/store/postgres/resource/repository_test.go
+++ b/internal/store/postgres/resource/repository_test.go
@@ -489,7 +489,7 @@ func TestPostgresResourceRepository(t *testing.T) {
 			urn, err := serviceResource.ParseURN("bigquery://project:dataset")
 			assert.NoError(t, err)
 
-			actualResource, actualError := repository.ReadByURN(ctx, tnnt, urn)
+			actualResource, actualError := repository.ReadByURN(ctx, urn)
 			assert.Nil(t, actualResource)
 			assert.ErrorContains(t, actualError, "not found for entity resource")
 		})
@@ -509,7 +509,7 @@ func TestPostgresResourceRepository(t *testing.T) {
 			err = repository.Create(ctx, resourceToCreate)
 			assert.NoError(t, err)
 
-			actualResource, actualError := repository.ReadByURN(ctx, tnnt, urn)
+			actualResource, actualError := repository.ReadByURN(ctx, urn)
 			assert.NotNil(t, actualResource)
 			assert.NoError(t, actualError)
 			resourceToCreate.SetUpdateAt(actualResource.GetUpdateAt())

--- a/plugin/upstream_identifier/parser/query_parser.go
+++ b/plugin/upstream_identifier/parser/query_parser.go
@@ -6,6 +6,20 @@ import (
 	"strings"
 )
 
+type fromListEventKind int
+
+const (
+	eventKindKeyword    fromListEventKind = iota
+	eventKindOpenParen                    // entering a subquery
+	eventKindCloseParen                   // leaving a subquery
+)
+
+type fromListEvent struct {
+	pos     int
+	kind    fromListEventKind
+	turnsOn bool // only meaningful for eventKindKeyword: true for FROM/JOIN, false otherwise
+}
+
 var (
 	topLevelUpstreamsPattern = regexp.MustCompile(
 		"(?i)(?:FROM)\\s*(?:/\\*\\s*([a-zA-Z0-9@_-]*)\\s*\\*/)?\\s+`?(`?[\\w-]+`?\\.`?[\\w-]+`?\\.`?[\\w-\\*?]+`?)`?" + //nolint:gocritic
@@ -34,33 +48,32 @@ var (
 	multiLineCommentsPattern  = regexp.MustCompile(`(((/\*)+?[\w\W]*?(\*/)+))`)
 	specialCommentPattern     = regexp.MustCompile(`(\/\*\s*(@[a-zA-Z0-9_-]+)\s*\*\/)`)
 
-	// fromListStateKeywordPattern recognizes the keywords that toggle whether a given position in
-	// the query is inside an active FROM/JOIN table list. It is scanned independently of
-	// topLevelUpstreamsPattern (see newFromListChecker) precisely because a bare dotted identifier
-	// with no clause keyword directly in front of it (topLevelUpstreamsPattern's keyword-less final
-	// alternative, dispatched to the "default" case below) is structurally ambiguous on its own:
-	// it might be the next item in a comma-joined FROM list, or it might be a struct/record field
-	// access, a SELECT-list expression, or part of a WHERE/ON condition. This independent scan is
-	// what disambiguates the two by tracking which clause is actually in effect at that position.
 	fromListStateKeywordPattern = regexp.MustCompile(`(?i)\b(FROM|JOIN|WHERE|GROUP\s+BY|ORDER\s+BY|HAVING|ON|WINDOW|QUALIFY|UNION|LIMIT)\b`)
 )
 
 func ParseTopLevelUpstreamsFromQuery(query string) []string {
 	cleanedQuery := cleanQueryFromComment(query)
 
-	tableFound := map[string]bool{}
-	pseudoTable := map[string]bool{}
+	upstreamTables := extractUpstreamTables(cleanedQuery)
 
-	matches := topLevelUpstreamsPattern.FindAllStringSubmatchIndex(cleanedQuery, -1)
-	insideFromList := newFromListChecker(cleanedQuery, matches)
+	return upstreamTables
+}
 
-	for _, idx := range matches {
-		tokens := strings.Fields(groupText(cleanedQuery, idx, 0))
-		clause := strings.ToLower(tokens[0])
+func extractUpstreamTables(query string) []string {
+	referencedTables := map[string]bool{}
+	cteAliases := map[string]bool{}
 
+	matchIndexes := topLevelUpstreamsPattern.FindAllStringSubmatchIndex(query, -1)
+	insideFromOrJoinClause := buildFromListChecker(query, matchIndexes)
+
+	for _, idx := range matchIndexes {
+		clause := getClauseFromMatch(query, idx)
 		ignoreUpstreamIdx, tableIdx, isKeywordMatch := clauseGroupIndices(clause)
 
-		if strings.TrimSpace(groupText(cleanedQuery, idx, ignoreUpstreamIdx)) == "@ignoreupstream" {
+		ignoreUpstreamClause := groupText(query, idx, ignoreUpstreamIdx)
+		tableName := groupText(query, idx, tableIdx)
+
+		if strings.TrimSpace(ignoreUpstreamClause) == "@ignoreupstream" {
 			continue
 		}
 
@@ -68,29 +81,22 @@ func ParseTopLevelUpstreamsFromQuery(query string) []string {
 			continue
 		}
 
-		// A keyword-less match is only a genuine table reference if it's actually reachable from
-		// a FROM/JOIN clause (e.g. SELECT * FROM a.b.c, a.b.f which makes a.b.c & a.b.f actual upstreams) -
-		// otherwise it's a false positive, such as struct/record field access, a SELECT-list
-		// expression, or a WHERE/ON condition, and must not be treated as an upstream.
-		if !isKeywordMatch && !insideFromList(idx[0]) {
+		if !isKeywordMatch && !insideFromOrJoinClause(idx[0]) {
 			continue
 		}
 
-		tableName := cleanTableFromTickQuote(groupText(cleanedQuery, idx, tableIdx))
+		cleanTableName := cleanTableFromTickQuote(tableName)
 		if clause == "with" {
-			pseudoTable[tableName] = true
+			cteAliases[cleanTableName] = true
 		} else {
-			tableFound[tableName] = true
+			referencedTables[cleanTableName] = true
 		}
 	}
 
-	return filterAliases(tableFound, pseudoTable)
+	return filterAliases(referencedTables, cteAliases)
 }
 
-// clauseGroupIndices maps a SQL clause keyword to the submatch group indices used by
-// topLevelUpstreamsPattern: ignoreIdx is the @ignoreupstream annotation group, tableIdx is the
-// table-name group. isKeyword is false only for the pattern's keyword-less final alternative.
-func clauseGroupIndices(clause string) (ignoreIdx, tableIdx int, isKeyword bool) {
+func clauseGroupIndices(clause string) (ignoreUpstreamIdx, tableIdx int, isKeyword bool) {
 	switch clause {
 	case "from":
 		return 1, 2, true
@@ -141,81 +147,103 @@ func groupText(query string, idx []int, groupIndex int) string {
 	return query[start:end]
 }
 
-// newFromListChecker returns a function reporting, for a given byte offset into query, whether
-// that position is reachable from a preceding FROM/JOIN keyword without having crossed into a
-// different clause (WHERE, GROUP BY, ORDER BY, HAVING, ON, WINDOW, QUALIFY, UNION, LIMIT) or out
-// of the parenthesis depth it was set at (so a subquery's own FROM doesn't leak its "in a table
-// list" state into the clause that encloses it, e.g. `WHERE x IN (SELECT y FROM a.b.c) AND d.e.f`
-// must not treat d.e.f as a table just because the subquery had an active FROM).
-// upstreamMatches masks out MERGE/INSERT/DELETE/CREATE/SET spans (already found by the caller via
-// topLevelUpstreamsPattern) so that e.g. the literal "FROM" inside "DELETE FROM x.y.z" is never
-// treated as a real FROM clause.
-func newFromListChecker(query string, upstreamMatches [][]int) func(pos int) bool {
-	var ignoredSpans [][2]int
-	for _, idx := range upstreamMatches {
-		clause := strings.ToLower(strings.Fields(groupText(query, idx, 0))[0])
-		switch clause {
-		case "merge", "insert", "delete", "create", "set":
-			ignoredSpans = append(ignoredSpans, [2]int{idx[0], idx[1]})
-		}
-	}
+// newFromListChecker returns a closure that answers, for any position index in query, whether that
+// position sits inside an active FROM/JOIN table list. This is used to differentiate dotted
+// identifiers (like the comma-joined `a.b.d` in `FROM a.b.c, a.b.d`) from false positives like
+// nested struct field access
+func buildFromListChecker(query string, upstreamMatches [][]int) func(pos int) bool {
+	writeOnlySpans := collectWriteOnlySpans(query, upstreamMatches)
 
-	type event struct {
-		pos     int
-		turnsOn bool
-		paren   byte // '(', ')', or 0 for a keyword event
-	}
+	events := buildFromListEvents(query, writeOnlySpans)
 
-	var events []event
-	for _, kwIdx := range fromListStateKeywordPattern.FindAllStringIndex(query, -1) {
-		if withinAnySpan(kwIdx[0], ignoredSpans) {
-			continue
-		}
-		kw := strings.ToLower(strings.Join(strings.Fields(query[kwIdx[0]:kwIdx[1]]), " "))
-		events = append(events, event{pos: kwIdx[0], turnsOn: kw == "from" || kw == "join"})
-	}
-	for i, c := range query {
-		switch c {
-		case '(':
-			events = append(events, event{pos: i, paren: '('})
-		case ')':
-			events = append(events, event{pos: i, paren: ')'})
-		}
-	}
-	sort.Slice(events, func(i, j int) bool { return events[i].pos < events[j].pos })
-
-	positions := make([]int, len(events))
-	states := make([]bool, len(events))
-
-	state := false
-	var stack []bool
-	for i, e := range events {
-		switch e.paren {
-		case '(':
-			stack = append(stack, state)
-			state = false
-		case ')':
-			if len(stack) > 0 {
-				state = stack[len(stack)-1]
-				stack = stack[:len(stack)-1]
-			} else {
-				state = false
-			}
-		default:
-			state = e.turnsOn
-		}
-		positions[i] = e.pos
-		states[i] = state
-	}
+	positions, states := buildFromListStateIndex(events)
 
 	return func(pos int) bool {
-		// binary search for the last event strictly before pos
 		i := sort.SearchInts(positions, pos)
 		if i == 0 {
 			return false
 		}
 		return states[i-1]
 	}
+}
+
+func getClauseFromMatch(query string, upstreamMatchIdx []int) string {
+	tokens := strings.Fields(groupText(query, upstreamMatchIdx, 0))
+	return strings.ToLower(tokens[0])
+}
+
+func collectWriteOnlySpans(query string, upstreamMatches [][]int) [][2]int {
+	var spans [][2]int
+	for _, idx := range upstreamMatches {
+		clause := getClauseFromMatch(query, idx)
+		if isWriteOnlyClause(clause) {
+			spans = append(spans, [2]int{idx[0], idx[1]})
+		}
+	}
+	return spans
+}
+
+// buildFromListEvents scans query for clause keywords and parentheses, skipping any keyword
+// that falls inside a write-only span, and returns all events sorted by position.
+func buildFromListEvents(query string, writeOnlySpans [][2]int) []fromListEvent {
+	var events []fromListEvent
+
+	for _, keywordIdx := range fromListStateKeywordPattern.FindAllStringIndex(query, -1) {
+		if withinAnySpan(keywordIdx[0], writeOnlySpans) {
+			continue
+		}
+		kw := strings.ToLower(strings.Join(strings.Fields(query[keywordIdx[0]:keywordIdx[1]]), " "))
+		events = append(events, fromListEvent{
+			pos:     keywordIdx[0],
+			kind:    eventKindKeyword,
+			turnsOn: kw == "from" || kw == "join",
+		})
+	}
+
+	for i, c := range query {
+		switch c {
+		case '(':
+			events = append(events, fromListEvent{pos: i, kind: eventKindOpenParen})
+		case ')':
+			events = append(events, fromListEvent{pos: i, kind: eventKindCloseParen})
+		}
+	}
+
+	sort.Slice(events, func(i, j int) bool { return events[i].pos < events[j].pos })
+	return events
+}
+
+// buildFromListStateIndex walks the sorted events and tracks whether a FROM/JOIN clause is
+// active at each position. Parentheses create an isolated scope: opening a paren saves the
+// current active state and resets it (so a subquery's FROM doesn't leak into the enclosing
+// clause), and closing a paren restores the enclosing scope's state.
+func buildFromListStateIndex(events []fromListEvent) (positions []int, states []bool) {
+	positions = make([]int, len(events))
+	states = make([]bool, len(events))
+
+	active := false
+	var scopeStack []bool
+
+	for i, e := range events {
+		switch e.kind {
+		case eventKindOpenParen:
+			scopeStack = append(scopeStack, active)
+			active = false
+		case eventKindCloseParen:
+			if len(scopeStack) > 0 {
+				active = scopeStack[len(scopeStack)-1]
+				scopeStack = scopeStack[:len(scopeStack)-1]
+			} else {
+				active = false
+			}
+		case eventKindKeyword:
+			active = e.turnsOn
+		}
+		positions[i] = e.pos
+		states[i] = active
+	}
+
+	return
 }
 
 func withinAnySpan(pos int, spans [][2]int) bool {

--- a/plugin/upstream_identifier/parser/query_parser.go
+++ b/plugin/upstream_identifier/parser/query_parser.go
@@ -52,41 +52,19 @@ func ParseTopLevelUpstreamsFromQuery(query string) []string {
 	pseudoTable := map[string]bool{}
 
 	matches := topLevelUpstreamsPattern.FindAllStringSubmatchIndex(cleanedQuery, -1)
-	inFromList := newFromListChecker(cleanedQuery, matches)
+	insideFromList := newFromListChecker(cleanedQuery, matches)
 
 	for _, idx := range matches {
-		var tableIdx, ignoreUpstreamIdx int
 		tokens := strings.Fields(groupText(cleanedQuery, idx, 0))
 		clause := strings.ToLower(tokens[0])
 
-		isKeywordMatch := true
-		switch clause {
-		case "from":
-			ignoreUpstreamIdx, tableIdx = 1, 2
-		case "join":
-			ignoreUpstreamIdx, tableIdx = 3, 4
-		case "with":
-			ignoreUpstreamIdx, tableIdx = 5, 6
-		case "merge":
-			ignoreUpstreamIdx, tableIdx = 7, 8
-		case "insert":
-			ignoreUpstreamIdx, tableIdx = 9, 10
-		case "delete":
-			ignoreUpstreamIdx, tableIdx = 11, 12
-		case "create":
-			ignoreUpstreamIdx, tableIdx = 13, 14
-		case "set":
-			ignoreUpstreamIdx, tableIdx = 15, 16
-		default:
-			ignoreUpstreamIdx, tableIdx = 17, 18
-			isKeywordMatch = false
-		}
+		ignoreUpstreamIdx, tableIdx, isKeywordMatch := clauseGroupIndices(clause)
 
 		if strings.TrimSpace(groupText(cleanedQuery, idx, ignoreUpstreamIdx)) == "@ignoreupstream" {
 			continue
 		}
 
-		if clause == "create" || clause == "merge" || clause == "insert" || clause == "delete" || clause == "set" {
+		if isWriteOnlyClause(clause) {
 			continue
 		}
 
@@ -94,7 +72,7 @@ func ParseTopLevelUpstreamsFromQuery(query string) []string {
 		// a FROM/JOIN clause (e.g. SELECT * FROM a.b.c, a.b.f which makes a.b.c & a.b.f actual upstreams) -
 		// otherwise it's a false positive, such as struct/record field access, a SELECT-list
 		// expression, or a WHERE/ON condition, and must not be treated as an upstream.
-		if !isKeywordMatch && !inFromList(idx[0]) {
+		if !isKeywordMatch && !insideFromList(idx[0]) {
 			continue
 		}
 
@@ -106,15 +84,50 @@ func ParseTopLevelUpstreamsFromQuery(query string) []string {
 		}
 	}
 
-	output := []string{}
+	return filterAliases(tableFound, pseudoTable)
+}
 
-	for table := range tableFound {
-		if pseudoTable[table] {
-			continue
-		}
-		output = append(output, table)
+// clauseGroupIndices maps a SQL clause keyword to the submatch group indices used by
+// topLevelUpstreamsPattern: ignoreIdx is the @ignoreupstream annotation group, tableIdx is the
+// table-name group. isKeyword is false only for the pattern's keyword-less final alternative.
+func clauseGroupIndices(clause string) (ignoreIdx, tableIdx int, isKeyword bool) {
+	switch clause {
+	case "from":
+		return 1, 2, true
+	case "join":
+		return 3, 4, true
+	case "with":
+		return 5, 6, true
+	case "merge":
+		return 7, 8, true
+	case "insert":
+		return 9, 10, true
+	case "delete":
+		return 11, 12, true
+	case "create":
+		return 13, 14, true
+	case "set":
+		return 15, 16, true
+	default:
+		return 17, 18, false
 	}
+}
 
+func isWriteOnlyClause(clause string) bool {
+	switch clause {
+	case "create", "merge", "insert", "delete", "set":
+		return true
+	}
+	return false
+}
+
+func filterAliases(tableFound, pseudoTable map[string]bool) []string {
+	output := make([]string, 0, len(tableFound))
+	for table := range tableFound {
+		if !pseudoTable[table] {
+			output = append(output, table)
+		}
+	}
 	return output
 }
 

--- a/plugin/upstream_identifier/parser/query_parser.go
+++ b/plugin/upstream_identifier/parser/query_parser.go
@@ -189,10 +189,10 @@ func collectWriteOnlySpans(query string, upstreamMatches [][]int) [][2]int {
 // buildFromListEvents scans query for clause keywords and parentheses, skipping any keyword
 // that falls inside a write-only span, and returns all events sorted by position.
 func buildFromListEvents(query string, writeOnlySpans [][2]int) []fromListEvent {
-	keywordEvents := buildKeywordEvents(query, writeOnlySpans)
+	events := buildKeywordEvents(query, writeOnlySpans)
 	parenthesesEvents := buildParenthesesEvents(query)
 
-	events := append(keywordEvents, parenthesesEvents...)
+	events = append(events, parenthesesEvents...)
 	sort.Slice(events, func(i, j int) bool { return events[i].pos < events[j].pos })
 
 	return events

--- a/plugin/upstream_identifier/parser/query_parser.go
+++ b/plugin/upstream_identifier/parser/query_parser.go
@@ -54,9 +54,7 @@ var (
 func ParseTopLevelUpstreamsFromQuery(query string) []string {
 	cleanedQuery := cleanQueryFromComment(query)
 
-	upstreamTables := extractUpstreamTables(cleanedQuery)
-
-	return upstreamTables
+	return extractUpstreamTables(cleanedQuery)
 }
 
 func extractUpstreamTables(query string) []string {
@@ -67,29 +65,15 @@ func extractUpstreamTables(query string) []string {
 	insideFromOrJoinClause := buildFromListChecker(query, matchIndexes)
 
 	for _, idx := range matchIndexes {
-		clause := getClauseFromMatch(query, idx)
-		ignoreUpstreamIdx, tableIdx, isKeywordMatch := clauseGroupIndices(clause)
-
-		ignoreUpstreamClause := groupText(query, idx, ignoreUpstreamIdx)
-		tableName := groupText(query, idx, tableIdx)
-
-		if strings.TrimSpace(ignoreUpstreamClause) == "@ignoreupstream" {
+		tableName, isCTEAlias := extractValidTable(query, idx, insideFromOrJoinClause)
+		if tableName == "" {
 			continue
 		}
 
-		if isWriteOnlyClause(clause) {
-			continue
-		}
-
-		if !isKeywordMatch && !insideFromOrJoinClause(idx[0]) {
-			continue
-		}
-
-		cleanTableName := cleanTableFromTickQuote(tableName)
-		if clause == "with" {
-			cteAliases[cleanTableName] = true
+		if isCTEAlias {
+			cteAliases[tableName] = true
 		} else {
-			referencedTables[cleanTableName] = true
+			referencedTables[tableName] = true
 		}
 	}
 
@@ -127,10 +111,10 @@ func isWriteOnlyClause(clause string) bool {
 	return false
 }
 
-func filterAliases(tableFound, pseudoTable map[string]bool) []string {
-	output := make([]string, 0, len(tableFound))
-	for table := range tableFound {
-		if !pseudoTable[table] {
+func filterAliases(referencedTables, cteAliases map[string]bool) []string {
+	output := make([]string, 0, len(referencedTables))
+	for table := range referencedTables {
+		if !cteAliases[table] {
 			output = append(output, table)
 		}
 	}
@@ -147,7 +131,7 @@ func groupText(query string, idx []int, groupIndex int) string {
 	return query[start:end]
 }
 
-// newFromListChecker returns a closure that answers, for any position index in query, whether that
+// buildFromListChecker returns a closure that answers, for any position index in query, whether that
 // position sits inside an active FROM/JOIN table list. This is used to differentiate dotted
 // identifiers (like the comma-joined `a.b.d` in `FROM a.b.c, a.b.d`) from false positives like
 // nested struct field access
@@ -165,6 +149,25 @@ func buildFromListChecker(query string, upstreamMatches [][]int) func(pos int) b
 		}
 		return states[i-1]
 	}
+}
+
+// extractValidTable validates a single regex match and returns the cleaned table name and whether
+// it is a CTE alias. Returns ("", false) if the match should be skipped.
+func extractValidTable(query string, idx []int, insideFromOrJoinClause func(int) bool) (string, bool) {
+	clause := getClauseFromMatch(query, idx)
+	ignoreUpstreamIdx, tableIdx, isKeywordMatch := clauseGroupIndices(clause)
+
+	if strings.TrimSpace(groupText(query, idx, ignoreUpstreamIdx)) == "@ignoreupstream" {
+		return "", false
+	}
+	if isWriteOnlyClause(clause) {
+		return "", false
+	}
+	if !isKeywordMatch && !insideFromOrJoinClause(idx[0]) {
+		return "", false
+	}
+
+	return cleanTableFromTickQuote(groupText(query, idx, tableIdx)), clause == "with"
 }
 
 func getClauseFromMatch(query string, upstreamMatchIdx []int) string {
@@ -186,6 +189,16 @@ func collectWriteOnlySpans(query string, upstreamMatches [][]int) [][2]int {
 // buildFromListEvents scans query for clause keywords and parentheses, skipping any keyword
 // that falls inside a write-only span, and returns all events sorted by position.
 func buildFromListEvents(query string, writeOnlySpans [][2]int) []fromListEvent {
+	keywordEvents := buildKeywordEvents(query, writeOnlySpans)
+	parenthesesEvents := buildParenthesesEvents(query)
+
+	events := append(keywordEvents, parenthesesEvents...)
+	sort.Slice(events, func(i, j int) bool { return events[i].pos < events[j].pos })
+
+	return events
+}
+
+func buildKeywordEvents(query string, writeOnlySpans [][2]int) []fromListEvent {
 	var events []fromListEvent
 
 	for _, keywordIdx := range fromListStateKeywordPattern.FindAllStringIndex(query, -1) {
@@ -200,6 +213,12 @@ func buildFromListEvents(query string, writeOnlySpans [][2]int) []fromListEvent 
 		})
 	}
 
+	return events
+}
+
+func buildParenthesesEvents(query string) []fromListEvent {
+	var events []fromListEvent
+
 	for i, c := range query {
 		switch c {
 		case '(':
@@ -209,7 +228,6 @@ func buildFromListEvents(query string, writeOnlySpans [][2]int) []fromListEvent 
 		}
 	}
 
-	sort.Slice(events, func(i, j int) bool { return events[i].pos < events[j].pos })
 	return events
 }
 

--- a/plugin/upstream_identifier/parser/query_parser.go
+++ b/plugin/upstream_identifier/parser/query_parser.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -32,6 +33,16 @@ var (
 	singleLineCommentsPattern = regexp.MustCompile(`(--.*)`)
 	multiLineCommentsPattern  = regexp.MustCompile(`(((/\*)+?[\w\W]*?(\*/)+))`)
 	specialCommentPattern     = regexp.MustCompile(`(\/\*\s*(@[a-zA-Z0-9_-]+)\s*\*\/)`)
+
+	// fromListStateKeywordPattern recognizes the keywords that toggle whether a given position in
+	// the query is inside an active FROM/JOIN table list. It is scanned independently of
+	// topLevelUpstreamsPattern (see newFromListChecker) precisely because a bare dotted identifier
+	// with no clause keyword directly in front of it (topLevelUpstreamsPattern's keyword-less final
+	// alternative, dispatched to the "default" case below) is structurally ambiguous on its own:
+	// it might be the next item in a comma-joined FROM list, or it might be a struct/record field
+	// access, a SELECT-list expression, or part of a WHERE/ON condition. This independent scan is
+	// what disambiguates the two by tracking which clause is actually in effect at that position.
+	fromListStateKeywordPattern = regexp.MustCompile(`(?i)\b(FROM|JOIN|WHERE|GROUP\s+BY|ORDER\s+BY|HAVING|ON|WINDOW|QUALIFY|UNION|LIMIT)\b`)
 )
 
 func ParseTopLevelUpstreamsFromQuery(query string) []string {
@@ -40,13 +51,15 @@ func ParseTopLevelUpstreamsFromQuery(query string) []string {
 	tableFound := map[string]bool{}
 	pseudoTable := map[string]bool{}
 
-	matches := topLevelUpstreamsPattern.FindAllStringSubmatch(cleanedQuery, -1)
+	matches := topLevelUpstreamsPattern.FindAllStringSubmatchIndex(cleanedQuery, -1)
+	inFromList := newFromListChecker(cleanedQuery, matches)
 
-	for _, match := range matches {
+	for _, idx := range matches {
 		var tableIdx, ignoreUpstreamIdx int
-		tokens := strings.Fields(match[0])
+		tokens := strings.Fields(groupText(cleanedQuery, idx, 0))
 		clause := strings.ToLower(tokens[0])
 
+		isKeywordMatch := true
 		switch clause {
 		case "from":
 			ignoreUpstreamIdx, tableIdx = 1, 2
@@ -66,9 +79,10 @@ func ParseTopLevelUpstreamsFromQuery(query string) []string {
 			ignoreUpstreamIdx, tableIdx = 15, 16
 		default:
 			ignoreUpstreamIdx, tableIdx = 17, 18
+			isKeywordMatch = false
 		}
 
-		if strings.TrimSpace(match[ignoreUpstreamIdx]) == "@ignoreupstream" {
+		if strings.TrimSpace(groupText(cleanedQuery, idx, ignoreUpstreamIdx)) == "@ignoreupstream" {
 			continue
 		}
 
@@ -76,7 +90,15 @@ func ParseTopLevelUpstreamsFromQuery(query string) []string {
 			continue
 		}
 
-		tableName := cleanTableFromTickQuote(match[tableIdx])
+		// A keyword-less match is only a genuine table reference if it's actually reachable from
+		// a FROM/JOIN clause (e.g. SELECT * FROM a.b.c, a.b.f which makes a.b.c & a.b.f actual upstreams) -
+		// otherwise it's a false positive, such as struct/record field access, a SELECT-list
+		// expression, or a WHERE/ON condition, and must not be treated as an upstream.
+		if !isKeywordMatch && !inFromList(idx[0]) {
+			continue
+		}
+
+		tableName := cleanTableFromTickQuote(groupText(cleanedQuery, idx, tableIdx))
 		if clause == "with" {
 			pseudoTable[tableName] = true
 		} else {
@@ -94,6 +116,102 @@ func ParseTopLevelUpstreamsFromQuery(query string) []string {
 	}
 
 	return output
+}
+
+// groupText returns the text captured by submatch group groupIndex within idx (as produced by
+// FindAllStringSubmatchIndex), or "" if that group did not participate in the match.
+func groupText(query string, idx []int, groupIndex int) string {
+	start, end := idx[2*groupIndex], idx[2*groupIndex+1]
+	if start < 0 {
+		return ""
+	}
+	return query[start:end]
+}
+
+// newFromListChecker returns a function reporting, for a given byte offset into query, whether
+// that position is reachable from a preceding FROM/JOIN keyword without having crossed into a
+// different clause (WHERE, GROUP BY, ORDER BY, HAVING, ON, WINDOW, QUALIFY, UNION, LIMIT) or out
+// of the parenthesis depth it was set at (so a subquery's own FROM doesn't leak its "in a table
+// list" state into the clause that encloses it, e.g. `WHERE x IN (SELECT y FROM a.b.c) AND d.e.f`
+// must not treat d.e.f as a table just because the subquery had an active FROM).
+// upstreamMatches masks out MERGE/INSERT/DELETE/CREATE/SET spans (already found by the caller via
+// topLevelUpstreamsPattern) so that e.g. the literal "FROM" inside "DELETE FROM x.y.z" is never
+// treated as a real FROM clause.
+func newFromListChecker(query string, upstreamMatches [][]int) func(pos int) bool {
+	var ignoredSpans [][2]int
+	for _, idx := range upstreamMatches {
+		clause := strings.ToLower(strings.Fields(groupText(query, idx, 0))[0])
+		switch clause {
+		case "merge", "insert", "delete", "create", "set":
+			ignoredSpans = append(ignoredSpans, [2]int{idx[0], idx[1]})
+		}
+	}
+
+	type event struct {
+		pos     int
+		turnsOn bool
+		paren   byte // '(', ')', or 0 for a keyword event
+	}
+
+	var events []event
+	for _, kwIdx := range fromListStateKeywordPattern.FindAllStringIndex(query, -1) {
+		if withinAnySpan(kwIdx[0], ignoredSpans) {
+			continue
+		}
+		kw := strings.ToLower(strings.Join(strings.Fields(query[kwIdx[0]:kwIdx[1]]), " "))
+		events = append(events, event{pos: kwIdx[0], turnsOn: kw == "from" || kw == "join"})
+	}
+	for i, c := range query {
+		switch c {
+		case '(':
+			events = append(events, event{pos: i, paren: '('})
+		case ')':
+			events = append(events, event{pos: i, paren: ')'})
+		}
+	}
+	sort.Slice(events, func(i, j int) bool { return events[i].pos < events[j].pos })
+
+	positions := make([]int, len(events))
+	states := make([]bool, len(events))
+
+	state := false
+	var stack []bool
+	for i, e := range events {
+		switch e.paren {
+		case '(':
+			stack = append(stack, state)
+			state = false
+		case ')':
+			if len(stack) > 0 {
+				state = stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+			} else {
+				state = false
+			}
+		default:
+			state = e.turnsOn
+		}
+		positions[i] = e.pos
+		states[i] = state
+	}
+
+	return func(pos int) bool {
+		// binary search for the last event strictly before pos
+		i := sort.SearchInts(positions, pos)
+		if i == 0 {
+			return false
+		}
+		return states[i-1]
+	}
+}
+
+func withinAnySpan(pos int, spans [][2]int) bool {
+	for _, s := range spans {
+		if pos >= s[0] && pos < s[1] {
+			return true
+		}
+	}
+	return false
 }
 
 func cleanQueryFromComment(query string) string {

--- a/plugin/upstream_identifier/parser/query_parser_test.go
+++ b/plugin/upstream_identifier/parser/query_parser_test.go
@@ -330,6 +330,68 @@ func TestParseTopLevelUpstreamsFromQuery(t *testing.T) {
 				InputQuery:     "create or replace table `data-engineering.testing.table_b`",
 				ExpectedTables: []string{},
 			},
+			{
+				Name:           "does not treat a struct/record field access in the select list as an upstream",
+				InputQuery:     "select struct_col.nested_field.subfield from `data-engineering.testing.table1`",
+				ExpectedTables: []string{newTable("data-engineering", "testing", "table1")},
+			},
+			{
+				Name:           "does not treat a qualified-alias struct field access in the select list as an upstream",
+				InputQuery:     "select t.struct_col.field from `data-engineering.testing.table1` t",
+				ExpectedTables: []string{newTable("data-engineering", "testing", "table1")},
+			},
+			{
+				Name:           "does not treat multiple comma-separated struct field accesses in the select list as upstreams",
+				InputQuery:     "select a.b.c, d.e.f from `data-engineering.testing.table1`",
+				ExpectedTables: []string{newTable("data-engineering", "testing", "table1")},
+			},
+			{
+				Name:       "still captures the second and later tables of a comma-joined from list",
+				InputQuery: "select * from `data-engineering.testing.table1`, `data-engineering.testing.table2`",
+				ExpectedTables: []string{
+					newTable("data-engineering", "testing", "table1"),
+					newTable("data-engineering", "testing", "table2"),
+				},
+			},
+			{
+				Name:       "still captures a comma-joined from list without backtick quoting",
+				InputQuery: "select * from data-engineering.testing.table1, data-engineering.testing.table2 where table1.id = table2.id",
+				ExpectedTables: []string{
+					newTable("data-engineering", "testing", "table1"),
+					newTable("data-engineering", "testing", "table2"),
+				},
+			},
+			{
+				Name:           "does not treat a struct field access in a where clause as an upstream",
+				InputQuery:     "select * from data-engineering.testing.table1 where x.y.z = 1",
+				ExpectedTables: []string{newTable("data-engineering", "testing", "table1")},
+			},
+			{
+				Name:           "does not treat a struct field access in a group by clause as an upstream",
+				InputQuery:     "select * from data-engineering.testing.table1 group by x.y.z",
+				ExpectedTables: []string{newTable("data-engineering", "testing", "table1")},
+			},
+			{
+				Name:           "does not treat a struct field access in an order by clause as an upstream",
+				InputQuery:     "select * from data-engineering.testing.table1 order by x.y.z",
+				ExpectedTables: []string{newTable("data-engineering", "testing", "table1")},
+			},
+			{
+				Name:       "does not treat a struct field access in a join's on clause as an upstream",
+				InputQuery: "select * from data-engineering.testing.table1 x join data-engineering.testing.table2 y on x.struct_field.value = y.id",
+				ExpectedTables: []string{
+					newTable("data-engineering", "testing", "table1"),
+					newTable("data-engineering", "testing", "table2"),
+				},
+			},
+			{
+				Name:       "does not leak a subquery's from-list state into the clause that encloses it",
+				InputQuery: "select * from data-engineering.testing.table1 where x in (select y from data-engineering.testing.table2) and g.h.i = 1",
+				ExpectedTables: []string{
+					newTable("data-engineering", "testing", "table1"),
+					newTable("data-engineering", "testing", "table2"),
+				},
+			},
 		}
 		for _, test := range testCases {
 			t.Run(test.Name, func(t *testing.T) {


### PR DESCRIPTION
### Summary
This PR's main change is to make the job cyclic dependency check work on a global optimus instance scale, not on tenant level only. With this change, there are also stability fixes on the optimus job validate

**Fix cyclic dependency validation to be global-scoped**
- Cyclic dependency previously works only on tenant-level due to `GetAllByTenant` jobs
- Instead of tenant only, now the cyclic checks are based on global cross-project jobs by using a new function `JobRepository.GetAllResolvedUpstreamEdges`. New detected dependencies are built using `JobService.BuildGlobalUpstreamGraph` so that cyclic dependency check will also work with newly added upstreams

**Query parser: exclude UDFs / nested struct columns to be parsed as upstreams**
- Current query parser keyword-less case (needed to support comma-joined FROM a, b, c lists) had no way to tell a genuine table reference apart from any other three-dotted expression elsewhere in the query — so SELECT a.b.c, a.d.e FROM ... picked up a.b.c and a.d.e as invalid upstream tables.