### PR TITLE
fix resource.yaml validation: required fields for struct, array, and map

### DIFF
--- a/client/jsonschema/resource.json
+++ b/client/jsonschema/resource.json
@@ -485,6 +485,42 @@
           "then": {
             "required": ["decimal"]
           }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "enum": ["array", "ARRAY"]
+              }
+            }
+          },
+          "then": {
+            "required": ["array"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "enum": ["struct", "STRUCT"]
+              }
+            }
+          },
+          "then": {
+            "required": ["struct"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "enum": ["map", "MAP"]
+              }
+            }
+          },
+          "then": {
+            "required": ["map"]
+          }
         }
       ]
     },


### PR DESCRIPTION
### Background
Previously resource spec validation of data-type specific field presence (e.g. STRUCT, ARRAY, MAP) is not there in the related jsonschema. This results in `optimus verify specs` returning valid specs for any resource schema containing those data type columns, when the schema of the above complex data types are not set.

For example, `optimus verify specs` returned valid for the below specs, but when it is applied, it will return fail due to the absence of the detail schema description for those complex data types.
```yaml
version: 2
name: project.schema.table
type: table
spec:
  project: project
  database: schema
  name: table
  schema:
  - name: sample_string_column
    description: sample string column
    type: STRING
  - name: sample_struct_column
    description: sample struct column
    type: STRUCT
  - name: sample_array_column
    description: sample struct column
    type: ARRAY
```
Validation results
```
Validating Specs (Single Spec Mode)
└─ Resource file: /resource.yaml
        └─ ✅ Valid spec
```

correct spec should be
```yaml
version: 2
name: project.schema.table
type: table
spec:
  project: project
  database: schema
  name: table
  schema:
  - name: sample_string_column
    description: sample string column
    type: STRING
  - name: sample_struct_column
    description: sample struct column
    type: STRUCT
    struct:
       - name: value_1
         type: STRING
  - name: sample_array_column
    description: sample struct column
    type: ARRAY
    array:
      type: STRING
```

### Fix
The fix is to adjust the jsonschema for resource specs so it will fail if the complex data type columns does not contain its relevant schema detail.
The resulting validation for the above wrong spec should be:
```
Validating Specs (Single Spec Mode)
└─ Resource file: /resource.yaml
        │    Invalid spec at : resource.yaml
        │      - at '': 'allOf' failed
        │        - at '/spec/schema/24': 'allOf' failed
        │          - at '/spec/schema/24': missing property 'struct'
```
