### PR TITLE
fix job validate: no error on 404 dex errors, fix different upstream schedule frequency

### DIFF
--- a/core/job/job.go
+++ b/core/job/job.go
@@ -194,11 +194,19 @@ func (j *Job) IsScheduledAfter(otherJob *Job, referenceTime time.Time) (bool, st
 	}
 
 	refTimeUTC := referenceTime.UTC()
+	subjectNext := subjectJobCron.Next(refTimeUTC)
+	otherNext := otherJobCron.Next(refTimeUTC)
 
-	subjectNextSchedule := subjectJobCron.Next(refTimeUTC)
-	otherNextSchedule := otherJobCron.Next(refTimeUTC)
+	// Only enforce precedence between daily+ jobs with the same interval.
+	// A daily job depending on a weekly job (or vice versa) has no meaningful ordering.
+	subjectInterval := subjectJobCron.Next(subjectNext).Sub(subjectNext)
+	otherInterval := otherJobCron.Next(otherNext).Sub(otherNext)
+	if subjectInterval != otherInterval {
+		return true, fmt.Sprintf("skip schedule precedence: different schedule types (subject: %s, upstream: %s)",
+			subjectCronStr, otherCronStr)
+	}
 
-	if subjectNextSchedule.Before(otherNextSchedule) {
+	if subjectNext.Before(otherNext) {
 		return false, fmt.Sprintf("current job [%s] is scheduled before job %s [%s]",
 			subjectCronStr, otherJob.FullName(), otherCronStr)
 	}

--- a/core/job/job_test.go
+++ b/core/job/job_test.go
@@ -568,6 +568,30 @@ func TestEntityJob(t *testing.T) {
 				expectedIsAfter: true,
 				expectedMessage: "current job has sub-daily schedule [0 * * * *]",
 			},
+			{
+				name:            "scheduleSubject is daily, scheduleOther is weekly — different types, skip",
+				scheduleSubject: "0 2 * * *",
+				scheduleOther:   "0 2 * * 1",
+				referenceTime:   time.Date(2022, 10, 2, 0, 0, 0, 0, time.UTC),
+				expectedIsAfter: true,
+				expectedMessage: "skip schedule precedence: different schedule types (subject: 0 2 * * *, upstream: 0 2 * * 1)",
+			},
+			{
+				name:            "scheduleSubject is weekly, scheduleOther is daily — different types, skip",
+				scheduleSubject: "0 2 * * 1",
+				scheduleOther:   "0 2 * * *",
+				referenceTime:   time.Date(2022, 10, 2, 0, 0, 0, 0, time.UTC),
+				expectedIsAfter: true,
+				expectedMessage: "skip schedule precedence: different schedule types (subject: 0 2 * * 1, upstream: 0 2 * * *)",
+			},
+			{
+				name:            "skip when both schedule are subdaily",
+				scheduleSubject: "0 18,0 * * *",
+				scheduleOther:   "0 18,0 * * *",
+				referenceTime:   time.Date(2022, 10, 2, 0, 0, 0, 0, time.UTC),
+				expectedIsAfter: true,
+				expectedMessage: "current job has sub-daily schedule [0 18,0 * * *]",
+			},
 		}
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {

--- a/core/job/resolver/dex_upstream_resolver.go
+++ b/core/job/resolver/dex_upstream_resolver.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/goto/optimus/config"
 	"github.com/goto/optimus/core/job"
+	"github.com/goto/optimus/core/resource"
 	"github.com/goto/optimus/core/scheduler/service"
 	"github.com/goto/optimus/core/tenant"
 	"github.com/goto/optimus/internal/errors"
@@ -70,6 +71,12 @@ func (u *dexUpstreamResolver) Resolve(ctx context.Context, jobWithUpstream *job.
 	unresolvedUpstreams := []*job.Upstream{}
 	thirdPartyUpstreams := []*job.ThirdPartyUpstream{}
 	for _, unresolvedUpstream := range jobWithUpstream.GetUnresolvedUpstreams() {
+		// dex should only resolve upstreams with resource URN
+		// static dependencies are not supposed to be resolved here
+		if unresolvedUpstream.Resource() == resource.ZeroURN() {
+			continue
+		}
+
 		// segregate DEX managed upstreams and non-DEX managed upstreams
 		if isDEXManaged, err := u.dexClient.IsManaged(ctx, unresolvedUpstream.Resource()); err == nil && isDEXManaged {
 			cfg := map[string]string{}

--- a/core/job/resolver/upstream_resolver.go
+++ b/core/job/resolver/upstream_resolver.go
@@ -124,7 +124,7 @@ func (u UpstreamResolver) Resolve(ctx context.Context, subjectJob *job.Job, logW
 		me.Append(err)
 	}
 
-	return jobWithInternalExternalUpstream.Upstreams(), me.ToErr()
+	return jobWithThirdPartyUpstream.Upstreams(), me.ToErr()
 }
 
 func (UpstreamResolver) getUnresolvedUpstreamsErrors(jobsWithUpstreams []*job.WithUpstream, logWriter writer.LogWriter) error {

--- a/ext/dex/dex.go
+++ b/ext/dex/dex.go
@@ -126,6 +126,11 @@ func (d *Client) isResourceManagedUntil(ctx context.Context, store, resourceURN 
 
 	if response.StatusCode != http.StatusOK {
 		d.l.Error("unexpected status response", "status", response.Status, "body", response.Body)
+		// 404 means dex couldn't associate the provided resource URN as a table (either wrong table name or passing non-table string)
+		// treat this directly as nonmanaged, but not returning error for now
+		if response.StatusCode == http.StatusNotFound {
+			return false, nil
+		}
 		return false, fmt.Errorf("unexpected status response: %s", response.Status)
 	}
 

--- a/plugin/upstream_identifier/parser/query_parser.go
+++ b/plugin/upstream_identifier/parser/query_parser.go
@@ -12,6 +12,7 @@ const (
 	eventKindKeyword    fromListEventKind = iota
 	eventKindOpenParen                    // entering a subquery
 	eventKindCloseParen                   // leaving a subquery
+	eventKindSemicolon                    // semicolon char `;`, ending a part of a scripted query
 )
 
 type fromListEvent struct {
@@ -157,7 +158,8 @@ func extractValidTable(query string, idx []int, insideFromOrJoinClause func(int)
 	clause := getClauseFromMatch(query, idx)
 	ignoreUpstreamIdx, tableIdx, isKeywordMatch := clauseGroupIndices(clause)
 
-	if strings.TrimSpace(groupText(query, idx, ignoreUpstreamIdx)) == "@ignoreupstream" {
+	ignoreUpstreamClause := groupText(query, idx, ignoreUpstreamIdx)
+	if strings.TrimSpace(ignoreUpstreamClause) == "@ignoreupstream" {
 		return "", false
 	}
 	if isWriteOnlyClause(clause) {
@@ -167,7 +169,8 @@ func extractValidTable(query string, idx []int, insideFromOrJoinClause func(int)
 		return "", false
 	}
 
-	return cleanTableFromTickQuote(groupText(query, idx, tableIdx)), clause == "with"
+	tableName := groupText(query, idx, tableIdx)
+	return cleanTableFromTickQuote(tableName), clause == "with"
 }
 
 func getClauseFromMatch(query string, upstreamMatchIdx []int) string {
@@ -225,6 +228,8 @@ func buildParenthesesEvents(query string) []fromListEvent {
 			events = append(events, fromListEvent{pos: i, kind: eventKindOpenParen})
 		case ')':
 			events = append(events, fromListEvent{pos: i, kind: eventKindCloseParen})
+		case ';':
+			events = append(events, fromListEvent{pos: i, kind: eventKindSemicolon})
 		}
 	}
 
@@ -247,7 +252,7 @@ func buildFromListStateIndex(events []fromListEvent) (positions []int, states []
 		case eventKindOpenParen:
 			scopeStack = append(scopeStack, active)
 			active = false
-		case eventKindCloseParen:
+		case eventKindCloseParen, eventKindSemicolon:
 			if len(scopeStack) > 0 {
 				active = scopeStack[len(scopeStack)-1]
 				scopeStack = scopeStack[:len(scopeStack)-1]

--- a/plugin/upstream_identifier/parser/query_parser_test.go
+++ b/plugin/upstream_identifier/parser/query_parser_test.go
@@ -392,6 +392,23 @@ func TestParseTopLevelUpstreamsFromQuery(t *testing.T) {
 					newTable("data-engineering", "testing", "table2"),
 				},
 			},
+			{
+				Name: "query containing multiple variable assignments does not extract the nested columns as parsed table",
+				InputQuery: `
+				@select_result := select * from data-engineering.testing.table1 where value in
+					(select name from data-engineering.testing.table2);
+
+				@select_result_2 := select * from data-engineering.testing.table1 tb1,
+				(select value from data-engineering.testing.table3) tb3 where tb1.name = tb3.value;
+
+				select a.b.c, a.b.d from @select_result join @select_result_2;
+				`,
+				ExpectedTables: []string{
+					newTable("data-engineering", "testing", "table1"),
+					newTable("data-engineering", "testing", "table2"),
+					newTable("data-engineering", "testing", "table3"),
+				},
+			},
 		}
 		for _, test := range testCases {
 			t.Run(test.Name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
### Fix Third Party Resolver: Use Final Return State and Skip ZeroURN resources
1. Fix upstreamResolver.Resolve() function to return the final upstream states after thirdPartyResolver.Resolve() function
2. In case of resource containing ZeroURN (empty resource URN, for example static upstreams), do not check to dex
3. In case of Dex returning 404, treat it as non-managed resources, making this behavior consistent with MC tables that are not managed by dex (200 OK with managed = false)

### Fix Validate Upstream Schedule
1. In case of different schedule frequency, validateUpstreamSchedule in some cases will return error which confuses the user (e.g., for case `0 18 * * *` depending on `0 20 1 * *`, schedule precedence will fail because the generated next timestamp for monthly runs will bypass next run for daily)
2. This makes the schedule check only works on same schedule & reinforcing schedule precedence only on matching schedules

### Fix Query Parser: Treat semicolon `;` equally as closing parentheses (ending scope)
1. Fix is to add semicolon encounter case to the closing parentheses check, which means that the states are reset anew.