### PR TITLE
feat: optimus-airflow sync

### DIFF
--- a/config/config_server.go
+++ b/config/config_server.go
@@ -152,15 +152,17 @@ type BackfillConfig struct {
 // docs/docs/rfcs/20260727_manual_state_override_reconciliation.md. A zero
 // WindowIntervalInSeconds disables the worker entirely (see server/optimus.go), so unlike
 // most fields here it deliberately has no `default` tag: the feature must be opted into.
+// Retry policy, catch-up throttling, and boundary/commit-lag margins are fixed constants in
+// core/scheduler/service/airflow_state_sync_worker.go rather than config here -- they are not
+// properties of a particular deployment, only WindowInterval/LockDuration/concurrency/scope
+// are.
 type AirflowSyncConfig struct {
-	WindowIntervalInSeconds  int `mapstructure:"window_interval_in_seconds"`
-	SettlingDelayInSeconds   int `mapstructure:"settling_delay_in_seconds" default:"60"`
-	LockDurationInSeconds    int `mapstructure:"lock_duration_in_seconds" default:"300"`
-	InitialLookbackInSeconds int `mapstructure:"initial_lookback_in_seconds" default:"3600"`
-	OverlapEpsilonInSeconds  int `mapstructure:"overlap_epsilon_in_seconds" default:"2"`
-	MaxAttempts              int `mapstructure:"max_attempts" default:"3"`
-	MaxWindowsPerTick        int `mapstructure:"max_windows_per_tick" default:"6"`
-	MaxConcurrentProjects    int `mapstructure:"max_concurrent_projects" default:"5"`
+	WindowIntervalInSeconds int `mapstructure:"window_interval_in_seconds"`
+	LockDurationInSeconds   int `mapstructure:"lock_duration_in_seconds" default:"300"`
+	MaxConcurrentProjects   int `mapstructure:"max_concurrent_projects" default:"5"`
+	MaxAttempts             int `mapstructure:"max_attempts" default:"3"`
+	// ExcludeProjects lists project names to never sync. Every project is synced by default.
+	ExcludeProjects []string `mapstructure:"exclude_projects"`
 }
 
 type Publisher struct {

--- a/config/config_server.go
+++ b/config/config_server.go
@@ -27,6 +27,7 @@ type ServerConfig struct {
 	JobValidationConfig       JobValidationConfig       `mapstructure:"job_validation"`
 	JobExpectatorConfig       JobExpectatorConfig       `mapstructure:"job_expectator"`
 	JobExecutionSummaryConfig JobExecutionSummaryConfig `mapstructure:"job_execution_summary"`
+	AirflowSync               AirflowSyncConfig         `mapstructure:"airflow_sync"`
 }
 
 type UpstreamResolver struct {
@@ -145,6 +146,20 @@ type ReplayConfig struct {
 
 type BackfillConfig struct {
 	ExecutionIntervalInSeconds int `mapstructure:"execution_interval_in_seconds" default:"300"`
+}
+
+// AirflowSyncConfig drives the manual-state-override reconciliation worker -- see
+// docs/docs/rfcs/20260727_manual_state_override_reconciliation.md. A zero
+// WindowIntervalInSeconds disables the worker entirely (see server/optimus.go), so unlike
+// most fields here it deliberately has no `default` tag: the feature must be opted into.
+type AirflowSyncConfig struct {
+	WindowIntervalInSeconds  int `mapstructure:"window_interval_in_seconds"`
+	SettlingDelayInSeconds   int `mapstructure:"settling_delay_in_seconds" default:"60"`
+	LockDurationInSeconds    int `mapstructure:"lock_duration_in_seconds" default:"300"`
+	InitialLookbackInSeconds int `mapstructure:"initial_lookback_in_seconds" default:"3600"`
+	OverlapEpsilonInSeconds  int `mapstructure:"overlap_epsilon_in_seconds" default:"2"`
+	MaxAttempts              int `mapstructure:"max_attempts" default:"3"`
+	MaxWindowsPerTick        int `mapstructure:"max_windows_per_tick" default:"6"`
 }
 
 type Publisher struct {

--- a/config/config_server.go
+++ b/config/config_server.go
@@ -160,6 +160,7 @@ type AirflowSyncConfig struct {
 	OverlapEpsilonInSeconds  int `mapstructure:"overlap_epsilon_in_seconds" default:"2"`
 	MaxAttempts              int `mapstructure:"max_attempts" default:"3"`
 	MaxWindowsPerTick        int `mapstructure:"max_windows_per_tick" default:"6"`
+	MaxConcurrentProjects    int `mapstructure:"max_concurrent_projects" default:"5"`
 }
 
 type Publisher struct {

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -331,13 +331,9 @@ func (s *ConfigTestSuite) initExpectedServerConfig() {
 	s.expectedServerConfig.Backfill.ExecutionIntervalInSeconds = 300
 
 	s.expectedServerConfig.AirflowSync = config.AirflowSyncConfig{
-		SettlingDelayInSeconds:   60,
-		LockDurationInSeconds:    300,
-		InitialLookbackInSeconds: 3600,
-		OverlapEpsilonInSeconds:  2,
-		MaxAttempts:              3,
-		MaxWindowsPerTick:        6,
-		MaxConcurrentProjects:    5,
+		LockDurationInSeconds: 300,
+		MaxConcurrentProjects: 5,
+		MaxAttempts:           3,
 	}
 }
 

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -337,6 +337,7 @@ func (s *ConfigTestSuite) initExpectedServerConfig() {
 		OverlapEpsilonInSeconds:  2,
 		MaxAttempts:              3,
 		MaxWindowsPerTick:        6,
+		MaxConcurrentProjects:    5,
 	}
 }
 

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -329,6 +329,15 @@ func (s *ConfigTestSuite) initExpectedServerConfig() {
 		},
 	}
 	s.expectedServerConfig.Backfill.ExecutionIntervalInSeconds = 300
+
+	s.expectedServerConfig.AirflowSync = config.AirflowSyncConfig{
+		SettlingDelayInSeconds:   60,
+		LockDurationInSeconds:    300,
+		InitialLookbackInSeconds: 3600,
+		OverlapEpsilonInSeconds:  2,
+		MaxAttempts:              3,
+		MaxWindowsPerTick:        6,
+	}
 }
 
 func (*ConfigTestSuite) initServerConfigEnv() {

--- a/core/scheduler/airflow_sync.go
+++ b/core/scheduler/airflow_sync.go
@@ -1,0 +1,171 @@
+package scheduler
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/goto/optimus/core/tenant"
+	"github.com/goto/optimus/internal/errors"
+)
+
+// EntityAirflowSync is used for error wrapping across the manual-state-override
+// reconciliation feature (see docs/docs/rfcs/20260727_manual_state_override_reconciliation.md).
+const EntityAirflowSync = "airflowSync"
+
+// Airflow run_id prefixes the manual-state-override reconciler recognises. This is an
+// allow-list, not a deny-list -- an unrecognised prefix is skipped and counted
+// (reason="run_type"), never guessed at, so an Airflow convention we haven't seen gets
+// noticed rather than mis-parsed. Shared between ext/scheduler/airflow (which filters on
+// these) and this package's ExecutionDate (which parses them), so the convention lives in
+// exactly one place.
+//
+// Originally only RunIDScheduledPrefix was in scope, out of concern that the replay/backfill
+// workers might race the reconciler writing to the same job_run/task_run rows. That concern
+// didn't hold up: replayRepo/backfillRepo only ever write to their own tracking tables
+// (replay_request/replay_run, backfill) -- job_run/task_run/sensor_run/hook_run are updated
+// exclusively via the normal Airflow callback path regardless of whether a run was
+// scheduled, replayed, or backfilled. So the only race here is the same one that already
+// exists for scheduled__ runs (a normal callback landing around the same time as a manual
+// override), which the updated_at freshness check already covers.
+const (
+	RunIDScheduledPrefix      = "scheduled__"
+	RunIDManualPrefix         = "manual__"
+	RunIDReplayedPrefix       = "replayed__"
+	RunIDCustomBackfillPrefix = "custom-backfill_"
+)
+
+var runIDPrefixes = []string{RunIDScheduledPrefix, RunIDManualPrefix, RunIDReplayedPrefix, RunIDCustomBackfillPrefix}
+
+// HasRecognisedRunIDPrefix reports whether RunID matches one of the run_id conventions this
+// reconciler knows how to parse. Callers (ext/scheduler/airflow's GetEventLogs) should skip
+// and count anything that doesn't match, rather than attempt ExecutionDate on it.
+func (m ManualOverrideEvent) HasRecognisedRunIDPrefix() bool {
+	for _, p := range runIDPrefixes {
+		if strings.HasPrefix(m.RunID, p) {
+			return true
+		}
+	}
+	return false
+}
+
+type AirflowSyncStatus string
+
+const (
+	AirflowSyncInProgress AirflowSyncStatus = "in_progress"
+	AirflowSyncSuccess    AirflowSyncStatus = "success"
+	AirflowSyncFailed     AirflowSyncStatus = "failed"
+)
+
+func (s AirflowSyncStatus) String() string {
+	return string(s)
+}
+
+// AirflowSyncWindow is one claimed [StartTime, EndTime) slice of an Airflow project's
+// audit log that a worker has processed, or is processing. The composite
+// (ProjectName, StartTime, EndTime) is the claim itself: a row existing at all means some
+// worker already owns or has finished that window, so callers should INSERT ... ON
+// CONFLICT DO NOTHING rather than read-then-write.
+type AirflowSyncWindow struct {
+	ID          uuid.UUID
+	ProjectName tenant.ProjectName
+	StartTime   time.Time
+	EndTime     time.Time
+
+	Status       AirflowSyncStatus
+	AttemptCount int
+	LastError    string
+
+	// WorkerID/LockedUntil fence a crashed worker: a window left InProgress past
+	// LockedUntil is re-claimable by another replica, and only the replica whose
+	// WorkerID still matches may mark it Success/Failed.
+	WorkerID    uuid.UUID
+	LockedUntil time.Time
+
+	// Observability only, not required for correctness. RunsReconciled deliberately
+	// separate from EventsMatched: matched>0 with reconciled=0 means resolution is
+	// silently broken (unknown dag_id, croniter shift mismatch, no matching job_run, ...).
+	MaxProcessedLogID int64
+	EventsMatched     int
+	RunsReconciled    int
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// ManualOverrideEvent is a single Airflow `log` row identified as a human-driven state
+// change: a bare success/failed/dagrun_success/dagrun_failed event (the legacy `www` mark
+// endpoints the Airflow 2.9 grid UI posts to) with the confirmed=true extra JSON.
+// See the RFC for why this is sufficient to distinguish it from an ordinary worker
+// transition (which never has extra populated at all) without needing owner_display_name,
+// which the eventLogs REST API does not expose.
+type ManualOverrideEvent struct {
+	LogID int64
+	Event string // one of: success, failed, dagrun_success, dagrun_failed
+
+	DagID  string
+	TaskID string // empty for dagrun_* events
+	RunID  string // e.g. "scheduled__2026-07-24T18:00:00+00:00" -- see runIDPrefixes for recognised shapes
+
+	Owner string
+	When  time.Time
+}
+
+// IsDagRunLevel reports whether this event targets the whole DAG run rather than a
+// single task instance.
+func (m ManualOverrideEvent) IsDagRunLevel() bool {
+	return m.Event == "dagrun_success" || m.Event == "dagrun_failed"
+}
+
+// ExecutionDate parses the Airflow execution_date embedded in RunID. RunID is expected to
+// carry one of runIDPrefixes already -- ext/scheduler/airflow's GetEventLogs only returns
+// events matching HasRecognisedRunIDPrefix -- so this only needs to strip the prefix and
+// parse the remaining timestamp.
+//
+// custom-backfill_ is the one irregular shape: it embeds a UUID before the timestamp
+// (custom-backfill_<uuid>__<timestamp>), so it splits on the *last* "__" rather than
+// stripping a fixed prefix. That's safe because a UUID's hyphens never produce a literal
+// "__", confirmed against a real run_id
+// (custom-backfill_76515cc3-b3aa-440f-b998-04e6f4935ea3__2026-07-25T09:38:53+00:00).
+func (m ManualOverrideEvent) ExecutionDate() (time.Time, error) {
+	raw := m.RunID
+	switch {
+	case strings.HasPrefix(raw, RunIDCustomBackfillPrefix):
+		idx := strings.LastIndex(raw, "__")
+		if idx < 0 {
+			return time.Time{}, errors.InvalidArgument(EntityAirflowSync, fmt.Sprintf("malformed custom-backfill run_id %q: no timestamp separator", raw))
+		}
+		raw = raw[idx+2:]
+	case strings.HasPrefix(raw, RunIDScheduledPrefix):
+		raw = strings.TrimPrefix(raw, RunIDScheduledPrefix)
+	case strings.HasPrefix(raw, RunIDManualPrefix):
+		raw = strings.TrimPrefix(raw, RunIDManualPrefix)
+	case strings.HasPrefix(raw, RunIDReplayedPrefix):
+		raw = strings.TrimPrefix(raw, RunIDReplayedPrefix)
+	default:
+		return time.Time{}, errors.InvalidArgument(EntityAirflowSync, "unrecognised run_id prefix: "+raw)
+	}
+
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, errors.InvalidArgument(EntityAirflowSync, fmt.Sprintf("unparseable execution date in run_id %q: %s", m.RunID, err))
+	}
+	return t, nil
+}
+
+// TargetState is the state the manual action set. For the four bare legacy-endpoint
+// events this is encoded directly in the event name itself -- unlike the REST /api/v1
+// endpoints (api.patch_task_instance etc., out of scope for v1), the target state there is
+// not in the event name and must be parsed out of `extra["new_state"]`/`extra["state"]`.
+func (m ManualOverrideEvent) TargetState() (State, error) {
+	switch m.Event {
+	case "success", "dagrun_success":
+		return StateSuccess, nil
+	case "failed", "dagrun_failed":
+		return StateFailed, nil
+	default:
+		return "", errors.InvalidArgument(EntityAirflowSync, "unrecognized manual override event: "+m.Event)
+	}
+}

--- a/core/scheduler/airflow_sync.go
+++ b/core/scheduler/airflow_sync.go
@@ -40,7 +40,7 @@ const (
 var runIDPrefixes = []string{RunIDScheduledPrefix, RunIDManualPrefix, RunIDReplayedPrefix, RunIDCustomBackfillPrefix}
 
 // HasRecognisedRunIDPrefix reports whether RunID matches one of the run_id conventions this
-// reconciler knows how to parse. Callers (ext/scheduler/airflow's GetEventLogs) should skip
+// reconciler knows how to parse. Callers (ext/scheduler/airflow's GetManualEventLogs) should skip
 // and count anything that doesn't match, rather than attempt ExecutionDate on it.
 func (m ManualOverrideEvent) HasRecognisedRunIDPrefix() bool {
 	for _, p := range runIDPrefixes {
@@ -98,9 +98,6 @@ type AirflowSyncWindow struct {
 // ManualOverrideEvent is a single Airflow `log` row identified as a human-driven state
 // change: a bare success/failed/dagrun_success/dagrun_failed event (the legacy `www` mark
 // endpoints the Airflow 2.9 grid UI posts to) with the confirmed=true extra JSON.
-// See the RFC for why this is sufficient to distinguish it from an ordinary worker
-// transition (which never has extra populated at all) without needing owner_display_name,
-// which the eventLogs REST API does not expose.
 type ManualOverrideEvent struct {
 	LogID int64
 	Event string // one of: success, failed, dagrun_success, dagrun_failed
@@ -120,7 +117,7 @@ func (m ManualOverrideEvent) IsDagRunLevel() bool {
 }
 
 // ExecutionDate parses the Airflow execution_date embedded in RunID. RunID is expected to
-// carry one of runIDPrefixes already -- ext/scheduler/airflow's GetEventLogs only returns
+// carry one of runIDPrefixes already -- ext/scheduler/airflow's GetManualEventLogs only returns
 // events matching HasRecognisedRunIDPrefix -- so this only needs to strip the prefix and
 // parse the remaining timestamp.
 //

--- a/core/scheduler/job.go
+++ b/core/scheduler/job.go
@@ -49,6 +49,13 @@ const (
 	OperatorSensor OperatorType = "sensor"
 	OperatorHook   OperatorType = "hook"
 
+	// airflowSensorTaskIDPrefix / airflowHookTaskIDPrefix mirror the task_id naming
+	// convention the DAG templates use (ext/scheduler/airflow/dag/template/*.tmpl) and
+	// that __lib.py's get_run_type classifies on. Anything without either prefix is the
+	// main transformation task.
+	airflowSensorTaskIDPrefix = "wait_"
+	airflowHookTaskIDPrefix   = "hook_"
+
 	UpstreamTypeStatic   = "static"
 	UpstreamTypeInferred = "inferred"
 )
@@ -106,6 +113,22 @@ func (j *Job) GetHookAlertConfigByName(hookName string) *OperatorAlertConfig {
 		}
 	}
 	return nil
+}
+
+// OperatorTypeFromTaskID classifies a raw Airflow task_id by the same convention
+// __lib.py's get_run_type uses: a "wait_" prefix is a sensor, a "hook_" prefix is a
+// hook, anything else is the main task. There is deliberately no error return -- every
+// task_id classifies to something, unlike NewOperatorType which validates an explicit
+// operator-type string.
+func OperatorTypeFromTaskID(taskID string) OperatorType {
+	switch {
+	case strings.HasPrefix(taskID, airflowSensorTaskIDPrefix):
+		return OperatorSensor
+	case strings.HasPrefix(taskID, airflowHookTaskIDPrefix):
+		return OperatorHook
+	default:
+		return OperatorTask
+	}
 }
 
 func (j *Job) GetOperatorAlertConfigByName(operatorType OperatorType, operatorName string) *OperatorAlertConfig {

--- a/core/scheduler/job_run.go
+++ b/core/scheduler/job_run.go
@@ -47,6 +47,12 @@ type JobRun struct {
 	WindowEnd     *time.Time
 	SLADefinition int64
 
+	// UpdatedAt is only populated by GetByScheduledAt today, not every JobRunRepository
+	// method -- it exists for the airflow-sync reconciler to compare against an external
+	// change's timestamp so a stale write never overwrites fresher data. Don't assume it is
+	// set on a JobRun obtained from another method.
+	UpdatedAt time.Time
+
 	Monitoring map[string]any
 }
 
@@ -70,6 +76,9 @@ type OperatorRun struct {
 	Status       State
 	StartTime    time.Time
 	EndTime      *time.Time
+
+	// UpdatedAt is only populated by GetOperatorRun today. See JobRun.UpdatedAt for why.
+	UpdatedAt time.Time
 }
 
 type AlertAttrs struct {

--- a/core/scheduler/service/airflow_state_sync_service.go
+++ b/core/scheduler/service/airflow_state_sync_service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/goto/salt/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -18,32 +17,9 @@ import (
 
 // AirflowEventLogFetcher is satisfied by *ext/scheduler/airflow.Scheduler. Declared here
 // rather than imported, matching this package's existing convention of declaring narrow
-// interfaces where they're used (see JobRepository/JobRunRepository above in
-// job_run_service.go).
+// interfaces where they're used.
 type AirflowEventLogFetcher interface {
 	GetManualEventLogs(ctx context.Context, projectName tenant.ProjectName, after, before time.Time) ([]scheduler.ManualOverrideEvent, error)
-}
-
-// AirflowSyncJobRepository is the subset of the wider JobRepository the reconciler needs.
-type AirflowSyncJobRepository interface {
-	GetJobDetails(ctx context.Context, projectName tenant.ProjectName, jobName scheduler.JobName) (*scheduler.JobWithDetails, error)
-}
-
-// AirflowSyncJobRunRepository is deliberately narrower than JobRunRepository: reconciliation
-// never creates a job_run row (see the RFC's write-scope rules -- v1 does not fabricate rows
-// or timing for runs Optimus never saw), so only GetByScheduledAt/Update are needed.
-type AirflowSyncJobRunRepository interface {
-	GetByScheduledAt(ctx context.Context, tnnt tenant.Tenant, jobName scheduler.JobName, scheduledAt time.Time) (*scheduler.JobRun, error)
-	Update(ctx context.Context, jobRunID uuid.UUID, endTime time.Time, status scheduler.State) error
-}
-
-// AirflowSyncOperatorRunRepository mirrors the same non-creating restriction as
-// AirflowSyncJobRunRepository, plus ListLatestOperatorRunsByJobRunID which the dagrun-level
-// cascade needs to see every child's current status before deciding what to touch.
-type AirflowSyncOperatorRunRepository interface {
-	GetOperatorRun(ctx context.Context, name string, operatorType scheduler.OperatorType, jobRunID uuid.UUID) (*scheduler.OperatorRun, error)
-	ListLatestOperatorRunsByJobRunID(ctx context.Context, operatorType scheduler.OperatorType, jobRunID uuid.UUID) ([]*scheduler.OperatorRun, error)
-	UpdateOperatorRun(ctx context.Context, operatorType scheduler.OperatorType, operatorRunID uuid.UUID, eventTime time.Time, state scheduler.State) error
 }
 
 var (
@@ -66,14 +42,14 @@ type AirflowStateSyncService struct {
 	l log.Logger
 
 	eventLogFetcher AirflowEventLogFetcher
-	jobRepo         AirflowSyncJobRepository
-	jobRunRepo      AirflowSyncJobRunRepository
-	operatorRunRepo AirflowSyncOperatorRunRepository
+	jobRepo         JobRepository
+	jobRunRepo      JobRunRepository
+	operatorRunRepo OperatorRunRepository
 	eventHandler    EventHandler
 }
 
-func NewAirflowStateSyncService(l log.Logger, eventLogFetcher AirflowEventLogFetcher, jobRepo AirflowSyncJobRepository,
-	jobRunRepo AirflowSyncJobRunRepository, operatorRunRepo AirflowSyncOperatorRunRepository, eventHandler EventHandler,
+func NewAirflowStateSyncService(l log.Logger, eventLogFetcher AirflowEventLogFetcher, jobRepo JobRepository,
+	jobRunRepo JobRunRepository, operatorRunRepo OperatorRunRepository, eventHandler EventHandler,
 ) *AirflowStateSyncService {
 	return &AirflowStateSyncService{
 		l:               l,

--- a/core/scheduler/service/airflow_state_sync_service.go
+++ b/core/scheduler/service/airflow_state_sync_service.go
@@ -1,0 +1,305 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/goto/salt/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/goto/optimus/core/event"
+	"github.com/goto/optimus/core/event/moderator"
+	"github.com/goto/optimus/core/scheduler"
+	"github.com/goto/optimus/core/tenant"
+	"github.com/goto/optimus/internal/errors"
+)
+
+// AirflowEventLogFetcher is satisfied by *ext/scheduler/airflow.Scheduler. Declared here
+// rather than imported, matching this package's existing convention of declaring narrow
+// interfaces where they're used (see JobRepository/JobRunRepository above in
+// job_run_service.go).
+type AirflowEventLogFetcher interface {
+	GetEventLogs(ctx context.Context, projectName tenant.ProjectName, after, before time.Time) ([]scheduler.ManualOverrideEvent, error)
+}
+
+// AirflowSyncJobRepository is the subset of the wider JobRepository the reconciler needs.
+type AirflowSyncJobRepository interface {
+	GetJobDetails(ctx context.Context, projectName tenant.ProjectName, jobName scheduler.JobName) (*scheduler.JobWithDetails, error)
+}
+
+// AirflowSyncJobRunRepository is deliberately narrower than JobRunRepository: reconciliation
+// never creates a job_run row (see the RFC's write-scope rules -- v1 does not fabricate rows
+// or timing for runs Optimus never saw), so only GetByScheduledAt/Update are needed.
+type AirflowSyncJobRunRepository interface {
+	GetByScheduledAt(ctx context.Context, tnnt tenant.Tenant, jobName scheduler.JobName, scheduledAt time.Time) (*scheduler.JobRun, error)
+	Update(ctx context.Context, jobRunID uuid.UUID, endTime time.Time, status scheduler.State) error
+}
+
+// AirflowSyncOperatorRunRepository mirrors the same non-creating restriction as
+// AirflowSyncJobRunRepository, plus ListLatestOperatorRunsByJobRunID which the dagrun-level
+// cascade needs to see every child's current status before deciding what to touch.
+type AirflowSyncOperatorRunRepository interface {
+	GetOperatorRun(ctx context.Context, name string, operatorType scheduler.OperatorType, jobRunID uuid.UUID) (*scheduler.OperatorRun, error)
+	ListLatestOperatorRunsByJobRunID(ctx context.Context, operatorType scheduler.OperatorType, jobRunID uuid.UUID) ([]*scheduler.OperatorRun, error)
+	UpdateOperatorRun(ctx context.Context, operatorType scheduler.OperatorType, operatorRunID uuid.UUID, eventTime time.Time, state scheduler.State) error
+}
+
+var (
+	airflowSyncReconciledTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "airflow_state_reconciled_total",
+		Help: "run rows overwritten by the manual-state-override reconciler, by originating airflow event and the state it was set to",
+	}, []string{"project", "event", "to_state"})
+
+	// airflowSyncSkippedTotal is the load-bearing observability signal for this feature:
+	// without it, "no manual overrides found" and "N found but every one was skipped" are
+	// indistinguishable, which defeats the point of a feature whose job is to stop false
+	// positives silently persisting. See the RFC's per-scope-decision skip reasons.
+	airflowSyncSkippedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "airflow_state_reconcile_skipped_total",
+		Help: "airflow manual-override audit rows the reconciler chose not to act on, by reason",
+	}, []string{"project", "reason"})
+)
+
+type AirflowStateSyncService struct {
+	l log.Logger
+
+	eventLogFetcher AirflowEventLogFetcher
+	jobRepo         AirflowSyncJobRepository
+	jobRunRepo      AirflowSyncJobRunRepository
+	operatorRunRepo AirflowSyncOperatorRunRepository
+	eventHandler    EventHandler
+}
+
+func NewAirflowStateSyncService(l log.Logger, eventLogFetcher AirflowEventLogFetcher, jobRepo AirflowSyncJobRepository,
+	jobRunRepo AirflowSyncJobRunRepository, operatorRunRepo AirflowSyncOperatorRunRepository, eventHandler EventHandler,
+) *AirflowStateSyncService {
+	return &AirflowStateSyncService{
+		l:               l,
+		eventLogFetcher: eventLogFetcher,
+		jobRepo:         jobRepo,
+		jobRunRepo:      jobRunRepo,
+		operatorRunRepo: operatorRunRepo,
+		eventHandler:    eventHandler,
+	}
+}
+
+// ReconcileWindowResult feeds the airflow_sync_state observability columns (see the
+// repository/RFC) so a gap between EventsMatched and RunsReconciled is visible without
+// having to cross-reference metrics against a specific window.
+type ReconcileWindowResult struct {
+	MaxProcessedLogID *int64
+	EventsMatched     int
+	RunsReconciled    int
+}
+
+// ReconcileWindow fetches every manual override in [startTime, endTime) for the project and
+// applies the ones that pass the write-scope rules in
+// docs/docs/rfcs/20260727_manual_state_override_reconciliation.md. A per-event error is
+// logged and skipped rather than aborting the whole window, since one bad row should not
+// block every other row in the same window from being reconciled.
+func (s *AirflowStateSyncService) ReconcileWindow(ctx context.Context, projectName tenant.ProjectName, startTime, endTime time.Time) (ReconcileWindowResult, error) {
+	events, err := s.eventLogFetcher.GetEventLogs(ctx, projectName, startTime, endTime)
+	if err != nil {
+		return ReconcileWindowResult{}, errors.Wrap(scheduler.EntityAirflowSync, "error fetching airflow event logs", err)
+	}
+
+	result := ReconcileWindowResult{EventsMatched: len(events)}
+	// Cache job details per window: several events for the same job in one window (e.g. a
+	// task mark followed by a dagrun mark) should not re-fetch the job spec each time.
+	jobDetailsCache := map[scheduler.JobName]*scheduler.JobWithDetails{}
+
+	for i := range events {
+		evt := events[i]
+		if result.MaxProcessedLogID == nil || evt.LogID > *result.MaxProcessedLogID {
+			logID := evt.LogID
+			result.MaxProcessedLogID = &logID
+		}
+
+		reconciled, err := s.reconcileEvent(ctx, projectName, evt, jobDetailsCache)
+		if err != nil {
+			s.l.Warn("error reconciling manual override event_log_id [%d] for dag [%s]: %s", evt.LogID, evt.DagID, err)
+			continue
+		}
+		if reconciled {
+			result.RunsReconciled++
+		}
+	}
+	return result, nil
+}
+
+func (s *AirflowStateSyncService) reconcileEvent(ctx context.Context, projectName tenant.ProjectName, evt scheduler.ManualOverrideEvent, jobDetailsCache map[scheduler.JobName]*scheduler.JobWithDetails) (bool, error) {
+	skip := func(reason string) (bool, error) {
+		airflowSyncSkippedTotal.WithLabelValues(projectName.String(), reason).Inc()
+		return false, nil
+	}
+
+	jobName, err := scheduler.JobNameFrom(evt.DagID)
+	if err != nil {
+		return skip("invalid_dag_id")
+	}
+
+	jobDetails, ok := jobDetailsCache[jobName]
+	if !ok {
+		jobDetails, err = s.jobRepo.GetJobDetails(ctx, projectName, jobName)
+		if err != nil {
+			if errors.IsErrorType(err, errors.ErrNotFound) {
+				return skip("unknown_job")
+			}
+			return false, err
+		}
+		jobDetailsCache[jobName] = jobDetails
+	}
+	if jobDetails.Schedule == nil {
+		return skip("no_schedule")
+	}
+
+	executionDate, err := evt.ExecutionDate()
+	if err != nil {
+		return skip("unparseable_run_id")
+	}
+	// Mirrors __lib.py's get_scheduled_at: Airflow's execution_date is not Optimus's
+	// scheduled_at, it is the *previous* tick. Skipping this shift lands every reconciled
+	// row one interval off.
+	scheduledAt, err := jobDetails.Schedule.GetNextSchedule(executionDate)
+	if err != nil {
+		return skip("schedule_shift_error")
+	}
+
+	targetState, err := evt.TargetState()
+	if err != nil {
+		return skip("unrecognized_event")
+	}
+
+	jobRun, err := s.jobRunRepo.GetByScheduledAt(ctx, jobDetails.Job.Tenant, jobName, scheduledAt)
+	if err != nil {
+		if errors.IsErrorType(err, errors.ErrNotFound) {
+			// v1 does not create job_run rows -- nothing to reconcile against.
+			return skip("no_job_run")
+		}
+		return false, err
+	}
+
+	// Never regress fresher data: a callback may have landed after the manual action.
+	if !jobRun.UpdatedAt.IsZero() && jobRun.UpdatedAt.After(evt.When) {
+		return skip("stale_event")
+	}
+
+	if evt.IsDagRunLevel() {
+		return s.reconcileDagRun(ctx, projectName, evt, jobRun, targetState)
+	}
+	return s.reconcileTask(ctx, projectName, evt, jobRun, targetState)
+}
+
+// reconcileDagRun handles dagrun_success/dagrun_failed. It mirrors Airflow's own asymmetric
+// cascade (airflow/api/common/mark_tasks.py, see the RFC's finding V5) rather than force-
+// setting every child: set_dag_run_state_to_success sets every task instance to success,
+// but set_dag_run_state_to_failed only touches non-terminal instances and leaves already-
+// finished ones alone. Blindly overwriting a genuinely-successful task to failed would
+// corrupt the duration/percentile history the SLA predictor depends on.
+func (s *AirflowStateSyncService) reconcileDagRun(ctx context.Context, projectName tenant.ProjectName, evt scheduler.ManualOverrideEvent, jobRun *scheduler.JobRun, targetState scheduler.State) (bool, error) {
+	anyChanged := false
+
+	if jobRun.State != targetState {
+		if err := s.jobRunRepo.Update(ctx, jobRun.ID, evt.When, targetState); err != nil {
+			return false, err
+		}
+		anyChanged = true
+		airflowSyncReconciledTotal.WithLabelValues(projectName.String(), evt.Event, targetState.String()).Inc()
+
+		reconciledJobRun := *jobRun
+		reconciledJobRun.State = targetState
+		s.emitJobRunStateChange(&reconciledJobRun)
+	}
+
+	for _, operatorType := range []scheduler.OperatorType{scheduler.OperatorTask, scheduler.OperatorSensor, scheduler.OperatorHook} {
+		children, err := s.operatorRunRepo.ListLatestOperatorRunsByJobRunID(ctx, operatorType, jobRun.ID)
+		if err != nil {
+			s.l.Warn("error listing %s runs for job run [%s] dagrun cascade: %s", operatorType, jobRun.ID, err)
+			continue
+		}
+		for _, child := range children {
+			if child.Status == targetState {
+				continue
+			}
+			if targetState == scheduler.StateFailed && child.Status.IsTerminal() {
+				// leaves already-terminal tasks alone, matching set_dag_run_state_to_failed
+				continue
+			}
+			if !child.UpdatedAt.IsZero() && child.UpdatedAt.After(evt.When) {
+				continue
+			}
+			if err := s.operatorRunRepo.UpdateOperatorRun(ctx, operatorType, child.ID, evt.When, targetState); err != nil {
+				s.l.Warn("error cascading dagrun state to %s run [%s]: %s", operatorType, child.ID, err)
+				continue
+			}
+			anyChanged = true
+			airflowSyncReconciledTotal.WithLabelValues(projectName.String(), evt.Event, targetState.String()).Inc()
+		}
+	}
+
+	return anyChanged, nil
+}
+
+// reconcileTask handles the single-task success/failed events. Unlike the dagrun cascade,
+// a direct task-level mark is an explicit override of that one task, so it applies
+// regardless of the task's current state (subject only to the already-matches and
+// freshness checks) -- there is no "leave terminal tasks alone" rule here, that rule exists
+// specifically for a dagrun-level side effect touching tasks the human did not target.
+func (s *AirflowStateSyncService) reconcileTask(ctx context.Context, projectName tenant.ProjectName, evt scheduler.ManualOverrideEvent, jobRun *scheduler.JobRun, targetState scheduler.State) (bool, error) {
+	if evt.TaskID == "" {
+		airflowSyncSkippedTotal.WithLabelValues(projectName.String(), "missing_task_id").Inc()
+		return false, nil
+	}
+	operatorType := scheduler.OperatorTypeFromTaskID(evt.TaskID)
+
+	operatorRun, err := s.operatorRunRepo.GetOperatorRun(ctx, evt.TaskID, operatorType, jobRun.ID)
+	if err != nil {
+		if errors.IsErrorType(err, errors.ErrNotFound) {
+			// v1 does not fabricate a row/timing for a task Optimus never saw start.
+			airflowSyncSkippedTotal.WithLabelValues(projectName.String(), "no_operator_run").Inc()
+			return false, nil
+		}
+		return false, err
+	}
+
+	if operatorRun.Status == targetState {
+		airflowSyncSkippedTotal.WithLabelValues(projectName.String(), "already_matches").Inc()
+		return false, nil
+	}
+	if !operatorRun.UpdatedAt.IsZero() && operatorRun.UpdatedAt.After(evt.When) {
+		airflowSyncSkippedTotal.WithLabelValues(projectName.String(), "stale_event").Inc()
+		return false, nil
+	}
+
+	if err := s.operatorRunRepo.UpdateOperatorRun(ctx, operatorType, operatorRun.ID, evt.When, targetState); err != nil {
+		return false, err
+	}
+	airflowSyncReconciledTotal.WithLabelValues(projectName.String(), evt.Event, targetState.String()).Inc()
+	return true, nil
+}
+
+// emitJobRunStateChange mirrors JobRunService.raiseJobRunStateChangeEvent so downstream
+// consumers of the job-run-state-change event stream don't desync just because this state
+// change came from reconciliation instead of a live Airflow callback. This intentionally
+// does not go through the gRPC handler's notifier fan-out (ext/notify/alertmanager etc.), so
+// no user-facing alert is produced -- see the RFC's "Alerting" section for why that's the
+// deliberate v1 behaviour, not an oversight.
+func (s *AirflowStateSyncService) emitJobRunStateChange(jobRun *scheduler.JobRun) {
+	var schedulerEvent moderator.Event
+	var err error
+	switch jobRun.State {
+	case scheduler.StateSuccess:
+		schedulerEvent, err = event.NewJobRunSuccessEvent(jobRun)
+	case scheduler.StateFailed:
+		schedulerEvent, err = event.NewJobRunFailedEvent(jobRun)
+	default:
+		return
+	}
+	if err != nil {
+		s.l.Error("error creating event for reconciled job run [%s] state change: %s", jobRun.ID, err)
+		return
+	}
+	s.eventHandler.HandleEvent(schedulerEvent)
+}

--- a/core/scheduler/service/airflow_state_sync_service.go
+++ b/core/scheduler/service/airflow_state_sync_service.go
@@ -214,24 +214,24 @@ func (s *AirflowStateSyncService) reconcileDagRun(ctx context.Context, projectNa
 	}
 
 	for _, operatorType := range []scheduler.OperatorType{scheduler.OperatorTask, scheduler.OperatorSensor, scheduler.OperatorHook} {
-		children, err := s.operatorRunRepo.ListLatestOperatorRunsByJobRunID(ctx, operatorType, jobRun.ID)
+		operators, err := s.operatorRunRepo.ListLatestOperatorRunsByJobRunID(ctx, operatorType, jobRun.ID)
 		if err != nil {
 			s.l.Warn("error listing %s runs for job run [%s] dagrun cascade: %s", operatorType, jobRun.ID, err)
 			continue
 		}
-		for _, child := range children {
-			if child.Status == targetState {
+		for _, operator := range operators {
+			if operator.Status == targetState {
 				continue
 			}
-			if targetState == scheduler.StateFailed && child.Status.IsTerminal() {
+			if targetState == scheduler.StateFailed && operator.Status.IsTerminal() {
 				// leaves already-terminal tasks alone, matching set_dag_run_state_to_failed
 				continue
 			}
-			if !child.UpdatedAt.IsZero() && child.UpdatedAt.After(evt.When) {
+			if !operator.UpdatedAt.IsZero() && operator.UpdatedAt.After(evt.When) {
 				continue
 			}
-			if err := s.operatorRunRepo.UpdateOperatorRun(ctx, operatorType, child.ID, evt.When, targetState); err != nil {
-				s.l.Warn("error cascading dagrun state to %s run [%s]: %s", operatorType, child.ID, err)
+			if err := s.operatorRunRepo.UpdateOperatorRun(ctx, operatorType, operator.ID, evt.When, targetState); err != nil {
+				s.l.Warn("error cascading dagrun state to %s run [%s]: %s", operatorType, operator.ID, err)
 				continue
 			}
 			anyChanged = true

--- a/core/scheduler/service/airflow_state_sync_service.go
+++ b/core/scheduler/service/airflow_state_sync_service.go
@@ -21,7 +21,7 @@ import (
 // interfaces where they're used (see JobRepository/JobRunRepository above in
 // job_run_service.go).
 type AirflowEventLogFetcher interface {
-	GetEventLogs(ctx context.Context, projectName tenant.ProjectName, after, before time.Time) ([]scheduler.ManualOverrideEvent, error)
+	GetManualEventLogs(ctx context.Context, projectName tenant.ProjectName, after, before time.Time) ([]scheduler.ManualOverrideEvent, error)
 }
 
 // AirflowSyncJobRepository is the subset of the wider JobRepository the reconciler needs.
@@ -100,7 +100,7 @@ type ReconcileWindowResult struct {
 // logged and skipped rather than aborting the whole window, since one bad row should not
 // block every other row in the same window from being reconciled.
 func (s *AirflowStateSyncService) ReconcileWindow(ctx context.Context, projectName tenant.ProjectName, startTime, endTime time.Time) (ReconcileWindowResult, error) {
-	events, err := s.eventLogFetcher.GetEventLogs(ctx, projectName, startTime, endTime)
+	events, err := s.eventLogFetcher.GetManualEventLogs(ctx, projectName, startTime, endTime)
 	if err != nil {
 		return ReconcileWindowResult{}, errors.Wrap(scheduler.EntityAirflowSync, "error fetching airflow event logs", err)
 	}

--- a/core/scheduler/service/airflow_state_sync_worker.go
+++ b/core/scheduler/service/airflow_state_sync_worker.go
@@ -15,18 +15,15 @@ import (
 )
 
 // airflowSyncWindowsFailedTotal counts windows a project gave up on after exhausting
-// MaxAttempts -- each one is a span of time whose manual overrides were never reconciled
-// and, unlike a single skipped event, isn't visible anywhere else (FailExhaustedWindows was
-// previously only a log line). With multiple independent projects/Airflow instances, the
-// project label is what lets on-call tell which one needs attention.
+// MaxAttempts -- each one is a span of time whose manual overrides were never reconciled.
 var airflowSyncWindowsFailedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "airflow_sync_windows_failed_total",
 	Help: "airflow-sync windows marked failed after exhausting retries, by project",
 }, []string{"project"})
 
-// AirflowSyncProjectRepository lists every project the reconciler should sweep. Production
-// has multiple projects, each with its own Airflow instance (SCHEDULER_HOST is per-project
-// config), so this fans out to isolated, parallel sync per project rather than assuming one.
+// AirflowSyncProjectRepository lists every project the reconciler should sweep. Each project
+// has its own Airflow instance (SCHEDULER_HOST is per-project config), so sync runs
+// independently per project.
 type AirflowSyncProjectRepository interface {
 	GetAll(ctx context.Context) ([]*tenant.Project, error)
 }
@@ -49,42 +46,41 @@ type WindowReconciler interface {
 	ReconcileWindow(ctx context.Context, projectName tenant.ProjectName, startTime, endTime time.Time) (ReconcileWindowResult, error)
 }
 
+const (
+	// settlingDelay keeps a window's end_time from being claimed until it is this far in the
+	// past, so a row whose transaction hadn't committed yet when queried isn't permanently
+	// skipped.
+	settlingDelay = 60 * time.Second
+	// overlapEpsilon is subtracted from every window's start when querying Airflow: the
+	// eventLogs `after`/`before` bounds are both strict, so without an overlap a row landing
+	// exactly on a boundary is excluded by both the window before and the window after it.
+	// Re-fetching a couple of already-processed rows is harmless since reconciliation is
+	// idempotent.
+	overlapEpsilon = 2 * time.Second
+	// maxWindowsPerTick bounds how many windows a single tick claims and processes for one
+	// project, so catching up after downtime doesn't turn one tick into unbounded work.
+	maxWindowsPerTick = 12
+)
+
 type AirflowStateSyncConfig struct {
-	// WindowInterval is both the ticker cadence and the size of each claimed window: every
-	// tick, the worker advances each project's watermark by one window of this length
-	// (more, if catching up -- see MaxWindowsPerTick).
+	// WindowInterval is both the ticker cadence and the size of each claimed window. A zero
+	// value disables the worker entirely (see server/optimus.go).
 	WindowInterval time.Duration
-	// SettlingDelay keeps a window's end_time from being claimed until it is this far in
-	// the past, so a row whose transaction had not committed yet when queried is not
-	// permanently skipped (see the RFC's "windowing" section).
-	SettlingDelay time.Duration
 	// LockDuration bounds how long a claimed window may stay `in_progress` before another
-	// replica is allowed to treat it as crashed and re-claim it.
+	// replica may treat it as crashed and re-claim it. Also bounds how long a single window's
+	// reconcile call is allowed to run (see processWindow).
 	LockDuration time.Duration
-	// InitialLookback caps how far back the very first window goes for a project with no
-	// prior sync history, so a fresh deployment does not try to ingest all of history.
-	InitialLookback time.Duration
-	// OverlapEpsilon is subtracted from every window's start when querying Airflow, because
-	// eventLogs' `after`/`before` bounds are both strict: without an overlap, a row whose
-	// dttm exactly equals a window boundary is excluded by both the window that ends there
-	// and the one that begins there. The resulting re-fetch of a few already-processed rows
-	// is harmless: reconciliation is idempotent (it checks current-state-equals-target-state
-	// before writing anything).
-	OverlapEpsilon time.Duration
-	// MaxAttempts is how many times a crashed/failed window is retried (via
-	// ReclaimStaleWindow) before it is marked `failed` and the watermark advances past it
-	// anyway -- see the RFC on why a `failed` window still counts towards the watermark:
-	// excluding it would let one permanently-broken window block every later window for the
-	// project from ever being attempted.
-	MaxAttempts int
-	// MaxWindowsPerTick bounds how many windows a single tick will claim and process for one
-	// project, so a project catching up after downtime does not turn one tick into
-	// unbounded work.
-	MaxWindowsPerTick int
-	// MaxConcurrentProjects bounds how many projects one pod processes at once per tick.
-	// One project whose Airflow instance is slow or unreachable would otherwise delay every project listed
-	// after it in that same pod's tick, for up to LockDuration, before this was added.
+	// MaxConcurrentProjects bounds how many projects one pod processes at once per tick, so a
+	// project whose Airflow instance is slow or unreachable doesn't delay every project listed
+	// after it in the same tick.
 	MaxConcurrentProjects int
+	// MaxAttempts is how many times a crashed/failed window is retried before it's marked
+	// `failed` and the watermark advances past it anyway, so one broken window can't block a
+	// project's sync forever.
+	MaxAttempts int
+	// ExcludeProjects lists project names to skip syncing entirely -- e.g. an unstable
+	// instance, or a project not yet rolled out. Every project syncs by default.
+	ExcludeProjects []string
 }
 
 type AirflowStateSyncWorker struct {
@@ -94,19 +90,31 @@ type AirflowStateSyncWorker struct {
 	syncStateRepo AirflowSyncStateRepository
 	reconciler    WindowReconciler
 
-	config AirflowStateSyncConfig
+	config          AirflowStateSyncConfig
+	excludedProject map[string]struct{}
 }
 
 func NewAirflowStateSyncWorker(l log.Logger, projectRepo AirflowSyncProjectRepository, syncStateRepo AirflowSyncStateRepository,
 	reconciler WindowReconciler, config AirflowStateSyncConfig,
 ) *AirflowStateSyncWorker {
-	return &AirflowStateSyncWorker{
-		l:             l,
-		projectRepo:   projectRepo,
-		syncStateRepo: syncStateRepo,
-		reconciler:    reconciler,
-		config:        config,
+	excludedProject := make(map[string]struct{}, len(config.ExcludeProjects))
+	for _, name := range config.ExcludeProjects {
+		excludedProject[name] = struct{}{}
 	}
+	return &AirflowStateSyncWorker{
+		l:               l,
+		projectRepo:     projectRepo,
+		syncStateRepo:   syncStateRepo,
+		reconciler:      reconciler,
+		config:          config,
+		excludedProject: excludedProject,
+	}
+}
+
+// initialLookback caps how far back the very first window goes for a project with no prior
+// sync history, so a fresh project doesn't try to ingest all of history.
+func (w *AirflowStateSyncWorker) initialLookback() time.Duration {
+	return w.config.WindowInterval * time.Duration(maxWindowsPerTick)
 }
 
 // ScheduleAirflowStateSync starts the ticker loop. Modeled on SLAWorker.ScheduleSLAHandling:
@@ -127,10 +135,8 @@ func (w *AirflowStateSyncWorker) ScheduleAirflowStateSync(ctx context.Context) {
 	}()
 }
 
-// tick fans out across projects with bounded concurrency, rather than processing them one
-// at a time: a project whose Airflow instance is slow or unreachable is bounded to a
-// LockDuration-long stall (see processWindow's timeout) on whichever goroutine claimed it,
-// but no longer blocks this pod from starting every other project's turn until it's done.
+// tick processes projects concurrently, up to MaxConcurrentProjects at a time, so a slow or
+// unreachable project doesn't hold up the rest.
 func (w *AirflowStateSyncWorker) tick(ctx context.Context) {
 	projects, err := w.projectRepo.GetAll(ctx)
 	if err != nil {
@@ -145,6 +151,9 @@ func (w *AirflowStateSyncWorker) tick(ctx context.Context) {
 			break
 		}
 		projectName := p.Name()
+		if _, excluded := w.excludedProject[projectName.String()]; excluded {
+			continue
+		}
 
 		sem <- struct{}{}
 		wg.Add(1)
@@ -160,9 +169,7 @@ func (w *AirflowStateSyncWorker) tick(ctx context.Context) {
 func (w *AirflowStateSyncWorker) processProject(ctx context.Context, projectName tenant.ProjectName) {
 	workerID := uuid.New()
 
-	// A worker that died mid-window gets priority: make progress on it (or fail it out once
-	// attempts are exhausted) before claiming anything new, so a wedged window doesn't
-	// starve forever behind an ever-advancing watermark.
+	// Reclaim any window a crashed worker left stuck, before claiming anything new.
 	if reclaimed, err := w.syncStateRepo.ReclaimStaleWindow(ctx, projectName, workerID, w.config.LockDuration, w.config.MaxAttempts); err != nil {
 		w.l.Error("[airflowStateSync] project [%s] failed to reclaim stale window: %s", projectName, err)
 	} else if reclaimed != nil {
@@ -176,7 +183,7 @@ func (w *AirflowStateSyncWorker) processProject(ctx context.Context, projectName
 		w.l.Error("[airflowStateSync] project [%s] gave up on %d window(s) after exhausting retries -- manual overrides in that span went unreconciled, investigate and consider re-running", projectName, failedCount)
 	}
 
-	for i := 0; i < w.config.MaxWindowsPerTick; i++ {
+	for i := 0; i < maxWindowsPerTick; i++ {
 		if ctx.Err() != nil {
 			return
 		}
@@ -187,9 +194,8 @@ func (w *AirflowStateSyncWorker) processProject(ctx context.Context, projectName
 }
 
 // claimAndProcessNextWindow claims and processes exactly one window, returning false when
-// there is nothing to do this tick (either nothing due yet, per SettlingDelay, or another
-// replica already claimed it) so processProject's catch-up loop knows to stop early rather
-// than spinning through MaxWindowsPerTick iterations for nothing.
+// there's nothing to do (nothing due yet, or another replica already claimed it) so the
+// caller's catch-up loop can stop early.
 func (w *AirflowStateSyncWorker) claimAndProcessNextWindow(ctx context.Context, projectName tenant.ProjectName, workerID uuid.UUID) bool {
 	watermark, err := w.syncStateRepo.GetWatermark(ctx, projectName)
 	if err != nil {
@@ -197,13 +203,13 @@ func (w *AirflowStateSyncWorker) claimAndProcessNextWindow(ctx context.Context, 
 		return false
 	}
 
-	start := time.Now().Add(-w.config.InitialLookback)
+	start := time.Now().Add(-w.initialLookback())
 	if watermark != nil {
 		start = *watermark
 	}
 	end := start.Add(w.config.WindowInterval)
 
-	settleBoundary := time.Now().Add(-w.config.SettlingDelay)
+	settleBoundary := time.Now().Add(-settlingDelay)
 	if end.After(settleBoundary) {
 		return false // nothing due yet
 	}
@@ -223,16 +229,12 @@ func (w *AirflowStateSyncWorker) claimAndProcessNextWindow(ctx context.Context, 
 }
 
 func (w *AirflowStateSyncWorker) processWindow(ctx context.Context, win *scheduler.AirflowSyncWindow) {
-	// The Airflow HTTP client has no request timeout of its own (&http.Client{}, see
-	// ext/scheduler/airflow/client.go), so a hung request would otherwise block this
-	// goroutine forever instead of surfacing as an attempt error. Bound it to LockDuration:
-	// that's already the point at which another replica is allowed to reclaim this window,
-	// so a stuck call gets cancelled in line with when its lease would lapse anyway, rather
-	// than leaking a goroutine that outlives the window it was ever allowed to hold.
+	// The Airflow HTTP client has no request timeout of its own, so bound the reconcile call
+	// to LockDuration -- otherwise a hung request blocks this goroutine indefinitely.
 	reconcileCtx, cancel := context.WithTimeout(ctx, w.config.LockDuration)
 	defer cancel()
 
-	result, err := w.reconciler.ReconcileWindow(reconcileCtx, win.ProjectName, win.StartTime.Add(-w.config.OverlapEpsilon), win.EndTime)
+	result, err := w.reconciler.ReconcileWindow(reconcileCtx, win.ProjectName, win.StartTime.Add(-overlapEpsilon), win.EndTime)
 	if err != nil {
 		w.l.Error("[airflowStateSync] project [%s] failed reconciling window [%s, %s): %s", win.ProjectName, win.StartTime, win.EndTime, err)
 		if err := w.syncStateRepo.RecordAttemptError(ctx, win.ID, win.WorkerID, err.Error()); err != nil {

--- a/core/scheduler/service/airflow_state_sync_worker.go
+++ b/core/scheduler/service/airflow_state_sync_worker.go
@@ -1,0 +1,217 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/goto/salt/log"
+
+	"github.com/goto/optimus/core/scheduler"
+	"github.com/goto/optimus/core/tenant"
+)
+
+// AirflowSyncProjectRepository lists every project the reconciler should sweep. In this
+// deployment there is exactly one, but the worker fans out generically so other
+// deployments with several projects (and therefore several independent Airflow instances,
+// since SCHEDULER_HOST is per-project config) get isolated, parallel sync per project.
+type AirflowSyncProjectRepository interface {
+	GetAll(ctx context.Context) ([]*tenant.Project, error)
+}
+
+// AirflowSyncStateRepository backs the per-project window claim described in
+// docs/docs/rfcs/20260727_manual_state_override_reconciliation.md. A claimed window row is
+// the mutex -- ClaimWindow's INSERT ... ON CONFLICT DO NOTHING is what guarantees serial
+// processing within a project while leaving different projects free to run in parallel.
+type AirflowSyncStateRepository interface {
+	GetWatermark(ctx context.Context, projectName tenant.ProjectName) (*time.Time, error)
+	ClaimWindow(ctx context.Context, projectName tenant.ProjectName, startTime, endTime time.Time, workerID uuid.UUID, lockDuration time.Duration) (id uuid.UUID, claimed bool, err error)
+	ReclaimStaleWindow(ctx context.Context, projectName tenant.ProjectName, workerID uuid.UUID, lockDuration time.Duration, maxAttempts int) (*scheduler.AirflowSyncWindow, error)
+	FailExhaustedWindows(ctx context.Context, projectName tenant.ProjectName, maxAttempts int, lastError string) (int64, error)
+	CompleteWindow(ctx context.Context, id, workerID uuid.UUID, maxProcessedLogID *int64, eventsMatched, runsReconciled int) (bool, error)
+	RecordAttemptError(ctx context.Context, id, workerID uuid.UUID, lastError string) error
+}
+
+// WindowReconciler is satisfied by *AirflowStateSyncService.
+type WindowReconciler interface {
+	ReconcileWindow(ctx context.Context, projectName tenant.ProjectName, startTime, endTime time.Time) (ReconcileWindowResult, error)
+}
+
+type AirflowStateSyncConfig struct {
+	// WindowInterval is both the ticker cadence and the size of each claimed window: every
+	// tick, the worker advances each project's watermark by one window of this length
+	// (more, if catching up -- see MaxWindowsPerTick).
+	WindowInterval time.Duration
+	// SettlingDelay keeps a window's end_time from being claimed until it is this far in
+	// the past, so a row whose transaction had not committed yet when queried is not
+	// permanently skipped (see the RFC's "windowing" section).
+	SettlingDelay time.Duration
+	// LockDuration bounds how long a claimed window may stay `in_progress` before another
+	// replica is allowed to treat it as crashed and re-claim it.
+	LockDuration time.Duration
+	// InitialLookback caps how far back the very first window goes for a project with no
+	// prior sync history, so a fresh deployment does not try to ingest all of history.
+	InitialLookback time.Duration
+	// OverlapEpsilon is subtracted from every window's start when querying Airflow, because
+	// eventLogs' `after`/`before` bounds are both strict: without an overlap, a row whose
+	// dttm exactly equals a window boundary is excluded by both the window that ends there
+	// and the one that begins there. The resulting re-fetch of a few already-processed rows
+	// is harmless: reconciliation is idempotent (it checks current-state-equals-target-state
+	// before writing anything).
+	OverlapEpsilon time.Duration
+	// MaxAttempts is how many times a crashed/failed window is retried (via
+	// ReclaimStaleWindow) before it is marked `failed` and the watermark advances past it
+	// anyway -- see the RFC on why a `failed` window still counts towards the watermark:
+	// excluding it would let one permanently-broken window block every later window for the
+	// project from ever being attempted.
+	MaxAttempts int
+	// MaxWindowsPerTick bounds how many windows a single tick will claim and process for one
+	// project, so a project catching up after downtime does not turn one tick into
+	// unbounded work.
+	MaxWindowsPerTick int
+}
+
+type AirflowStateSyncWorker struct {
+	l log.Logger
+
+	projectRepo   AirflowSyncProjectRepository
+	syncStateRepo AirflowSyncStateRepository
+	reconciler    WindowReconciler
+
+	config AirflowStateSyncConfig
+}
+
+func NewAirflowStateSyncWorker(l log.Logger, projectRepo AirflowSyncProjectRepository, syncStateRepo AirflowSyncStateRepository,
+	reconciler WindowReconciler, config AirflowStateSyncConfig,
+) *AirflowStateSyncWorker {
+	return &AirflowStateSyncWorker{
+		l:             l,
+		projectRepo:   projectRepo,
+		syncStateRepo: syncStateRepo,
+		reconciler:    reconciler,
+		config:        config,
+	}
+}
+
+// ScheduleAirflowStateSync starts the ticker loop. Modeled on SLAWorker.ScheduleSLAHandling:
+// self-spawns its own goroutine and stops on ctx.Done(), so the caller just needs to wire a
+// cancellable context into server shutdown (see server/optimus.go's cleanupFn pattern).
+func (w *AirflowStateSyncWorker) ScheduleAirflowStateSync(ctx context.Context) {
+	ticker := time.NewTicker(w.config.WindowInterval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				w.tick(ctx)
+			}
+		}
+	}()
+}
+
+func (w *AirflowStateSyncWorker) tick(ctx context.Context) {
+	projects, err := w.projectRepo.GetAll(ctx)
+	if err != nil {
+		w.l.Error("[airflowStateSync] failed to list projects: %s", err)
+		return
+	}
+	for _, p := range projects {
+		if ctx.Err() != nil {
+			return
+		}
+		w.processProject(ctx, p.Name())
+	}
+}
+
+func (w *AirflowStateSyncWorker) processProject(ctx context.Context, projectName tenant.ProjectName) {
+	workerID := uuid.New()
+
+	// A worker that died mid-window gets priority: make progress on it (or fail it out once
+	// attempts are exhausted) before claiming anything new, so a wedged window doesn't
+	// starve forever behind an ever-advancing watermark.
+	if reclaimed, err := w.syncStateRepo.ReclaimStaleWindow(ctx, projectName, workerID, w.config.LockDuration, w.config.MaxAttempts); err != nil {
+		w.l.Error("[airflowStateSync] project [%s] failed to reclaim stale window: %s", projectName, err)
+	} else if reclaimed != nil {
+		w.processWindow(ctx, reclaimed)
+	}
+
+	if failedCount, err := w.syncStateRepo.FailExhaustedWindows(ctx, projectName, w.config.MaxAttempts, "max attempts exceeded"); err != nil {
+		w.l.Error("[airflowStateSync] project [%s] failed to fail exhausted windows: %s", projectName, err)
+	} else if failedCount > 0 {
+		w.l.Error("[airflowStateSync] project [%s] gave up on %d window(s) after exhausting retries -- manual overrides in that span went unreconciled, investigate and consider re-running", projectName, failedCount)
+	}
+
+	for i := 0; i < w.config.MaxWindowsPerTick; i++ {
+		if ctx.Err() != nil {
+			return
+		}
+		if !w.claimAndProcessNextWindow(ctx, projectName, workerID) {
+			return
+		}
+	}
+}
+
+// claimAndProcessNextWindow claims and processes exactly one window, returning false when
+// there is nothing to do this tick (either nothing due yet, per SettlingDelay, or another
+// replica already claimed it) so processProject's catch-up loop knows to stop early rather
+// than spinning through MaxWindowsPerTick iterations for nothing.
+func (w *AirflowStateSyncWorker) claimAndProcessNextWindow(ctx context.Context, projectName tenant.ProjectName, workerID uuid.UUID) bool {
+	watermark, err := w.syncStateRepo.GetWatermark(ctx, projectName)
+	if err != nil {
+		w.l.Error("[airflowStateSync] project [%s] failed to get watermark: %s", projectName, err)
+		return false
+	}
+
+	start := time.Now().Add(-w.config.InitialLookback)
+	if watermark != nil {
+		start = *watermark
+	}
+	end := start.Add(w.config.WindowInterval)
+
+	settleBoundary := time.Now().Add(-w.config.SettlingDelay)
+	if end.After(settleBoundary) {
+		return false // nothing due yet
+	}
+
+	id, claimed, err := w.syncStateRepo.ClaimWindow(ctx, projectName, start, end, workerID, w.config.LockDuration)
+	if err != nil {
+		w.l.Error("[airflowStateSync] project [%s] failed to claim window [%s, %s): %s", projectName, start, end, err)
+		return false
+	}
+	if !claimed {
+		// another replica holds it, or it is already terminal -- either way, stop for now
+		return false
+	}
+
+	w.processWindow(ctx, &scheduler.AirflowSyncWindow{ID: id, ProjectName: projectName, StartTime: start, EndTime: end, WorkerID: workerID})
+	return true
+}
+
+func (w *AirflowStateSyncWorker) processWindow(ctx context.Context, win *scheduler.AirflowSyncWindow) {
+	result, err := w.reconciler.ReconcileWindow(ctx, win.ProjectName, win.StartTime.Add(-w.config.OverlapEpsilon), win.EndTime)
+	if err != nil {
+		w.l.Error("[airflowStateSync] project [%s] failed reconciling window [%s, %s): %s", win.ProjectName, win.StartTime, win.EndTime, err)
+		if err := w.syncStateRepo.RecordAttemptError(ctx, win.ID, win.WorkerID, err.Error()); err != nil {
+			w.l.Error("[airflowStateSync] failed to record attempt error for window [%s]: %s", win.ID, err)
+		}
+		return
+	}
+
+	completed, err := w.syncStateRepo.CompleteWindow(ctx, win.ID, win.WorkerID, result.MaxProcessedLogID, result.EventsMatched, result.RunsReconciled)
+	if err != nil {
+		w.l.Error("[airflowStateSync] failed to complete window [%s]: %s", win.ID, err)
+		return
+	}
+	if !completed {
+		// lost the lease mid-window (another replica reclaimed it after our lock expired) --
+		// our progress is discarded, and the reclaiming replica will redo this window.
+		w.l.Warn("[airflowStateSync] lost lease on window [%s] before completion could be recorded, another replica will redo it", win.ID)
+		return
+	}
+	if result.EventsMatched > 0 {
+		w.l.Info("[airflowStateSync] project [%s] window [%s, %s): matched %d manual override(s), reconciled %d run(s)",
+			win.ProjectName, win.StartTime, win.EndTime, result.EventsMatched, result.RunsReconciled)
+	}
+}

--- a/core/scheduler/service/airflow_state_sync_worker.go
+++ b/core/scheduler/service/airflow_state_sync_worker.go
@@ -2,19 +2,31 @@ package service
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/goto/salt/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/goto/optimus/core/scheduler"
 	"github.com/goto/optimus/core/tenant"
 )
 
-// AirflowSyncProjectRepository lists every project the reconciler should sweep. In this
-// deployment there is exactly one, but the worker fans out generically so other
-// deployments with several projects (and therefore several independent Airflow instances,
-// since SCHEDULER_HOST is per-project config) get isolated, parallel sync per project.
+// airflowSyncWindowsFailedTotal counts windows a project gave up on after exhausting
+// MaxAttempts -- each one is a span of time whose manual overrides were never reconciled
+// and, unlike a single skipped event, isn't visible anywhere else (FailExhaustedWindows was
+// previously only a log line). With multiple independent projects/Airflow instances, the
+// project label is what lets on-call tell which one needs attention.
+var airflowSyncWindowsFailedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "airflow_sync_windows_failed_total",
+	Help: "airflow-sync windows marked failed after exhausting retries, by project",
+}, []string{"project"})
+
+// AirflowSyncProjectRepository lists every project the reconciler should sweep. Production
+// has multiple projects, each with its own Airflow instance (SCHEDULER_HOST is per-project
+// config), so this fans out to isolated, parallel sync per project rather than assuming one.
 type AirflowSyncProjectRepository interface {
 	GetAll(ctx context.Context) ([]*tenant.Project, error)
 }
@@ -69,6 +81,10 @@ type AirflowStateSyncConfig struct {
 	// project, so a project catching up after downtime does not turn one tick into
 	// unbounded work.
 	MaxWindowsPerTick int
+	// MaxConcurrentProjects bounds how many projects one pod processes at once per tick.
+	// One project whose Airflow instance is slow or unreachable would otherwise delay every project listed
+	// after it in that same pod's tick, for up to LockDuration, before this was added.
+	MaxConcurrentProjects int
 }
 
 type AirflowStateSyncWorker struct {
@@ -111,18 +127,34 @@ func (w *AirflowStateSyncWorker) ScheduleAirflowStateSync(ctx context.Context) {
 	}()
 }
 
+// tick fans out across projects with bounded concurrency, rather than processing them one
+// at a time: a project whose Airflow instance is slow or unreachable is bounded to a
+// LockDuration-long stall (see processWindow's timeout) on whichever goroutine claimed it,
+// but no longer blocks this pod from starting every other project's turn until it's done.
 func (w *AirflowStateSyncWorker) tick(ctx context.Context) {
 	projects, err := w.projectRepo.GetAll(ctx)
 	if err != nil {
 		w.l.Error("[airflowStateSync] failed to list projects: %s", err)
 		return
 	}
+
+	sem := make(chan struct{}, w.config.MaxConcurrentProjects)
+	var wg sync.WaitGroup
 	for _, p := range projects {
 		if ctx.Err() != nil {
-			return
+			break
 		}
-		w.processProject(ctx, p.Name())
+		projectName := p.Name()
+
+		sem <- struct{}{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			w.processProject(ctx, projectName)
+		}()
 	}
+	wg.Wait()
 }
 
 func (w *AirflowStateSyncWorker) processProject(ctx context.Context, projectName tenant.ProjectName) {
@@ -140,6 +172,7 @@ func (w *AirflowStateSyncWorker) processProject(ctx context.Context, projectName
 	if failedCount, err := w.syncStateRepo.FailExhaustedWindows(ctx, projectName, w.config.MaxAttempts, "max attempts exceeded"); err != nil {
 		w.l.Error("[airflowStateSync] project [%s] failed to fail exhausted windows: %s", projectName, err)
 	} else if failedCount > 0 {
+		airflowSyncWindowsFailedTotal.WithLabelValues(projectName.String()).Add(float64(failedCount))
 		w.l.Error("[airflowStateSync] project [%s] gave up on %d window(s) after exhausting retries -- manual overrides in that span went unreconciled, investigate and consider re-running", projectName, failedCount)
 	}
 
@@ -190,7 +223,16 @@ func (w *AirflowStateSyncWorker) claimAndProcessNextWindow(ctx context.Context, 
 }
 
 func (w *AirflowStateSyncWorker) processWindow(ctx context.Context, win *scheduler.AirflowSyncWindow) {
-	result, err := w.reconciler.ReconcileWindow(ctx, win.ProjectName, win.StartTime.Add(-w.config.OverlapEpsilon), win.EndTime)
+	// The Airflow HTTP client has no request timeout of its own (&http.Client{}, see
+	// ext/scheduler/airflow/client.go), so a hung request would otherwise block this
+	// goroutine forever instead of surfacing as an attempt error. Bound it to LockDuration:
+	// that's already the point at which another replica is allowed to reclaim this window,
+	// so a stuck call gets cancelled in line with when its lease would lapse anyway, rather
+	// than leaking a goroutine that outlives the window it was ever allowed to hold.
+	reconcileCtx, cancel := context.WithTimeout(ctx, w.config.LockDuration)
+	defer cancel()
+
+	result, err := w.reconciler.ReconcileWindow(reconcileCtx, win.ProjectName, win.StartTime.Add(-w.config.OverlapEpsilon), win.EndTime)
 	if err != nil {
 		w.l.Error("[airflowStateSync] project [%s] failed reconciling window [%s, %s): %s", win.ProjectName, win.StartTime, win.EndTime, err)
 		if err := w.syncStateRepo.RecordAttemptError(ctx, win.ID, win.WorkerID, err.Error()); err != nil {

--- a/core/scheduler/service/airflow_state_sync_worker_test.go
+++ b/core/scheduler/service/airflow_state_sync_worker_test.go
@@ -3,6 +3,7 @@ package service // nolint:testpackage
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -100,7 +101,6 @@ func TestAirflowStateSyncWorkerTickConcurrency(t *testing.T) {
 	stateRepo := &concurrencyTrackingSyncStateRepo{}
 
 	worker := NewAirflowStateSyncWorker(log.NewNoop(), projectRepo, stateRepo, noopWindowReconciler{}, AirflowStateSyncConfig{
-		MaxAttempts:           3,
 		MaxConcurrentProjects: maxConcurrent,
 	})
 
@@ -109,4 +109,64 @@ func TestAirflowStateSyncWorkerTickConcurrency(t *testing.T) {
 	assert.EqualValues(t, numProjects, atomic.LoadInt32(&stateRepo.calls), "every project should be processed exactly once")
 	assert.LessOrEqual(t, int(atomic.LoadInt32(&stateRepo.max)), maxConcurrent, "concurrency must not exceed MaxConcurrentProjects")
 	assert.Greater(t, int(atomic.LoadInt32(&stateRepo.max)), 1, "tick should actually run projects concurrently, not serially")
+}
+
+// recordingSyncStateRepo records which project each call was made for, so
+// TestAirflowStateSyncWorkerTickExcludesProjects can assert an excluded project's Airflow
+// instance is never touched at all -- not claimed, not even reclaimed-from.
+type recordingSyncStateRepo struct {
+	mu       sync.Mutex
+	projects []string
+}
+
+func (*recordingSyncStateRepo) GetWatermark(context.Context, tenant.ProjectName) (*time.Time, error) {
+	return nil, nil //nolint:nilnil
+}
+
+func (*recordingSyncStateRepo) ClaimWindow(context.Context, tenant.ProjectName, time.Time, time.Time, uuid.UUID, time.Duration) (uuid.UUID, bool, error) {
+	return uuid.Nil, false, nil
+}
+
+func (r *recordingSyncStateRepo) ReclaimStaleWindow(_ context.Context, projectName tenant.ProjectName, _ uuid.UUID, _ time.Duration, _ int) (*scheduler.AirflowSyncWindow, error) {
+	r.mu.Lock()
+	r.projects = append(r.projects, projectName.String())
+	r.mu.Unlock()
+	return nil, nil //nolint:nilnil
+}
+
+func (*recordingSyncStateRepo) FailExhaustedWindows(context.Context, tenant.ProjectName, int, string) (int64, error) {
+	return 0, nil
+}
+
+func (*recordingSyncStateRepo) CompleteWindow(context.Context, uuid.UUID, uuid.UUID, *int64, int, int) (bool, error) {
+	return true, nil
+}
+
+func (*recordingSyncStateRepo) RecordAttemptError(context.Context, uuid.UUID, uuid.UUID, string) error {
+	return nil
+}
+
+func TestAirflowStateSyncWorkerTickExcludesProjects(t *testing.T) {
+	conf := map[string]string{
+		tenant.ProjectSchedulerHost:  "https://scheduler.example.com",
+		tenant.ProjectStoragePathKey: "fs://bucket",
+	}
+	included, err := tenant.NewProject("proj-included", conf, nil)
+	assert.NoError(t, err)
+	excluded, err := tenant.NewProject("proj-excluded", conf, nil)
+	assert.NoError(t, err)
+
+	projectRepo := &mockAirflowSyncProjectRepo{}
+	projectRepo.On("GetAll", mock.Anything).Return([]*tenant.Project{included, excluded}, nil)
+
+	stateRepo := &recordingSyncStateRepo{}
+
+	worker := NewAirflowStateSyncWorker(log.NewNoop(), projectRepo, stateRepo, noopWindowReconciler{}, AirflowStateSyncConfig{
+		MaxConcurrentProjects: 5,
+		ExcludeProjects:       []string{"proj-excluded"},
+	})
+
+	worker.tick(context.Background())
+
+	assert.Equal(t, []string{"proj-included"}, stateRepo.projects)
 }

--- a/core/scheduler/service/airflow_state_sync_worker_test.go
+++ b/core/scheduler/service/airflow_state_sync_worker_test.go
@@ -39,11 +39,11 @@ type concurrencyTrackingSyncStateRepo struct {
 	calls   int32
 }
 
-func (r *concurrencyTrackingSyncStateRepo) GetWatermark(context.Context, tenant.ProjectName) (*time.Time, error) {
+func (*concurrencyTrackingSyncStateRepo) GetWatermark(context.Context, tenant.ProjectName) (*time.Time, error) {
 	return nil, nil //nolint:nilnil
 }
 
-func (r *concurrencyTrackingSyncStateRepo) ClaimWindow(context.Context, tenant.ProjectName, time.Time, time.Time, uuid.UUID, time.Duration) (uuid.UUID, bool, error) {
+func (*concurrencyTrackingSyncStateRepo) ClaimWindow(context.Context, tenant.ProjectName, time.Time, time.Time, uuid.UUID, time.Duration) (uuid.UUID, bool, error) {
 	return uuid.Nil, false, nil
 }
 
@@ -61,15 +61,15 @@ func (r *concurrencyTrackingSyncStateRepo) ReclaimStaleWindow(_ context.Context,
 	return nil, nil //nolint:nilnil
 }
 
-func (r *concurrencyTrackingSyncStateRepo) FailExhaustedWindows(context.Context, tenant.ProjectName, int, string) (int64, error) {
+func (*concurrencyTrackingSyncStateRepo) FailExhaustedWindows(context.Context, tenant.ProjectName, int, string) (int64, error) {
 	return 0, nil
 }
 
-func (r *concurrencyTrackingSyncStateRepo) CompleteWindow(context.Context, uuid.UUID, uuid.UUID, *int64, int, int) (bool, error) {
+func (*concurrencyTrackingSyncStateRepo) CompleteWindow(context.Context, uuid.UUID, uuid.UUID, *int64, int, int) (bool, error) {
 	return true, nil
 }
 
-func (r *concurrencyTrackingSyncStateRepo) RecordAttemptError(context.Context, uuid.UUID, uuid.UUID, string) error {
+func (*concurrencyTrackingSyncStateRepo) RecordAttemptError(context.Context, uuid.UUID, uuid.UUID, string) error {
 	return nil
 }
 

--- a/core/scheduler/service/airflow_state_sync_worker_test.go
+++ b/core/scheduler/service/airflow_state_sync_worker_test.go
@@ -1,0 +1,112 @@
+package service // nolint:testpackage
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/goto/salt/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/goto/optimus/core/scheduler"
+	"github.com/goto/optimus/core/tenant"
+)
+
+type mockAirflowSyncProjectRepo struct {
+	mock.Mock
+}
+
+func (m *mockAirflowSyncProjectRepo) GetAll(ctx context.Context) ([]*tenant.Project, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*tenant.Project), args.Error(1)
+}
+
+// concurrencyTrackingSyncStateRepo mocks AirflowSyncStateRepository. ReclaimStaleWindow is
+// the first repo call processProject makes, so it's where we observe how many projects are
+// being worked on at once: a short sleep widens the window during which an overlapping call
+// would be visible, letting the test assert both that every project got processed and that
+// concurrency never exceeded MaxConcurrentProjects.
+type concurrencyTrackingSyncStateRepo struct {
+	current int32
+	max     int32
+	calls   int32
+}
+
+func (r *concurrencyTrackingSyncStateRepo) GetWatermark(context.Context, tenant.ProjectName) (*time.Time, error) {
+	return nil, nil //nolint:nilnil
+}
+
+func (r *concurrencyTrackingSyncStateRepo) ClaimWindow(context.Context, tenant.ProjectName, time.Time, time.Time, uuid.UUID, time.Duration) (uuid.UUID, bool, error) {
+	return uuid.Nil, false, nil
+}
+
+func (r *concurrencyTrackingSyncStateRepo) ReclaimStaleWindow(_ context.Context, _ tenant.ProjectName, _ uuid.UUID, _ time.Duration, _ int) (*scheduler.AirflowSyncWindow, error) {
+	atomic.AddInt32(&r.calls, 1)
+	current := atomic.AddInt32(&r.current, 1)
+	for {
+		observedMax := atomic.LoadInt32(&r.max)
+		if current <= observedMax || atomic.CompareAndSwapInt32(&r.max, observedMax, current) {
+			break
+		}
+	}
+	time.Sleep(20 * time.Millisecond)
+	atomic.AddInt32(&r.current, -1)
+	return nil, nil //nolint:nilnil
+}
+
+func (r *concurrencyTrackingSyncStateRepo) FailExhaustedWindows(context.Context, tenant.ProjectName, int, string) (int64, error) {
+	return 0, nil
+}
+
+func (r *concurrencyTrackingSyncStateRepo) CompleteWindow(context.Context, uuid.UUID, uuid.UUID, *int64, int, int) (bool, error) {
+	return true, nil
+}
+
+func (r *concurrencyTrackingSyncStateRepo) RecordAttemptError(context.Context, uuid.UUID, uuid.UUID, string) error {
+	return nil
+}
+
+type noopWindowReconciler struct{}
+
+func (noopWindowReconciler) ReconcileWindow(context.Context, tenant.ProjectName, time.Time, time.Time) (ReconcileWindowResult, error) {
+	return ReconcileWindowResult{}, nil
+}
+
+func TestAirflowStateSyncWorkerTickConcurrency(t *testing.T) {
+	const numProjects = 12
+	const maxConcurrent = 3
+
+	projects := make([]*tenant.Project, 0, numProjects)
+	for i := 0; i < numProjects; i++ {
+		conf := map[string]string{
+			tenant.ProjectSchedulerHost:  "https://scheduler.example.com",
+			tenant.ProjectStoragePathKey: "fs://bucket",
+		}
+		p, err := tenant.NewProject(fmt.Sprintf("proj-%d", i), conf, nil)
+		assert.NoError(t, err)
+		projects = append(projects, p)
+	}
+
+	projectRepo := &mockAirflowSyncProjectRepo{}
+	projectRepo.On("GetAll", mock.Anything).Return(projects, nil)
+
+	stateRepo := &concurrencyTrackingSyncStateRepo{}
+
+	worker := NewAirflowStateSyncWorker(log.NewNoop(), projectRepo, stateRepo, noopWindowReconciler{}, AirflowStateSyncConfig{
+		MaxAttempts:           3,
+		MaxConcurrentProjects: maxConcurrent,
+	})
+
+	worker.tick(context.Background())
+
+	assert.EqualValues(t, numProjects, atomic.LoadInt32(&stateRepo.calls), "every project should be processed exactly once")
+	assert.LessOrEqual(t, int(atomic.LoadInt32(&stateRepo.max)), maxConcurrent, "concurrency must not exceed MaxConcurrentProjects")
+	assert.Greater(t, int(atomic.LoadInt32(&stateRepo.max)), 1, "tick should actually run projects concurrently, not serially")
+}

--- a/core/scheduler/service/job_run_service.go
+++ b/core/scheduler/service/job_run_service.go
@@ -88,6 +88,10 @@ type JobReplayRepository interface {
 
 type OperatorRunRepository interface {
 	GetOperatorRun(ctx context.Context, operatorName string, operator scheduler.OperatorType, jobRunID uuid.UUID) (*scheduler.OperatorRun, error)
+	// ListLatestOperatorRunsByJobRunID returns the newest row per distinct operator name for a
+	// job run -- used by the airflow-sync reconciler to see every child's current status before
+	// deciding what to touch (unlike GetOperatorRun, which only looks up one known name).
+	ListLatestOperatorRunsByJobRunID(ctx context.Context, operator scheduler.OperatorType, jobRunID uuid.UUID) ([]*scheduler.OperatorRun, error)
 	CreateOperatorRun(ctx context.Context, operatorName string, operator scheduler.OperatorType, jobRunID uuid.UUID, startTime time.Time) error
 	UpdateOperatorRun(ctx context.Context, operator scheduler.OperatorType, jobRunID uuid.UUID, eventTime time.Time, state scheduler.State) error
 }

--- a/core/scheduler/service/job_run_service_test.go
+++ b/core/scheduler/service/job_run_service_test.go
@@ -2783,6 +2783,14 @@ func (m *mockOperatorRunRepository) GetOperatorRun(ctx context.Context, operator
 	return args.Get(0).(*scheduler.OperatorRun), args.Error(1)
 }
 
+func (m *mockOperatorRunRepository) ListLatestOperatorRunsByJobRunID(ctx context.Context, operator scheduler.OperatorType, jobRunID uuid.UUID) ([]*scheduler.OperatorRun, error) {
+	args := m.Called(ctx, operator, jobRunID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*scheduler.OperatorRun), args.Error(1)
+}
+
 func (m *mockOperatorRunRepository) CreateOperatorRun(ctx context.Context, operatorName string, operator scheduler.OperatorType, jobRunID uuid.UUID, startTime time.Time) error {
 	args := m.Called(ctx, operatorName, operator, jobRunID, startTime)
 	return args.Error(0)

--- a/core/scheduler/status.go
+++ b/core/scheduler/status.go
@@ -64,6 +64,13 @@ func (j State) String() string {
 	return string(j)
 }
 
+// IsTerminal reports whether the run has reached success or failed. Used by the
+// airflow-sync reconciler when mirroring Airflow's own dagrun-level cascade, which only
+// touches non-terminal task instances and leaves already-finished ones alone.
+func (j State) IsTerminal() bool {
+	return j == StateSuccess || j == StateFailed
+}
+
 type DataCompletenessStatus struct {
 	IsComplete             bool
 	DataCompletenessByDate []*DataCompletenessByDate

--- a/core/tenant/service/secret_service_test.go
+++ b/core/tenant/service/secret_service_test.go
@@ -17,7 +17,7 @@ import (
 func TestSecretService(t *testing.T) {
 	ctx := context.Background()
 	bytes := []byte("32charshtesthashtesthashtesthash")
-	key := (*[32]byte)(bytes[:])
+	key := (*[32]byte)(bytes)
 	projectName, _ := tenant.ProjectNameFrom("test-project")
 	nsName := "test-namespace"
 	invalidSecret := tenant.Secret{}

--- a/dev/optimus.values.yaml
+++ b/dev/optimus.values.yaml
@@ -56,6 +56,7 @@ configYaml: |-
     overlap_epsilon_in_seconds: 2
     max_attempts: 3
     max_windows_per_tick: 6
+    max_concurrent_projects: 5
   plugins:
     location: /app/plugins
   telemetry:

--- a/dev/optimus.values.yaml
+++ b/dev/optimus.values.yaml
@@ -50,13 +50,10 @@ configYaml: |-
     worker_lock_duration_minutes: 120
   airflow_sync:
     window_interval_in_seconds: 30
-    settling_delay_in_seconds: 5
     lock_duration_in_seconds: 60
-    initial_lookback_in_seconds: 60
-    overlap_epsilon_in_seconds: 2
-    max_attempts: 3
-    max_windows_per_tick: 6
     max_concurrent_projects: 5
+    max_attempts: 3
+    # exclude_projects: []
   plugins:
     location: /app/plugins
   telemetry:

--- a/dev/optimus.values.yaml
+++ b/dev/optimus.values.yaml
@@ -48,6 +48,14 @@ configYaml: |-
   sla:
     worker_interval_minutes: 60
     worker_lock_duration_minutes: 120
+  airflow_sync:
+    window_interval_in_seconds: 30
+    settling_delay_in_seconds: 5
+    lock_duration_in_seconds: 60
+    initial_lookback_in_seconds: 60
+    overlap_epsilon_in_seconds: 2
+    max_attempts: 3
+    max_windows_per_tick: 6
   plugins:
     location: /app/plugins
   telemetry:

--- a/docs/docs/rfcs/20260727_manual_state_override_reconciliation.md
+++ b/docs/docs/rfcs/20260727_manual_state_override_reconciliation.md
@@ -1,0 +1,296 @@
+- Feature Name: Reconciling manually-overridden Airflow run states
+- Status: draft
+- Start Date: 2026-07-27
+- Authors: muhammad.fahlevi
+
+# Summary
+
+**What** — Detect when an engineer manually changes a task/DAG state in Airflow and bring
+Optimus's `job_run` / `task_run` / `sensor_run` / `hook_run` rows back in line.
+
+**Why** — Manual overrides bypass the operator callbacks Optimus relies on, so no event is posted.
+Optimus keeps a stale `running`/`failed`, producing false-positive incompleteness alerts.
+
+**How** — A background worker polls each Airflow's `log` (audit) table for human-driven state
+changes, maps them onto Optimus's run tables, and reconciles.
+
+**Impact** — New worker, new config, one new table, additive repository methods. No API or
+DAG-template change. Writes land in tables that feed alerting, SLA prediction and duration
+estimation, so write scope must be conservative.
+
+# Verified behaviour of Airflow 2.9.3
+
+Confirmed against production `log` rows and by reading the 2.9.3 source in the running image.
+Airflow app version 2.9.3 (chart 1.15.0, image `2.9.3-python3.12-1.1.0`).
+
+### V1. The audit-log approach works; the bare event names are the right filter
+
+The 2.9 grid UI posts to the **legacy `www` form endpoints**, so human marks appear as bare
+`success` / `failed` / `dagrun_success` / `dagrun_failed`. Their `extra` is the tell:
+
+```
+success        | extra = {"confirmed":"true","past":"false","future":"false",
+                          "upstream":"false","downstream":"false"}
+dagrun_success | extra = {"confirmed":"true"}
+```
+
+Requests served under `/api/v1` are instead prefixed `api.` / `ui.`
+(`api.patch_task_instance`, `api.post_set_task_instances_state`, `api.update_dag_run_state`,
+`api.post_clear_task_instances`, `api.clear_dag_run`).
+
+**Useful consequence:** Optimus's own replay/clear calls go through `/api/v1`, so they land under
+`api.*` and are naturally excluded by a bare-name filter. The feedback-loop risk of the reconciler
+fighting the replay worker is therefore already mitigated — provided the filter stays on bare
+names. Worth an explicit test so a future refactor doesn't silently widen it.
+
+**Residual gap:** state changes driven through the REST API by anything other than Optimus
+(scripts, other tooling) produce `api.*` events and will be missed. Decide whether that is in
+scope; if so, those need separate handling because their shape differs (see V4).
+
+### V2. Worker transitions also write `success`/`failed`, but are distinguishable
+
+`airflow/models/taskinstance.py` and `dagrun.py` insert `Log` rows for ordinary transitions:
+
+```
+ id   | event   | task_id | owner             | owner_display_name | extra
+ 1410 | success | python  | @muhammad.fahlevi | NULL               | NULL
+```
+
+`owner` is the **DAG owner**, `owner_display_name` is NULL, `extra` is NULL. So
+`owner_display_name IS NOT NULL` correctly isolates human actions, as proposed.
+
+Two caveats:
+- `self.owner_display_name = owner_display_name or None` — an **anonymous** UI action becomes
+  NULL too. Not an issue with SSO enforced (production shows `google_…` owners with real display
+  names), but it is why `extra IS NOT NULL` is a slightly stronger equivalent discriminator.
+- `GET /api/v1/eventLogs` **does not expose `owner_display_name`** (nor `map_index`). The
+  discriminator is therefore only available via **direct DB access** — see V6.
+
+### V3. `confirmed=false` rows are previews that changed nothing
+
+`_mark_dagrun_state_as_success/failed` call `set_dag_run_state_to_*(…, commit=confirmed)`, and
+`@action_logging` writes its row **before** the handler runs. So a `dagrun_success` row with
+`extra->>'confirmed' = 'false'` logged an action that **did not happen**.
+
+`success`/`failed` (task-level) ignore `confirmed` in 2.9.3 and always apply.
+
+**Required filter addition:** `AND (event NOT LIKE 'dagrun_%' OR extra::jsonb->>'confirmed' = 'true')`,
+or simply require `confirmed = 'true'` for all four events.
+
+More generally, because the row is written first, 404s and permission-denied attempts also log.
+
+### V4. Bulk flags change many task instances but write one row
+
+`extra` carries `past`/`future`/`upstream`/`downstream`. When any is `"true"`, a single log row
+corresponds to an unknown set of changed task instances — potentially across **other DAG runs**
+(`past`/`future` span execution dates).
+
+The audit log cannot enumerate them. Options: (a) treat any bulk-flagged row as a trigger to
+re-read actual state for that DAG from Airflow, or (b) explicitly scope v1 to
+`past=future=upstream=downstream=false` and count the rest in a metric. Option (b) is a
+defensible v1 as long as the gap is measured rather than silent.
+
+### V5. Airflow's own cascade is asymmetric — mirror it, don't force-set
+
+From `airflow/api/common/mark_tasks.py`:
+
+- `set_dag_run_state_to_failed`: sets the dag run failed, then marks **only**
+  `RUNNING` / `DEFERRED` / `UP_FOR_RESCHEDULE` task instances failed, marks other unfinished ones
+  `SKIPPED`, and **leaves already-terminal tasks untouched**.
+- `set_dag_run_state_to_success`: sets all task instances to success.
+
+So the proposed "cascade update to force all associated children into the target state" is wrong
+for the failure case — it would rewrite genuinely-successful task rows to `failed`, corrupting the
+duration/percentile history that `GetPercentileDurationByJobNames` and the SLA predictor consume.
+
+Note Airflow's `SKIPPED` has **no Optimus equivalent** (`core/scheduler/status.go` has no
+`skipped`), so those instances need an explicit decision — most likely leave untouched.
+
+### V6. REST vs direct DB
+
+Because the discriminator (`owner_display_name`) is not exposed over REST, and because there is no
+`id >` predicate on `eventLogs` (only `after`/`before` on `dttm`), the original instinct to read
+the `log` table directly is justified. It is nevertheless a **new dependency**: Optimus currently
+has exactly one DSN (`serve.db.dsn`) and has never connected to Airflow's metadata DB.
+
+That brings: a second pool, a read-only Airflow DB user + secret, a network path, and coupling to
+Airflow's internal schema across upgrades. All acceptable, but they should be a conscious,
+documented decision rather than a side effect — and the read-only grant matters, since this is a
+write-capable database that Optimus has no business writing to.
+
+### V7. There is no single Airflow
+
+`SCHEDULER_HOST` is **project-level** config (`ext/scheduler/airflow/airflow.go:626`), so there are
+N Airflow instances with independent `log.id` sequences. A single global `last_processed_log_id`
+is incorrect — the watermark must be keyed per scheduler host, as must the DB connection.
+
+# Technical design
+
+## Point 5 — synchronisation between replicas (revised)
+
+**Do not use `pg_try_advisory_lock`:**
+
+1. The codebase contains no advisory locks anywhere; the established idiom is a lease claim.
+2. Session-level advisory locks bind to a specific pooled connection. With `pgxpool`,
+   `pg_advisory_unlock` can run on a *different* connection, silently leaking the lock until that
+   connection is recycled.
+3. `pg_advisory_xact_lock` avoids the leak but forces the cycle into one long transaction, holding
+   a connection and generating bloat.
+
+**Use the existing lease pattern** — mirror `GetExpiredSLAsForProcessing`
+(`internal/store/postgres/scheduler/sla_repository.go:124`). Co-locate lease and watermark in one
+row keyed per scheduler host (V7), so claim + watermark read are atomic:
+
+```sql
+UPDATE airflow_sync_state
+   SET worker_signature = $1, worker_lock_until = now() + $2, updated_at = now()
+ WHERE scheduler_host = $3
+   AND (worker_lock_until IS NULL OR worker_lock_until < now())
+RETURNING last_processed_log_id, last_processed_dttm;
+```
+
+Gate on `RowsAffected() == 1`; losers skip the cycle. Crash recovery is automatic via expiry.
+
+**Fence the write-back** — a slow worker whose lease expired must not clobber a newer watermark:
+
+```sql
+UPDATE airflow_sync_state
+   SET last_processed_log_id = $1, last_processed_dttm = $2, updated_at = now()
+ WHERE scheduler_host = $3
+   AND worker_signature = $4
+   AND worker_lock_until > now();
+```
+
+0 rows affected ⇒ lease lost mid-cycle ⇒ discard this cycle's progress and log it.
+
+Bound each cycle's batch so it cannot outlive the lease, and set `worker_lock_until` above p99
+cycle time. Note `server/optimus.go:247` cancels worker contexts then immediately closes the DB
+pool without waiting, so check `ctx.Err()` between steps or every shutdown logs spurious errors.
+
+## Point 6 — codebase changes (revised)
+
+| File | Change |
+|---|---|
+| `migrations/000NNN_create_airflow_sync_state.{up,down}.sql` | `scheduler_host TEXT PRIMARY KEY`, `last_processed_log_id BIGINT`, `last_processed_dttm TIMESTAMPTZ`, `worker_signature UUID`, `worker_lock_until TIMESTAMPTZ`, timestamps |
+| `internal/store/postgres/scheduler/airflow_sync_state_repository.go` | new: `ClaimForProcessing`, `CommitWatermark`, both fenced |
+| `ext/scheduler/airflow/audit_log_reader.go` (new, in `package airflow`) | the Airflow-DB read. Keep it behind an interface so the service is testable and a future REST implementation can swap in |
+| `internal/store/postgres/scheduler/job_run_repository.go` | additive: lookup by `(project, job_name, scheduled_at)` in batch; batch state update |
+| `internal/store/postgres/scheduler/job_operator_repository.go` | additive: fetch/update newest child by `(job_run_id, name)`. Keep the `operatorTypeToTableName` seam |
+| `core/scheduler/service/airflow_state_sync_service.go` | new: parse rows → resolve entity → apply write-scope rules |
+| `core/scheduler/service/airflow_state_sync_worker.go` | new: ticker + lease + per-host fan-out, modelled on `sla_worker.go:54` |
+| `core/scheduler/job_run.go` | shared domain types (`scheduler` cannot import `service`) |
+| `core/scheduler/status.go` | Airflow→Optimus state map + ignore-list (see below) |
+| `config/config_server.go` | `AirflowSyncConfig`: interval, lock duration, per-host DSNs, lookback cap, batch size. `mapstructure` + `default:` tags |
+| `server/optimus.go` | wire next to the SLA worker (~line 479), guarded by `interval > 0` |
+| `config.sample.yaml`, `dev/optimus.values.yaml` | document new keys |
+
+Deviations from the original: a dedicated repository for lease+watermark rather than piling onto
+`job_run_repository.go`, and the Airflow-side read isolated behind its own interface rather than
+extending `client.go` (which is REST-shaped — `Client.Invoke` takes the unexported
+`airflowRequest`, so a DB reader does not belong there).
+
+## Entity resolution
+
+1. `dag_id` → Optimus job. On a shared Airflow, `dag_id` is only unique per project — resolve via
+   the project owning that `SCHEDULER_HOST`, and no-op on unknown DAGs.
+2. `run_id` → `scheduled_at`. `execution_date` is **NULL** in these rows; only `run_id` is
+   populated, and it comes in at least three shapes seen in production:
+   - `scheduled__2026-07-24T18:00:00+00:00`
+   - `custom-backfill_<uuid>__2026-07-25T09:38:53+00:00`
+   - `replayed__2025-05-29T18:00:00+00:00`
+   Parse the trailing timestamp, then apply the **same shift `__lib.py` uses**:
+   `croniter(interval, execution_date).get_next()`. Optimus's `scheduled_at` is *not*
+   `execution_date`; skipping this puts every row one interval off.
+3. `task_id` → run type via prefix: `wait_*` → `sensor_run`, `hook_*` → `hook_run`, otherwise
+   `task_run`. **This classifier does not exist in Go today** — it lives only in
+   `__lib.py get_run_type`. Add it next to `core/scheduler/job.go:48` and reuse `OperatorType`,
+   ideally sharing the prefixes with the DAG template rather than re-hardcoding them.
+4. Child rows have no unique constraint and retries insert duplicates; update the newest by
+   `created_at`, matching `GetOperatorRun`'s `ORDER BY created_at DESC LIMIT 1`.
+
+## Write-scope rules
+
+- **Only map to states `StateFromString` accepts.** `canceled`, `up_for_retry`, `restarting`,
+  `missing` are rejected on read (`core/scheduler/status.go:36`); persisting them makes later reads
+  fail hard. Airflow's `skipped`/`upstream_failed`/`removed`/`deferred` have no equivalent — use an
+  explicit map with an ignore-list, never a naive string pass-through.
+- **Mirror Airflow's asymmetric cascade (V5).** On `dagrun_failed`, only update non-terminal
+  children; never rewrite an existing `success`.
+- **Never regress fresher data.** A callback may have landed after the manual action. Compare the
+  log row's `dttm` against the row's `updated_at` and skip if ours is newer.
+- **Do not invent `end_time`.** Writing `now()` skews duration estimation for every future
+  prediction on that job. Prefer the log `dttm`, or leave it alone.
+- **Prefer not to roll up `job_run` from siblings.** Marking one task success does not finish the
+  DAG; Airflow recomputes the dag-run state and the DAG-level callback normally still fires, so
+  `job_run` often self-heals. Rolling up risks declaring a job complete while downstream tasks are
+  still running. (`IsAllTerminated` / `IsAnyFailure` in `status.go` remain available if wanted.)
+- **Emit state-change events.** Call `raiseJobRunStateChangeEvent`
+  (`core/scheduler/service/job_run_service.go:960`) so downstream consumers don't desync — but
+  decide deliberately whether it should alert (see unresolved question 1).
+
+## Edge cases
+
+**Correctness**
+1. **Sequence gap.** Transaction A takes `id` 100, B takes 101 and commits first. A read at that
+   instant sees 101, advances the watermark past 100, and 100 is skipped forever. Mitigate with a
+   settling delay — only process rows with `dttm < now() - 60s`. The same delay avoids racing
+   in-flight callbacks.
+2. Ordering — apply rows in ascending `id`, and make writes idempotent so a replayed cycle is a
+   no-op. Production data shows genuinely messy sequences (a `dagrun_success`, then a task
+   `success`, then another `dagrun_success` 20s apart on the same run).
+3. Clock skew between Optimus and Airflow if `dttm` is used for resume; keep a safety overlap and
+   de-duplicate on `id`.
+4. `airflow db clean` truncates `log`; the watermark must tolerate its rows vanishing.
+5. `map_index` (dynamic task mapping) is not modelled by Optimus's child tables — ignore
+   explicitly rather than by accident.
+
+**Scope / mapping**
+6. `custom-backfill_*` and `replayed__*` runs both appear in the data, and a human marking a
+   *replayed* run success is a real observed case — decide whether these are in scope.
+7. Renamed/deleted jobs and non-Optimus DAGs on a shared Airflow must no-op quietly.
+8. Task-group marks (`group_id` instead of `task_id`) hit the same endpoints and log `task_id`
+   NULL — detect and skip, or expand.
+
+**Operational**
+9. One unreachable Airflow DB must not starve other projects — isolate per host and still advance
+   the others.
+10. First run against a long backlog could be enormous — cap the initial lookback and batch size.
+11. Skip projects with `DISABLE_JOB_SCHEDULING`.
+12. Emit `airflow_state_reconciled_total{reason,result}` so divergence stays visible. A reconciler
+    silently repairing a broken callback path is a monitoring blind spot.
+
+# Drawbacks
+
+- New coupling to Airflow's internal `log` schema and to view-function names, neither of which is
+  a public API. Both can change on upgrade. Mitigation: keep the event names and `extra` keys in
+  one well-commented constant block, and add a test that fails loudly if the shape changes.
+- A second DB dependency (V6).
+- Bulk-flagged rows are not fully handled in v1 (V4).
+
+# Rationale and Alternatives
+
+- **State reconciliation** (poll Airflow for the current state of runs Optimus thinks are
+  unfinished, and diff) — immune to event-name coupling, bulk-op blindness and the
+  attempt-vs-outcome gap, needs no Airflow DB access, and additionally repairs state lost to
+  dropped callbacks or webserver 5xx. Costs more requests and loses attribution. Worth keeping in
+  mind as the v2 if audit-log parsing proves brittle across upgrades; the two are compatible
+  (audit log for attribution, reconciliation for correctness).
+- **REST `eventLogs` polling** — no new DB dependency, but cannot express the
+  `owner_display_name` discriminator or an `id >` predicate (V2, V6).
+- **Airflow listener plugin** — the correct long-term fix, but requires Airflow 3.x.
+- **Push from `__lib.py`** — cannot help; manual overrides are exactly the case where no task code
+  runs.
+
+# Unresolved questions
+
+1. **Should reconciliation alert?** Suppress on `failed`→`success`; what about a late
+   `running`→`failed`? Product decision.
+2. Are `clear` operations in scope? A cleared task re-runs and self-heals via callbacks, but a
+   cleared-then-never-scheduled task leaves a stale row.
+3. Bulk-flagged rows (V4): scope out with a metric, or trigger a state re-read?
+4. Backfill (`custom-backfill_*`) and replay (`replayed__*`) runs in scope?
+5. REST-driven (`api.*`) overrides from non-Optimus tooling in scope?
+6. Poll interval and lookback defaults (10 min proposed; interacts with the settling delay in
+   edge case 1).
+7. How are per-host Airflow DSNs supplied and rotated — server config, or a per-project secret
+   alongside `SCHEDULER_AUTH`?

--- a/docs/docs/rfcs/20260727_manual_state_override_reconciliation.md
+++ b/docs/docs/rfcs/20260727_manual_state_override_reconciliation.md
@@ -317,7 +317,10 @@ and pagination stable (V6). Four things it needs to be correct:
    short-lived seen-set) to drop the re-delivered rows.
 3. **Catch-up loop.** After downtime, one window per tick falls permanently behind. Process
    windows in a bounded loop per tick until caught up, and cap the very first window's lookback so
-   a fresh deployment doesn't try to ingest all of history.
+   a fresh deployment doesn't try to ingest all of history. **Revised:** the lookback cap is not a
+   separate config value — it's derived as `WindowInterval × MaxWindowsPerTick`, so a fresh
+   project's entire backlog always fits inside one tick's catch-up budget by construction, rather
+   than risking a lookback that's set larger than what the per-tick loop can actually drain.
 4. **Crash recovery** — see the table design below.
 
 ## `airflow_sync_state` design
@@ -529,6 +532,15 @@ cap. That confirms the originally-proposed 10-minute window remains safe without
 even against the largest project in this deployment — no further tuning needed on window size
 itself.
 
+**Indexes.** Confirmed present on this deployment's `log` table: `idx_log_dttm`, `idx_log_event`,
+`idx_log_dag` — standard Airflow indexes, not anything added for this feature. No composite
+`(dttm, event)` index exists or is recommended: at ~0.02% selectivity (435 of ~2M rows in a
+30-day table), the `dttm` range predicate alone is already enough for the planner to pick a cheap
+plan (an index scan on `idx_log_dttm`, or a bitmap AND with `idx_log_event`) and filter the
+remainder in memory. A composite index would only save filtering a few hundred rows — not worth
+adding write overhead to Airflow's own hottest table, or drift outside Airflow's managed schema,
+for that. Revisit only if `EXPLAIN ANALYZE` on the real query ever shows a sequential scan.
+
 **Keying: per project or per scheduler host? Resolved: per project, confirmed against production.**
 `eventLogs` only filters a **single** `dag_id` (V6), so a per-project worker must fetch the whole
 window and map `dag_id` → project client-side; where several Optimus projects share one
@@ -594,7 +606,7 @@ waiting, so check `ctx.Err()` between pages or every shutdown logs spurious clos
 | `core/scheduler/service/airflow_state_sync_worker.go` | new: ticker + lease + per-host fan-out, modelled on `sla_worker.go:54` |
 | `core/scheduler/job_run.go` | shared domain types (`scheduler` cannot import `service`) |
 | `core/scheduler/status.go` | Airflow→Optimus state map + ignore-list (see below) |
-| `config/config_server.go` | `AirflowSyncConfig`: window interval, settling delay, lock duration, initial lookback cap, page size, max windows per tick, optional owner deny-list. `mapstructure` + `default:` tags on every field (a zero interval panics `NewTicker`) |
+| `config/config_server.go` | `AirflowSyncConfig`: window interval, lock duration, max concurrent projects, max attempts, exclude-project list. `mapstructure` + `default:` tags (a zero window interval panics `NewTicker`, so it deliberately has none and doubles as the on/off switch). Settling delay, overlap epsilon and max-windows-per-tick are fixed constants in the worker, not config — see "Config surface" below |
 | `server/optimus.go` | wire next to the SLA worker (~line 479), guarded by `interval > 0` |
 | `config.sample.yaml`, `dev/optimus.values.yaml` | document new keys |
 
@@ -604,6 +616,33 @@ read is REST and belongs in `client.go`/`airflow.go` after all.
 
 **Unresolved questions 3, 5 and 7 from the first draft are now closed:** fetch is via REST, so
 there is no Airflow DSN to supply or rotate, and no second connection pool.
+
+### Config surface (revised)
+
+The first implementation exposed eight tunable fields. In practice most of them were either a
+fixed correctness margin (an order of magnitude larger than what it protects against) or a value
+that could silently contradict another field (an initial lookback set smaller than
+`WindowInterval × MaxWindowsPerTick` would never fully apply). Reduced to five:
+
+| Field | Configurable? |
+|---|---|
+| `window_interval_in_seconds` | yes — also the on/off switch (0 disables the worker) |
+| `lock_duration_in_seconds` | yes — depends on this deployment's Airflow latency and event volume |
+| `max_concurrent_projects` | yes — depends on project count and pod resources |
+| `max_attempts` | yes — how tolerant to be of a flaky Airflow instance is a deployment judgment call |
+| `exclude_projects` | yes — see below |
+| settling delay | no — fixed at 60s, roughly three orders of magnitude above typical commit latency |
+| overlap epsilon | no — fixed at 2s; only needs to cover a boundary tie, not clock skew (settling delay covers that) |
+| max windows per tick | no — fixed at 12; a catch-up throttle, not a deployment property |
+| initial lookback | not separate — derived as `window_interval × max_windows_per_tick` |
+
+**`exclude_projects`** is new: a list of project names to skip syncing entirely (an unstable
+instance, or a project not yet rolled out to this feature). Every project syncs by default —
+this is an exclude-list, not an allow-list. Excluding a project simply stops processing it and
+freezes its watermark; there's no separate staleness handling for re-inclusion after a long
+exclusion — a re-included project's backlog catches up the same way any post-downtime backlog
+does, bounded by `max_windows_per_tick` per tick. Kept deliberately simple over a staleness-clamp
+alternative.
 
 ## Entity resolution
 
@@ -780,8 +819,13 @@ Siren's resolve semantics wired up, so treat it as a follow-up rather than v1.
 **Operational**
 9. One unreachable Airflow DB must not starve other projects — isolate per host and still advance
    the others.
-10. First run against a long backlog could be enormous — cap the initial lookback and batch size.
-11. Skip projects with `DISABLE_JOB_SCHEDULING`.
+10. First run against a long backlog could be enormous — mitigated by deriving the initial
+    lookback from `window_interval × max_windows_per_tick` (see "Config surface"), so it can never
+    exceed one tick's catch-up budget.
+11. **Skipping a project.** Not wired to `DISABLE_JOB_SCHEDULING` — that remains unimplemented.
+    Instead, `exclude_projects` (see "Config surface") is an explicit, manually-maintained
+    exclude-list. Revisit tying it to `DISABLE_JOB_SCHEDULING` if manual maintenance proves to be
+    a real operational burden.
 12. Emit `airflow_state_reconciled_total{reason,result}` so divergence stays visible. A reconciler
     silently repairing a broken callback path is a monitoring blind spot.
 
@@ -844,8 +888,12 @@ Siren's resolve semantics wired up, so treat it as a follow-up rather than v1.
   and would otherwise leak a goroutine per genuinely-hung request instead of surfacing as a
   retryable attempt error.
 - New metric `airflow_sync_windows_failed_total{project}`: `FailExhaustedWindows` giving up on a
-  window was previously only a log line — with 19 independent projects/Airflow instances as
+  window was previously only a log line — with many independent projects/Airflow instances as
   separate failure domains, that needed to be alertable per project, not just grep-able.
+- **Config surface reduced from eight fields to five** (see "Config surface" above): settling
+  delay, overlap epsilon and max-windows-per-tick are now fixed constants, and initial lookback is
+  derived rather than separately set. Added `exclude_projects`, a manual exclude-list for projects
+  that shouldn't sync (unstable instance, not yet rolled out).
 
 All items in this section are now decided; nothing left blocking implementation.
 

--- a/docs/docs/rfcs/20260727_manual_state_override_reconciliation.md
+++ b/docs/docs/rfcs/20260727_manual_state_override_reconciliation.md
@@ -106,17 +106,35 @@ duration/percentile history that `GetPercentileDurationByJobNames` and the SLA p
 Note Airflow's `SKIPPED` has **no Optimus equivalent** (`core/scheduler/status.go` has no
 `skipped`), so those instances need an explicit decision — most likely leave untouched.
 
-### V6. REST vs direct DB
+### V6. REST is viable — `extra` is exposed, so `owner_display_name` is not needed
 
-Because the discriminator (`owner_display_name`) is not exposed over REST, and because there is no
-`id >` predicate on `eventLogs` (only `after`/`before` on `dttm`), the original instinct to read
-the `log` table directly is justified. It is nevertheless a **new dependency**: Optimus currently
-has exactly one DSN (`serve.db.dsn`) and has never connected to Airflow's metadata DB.
+**Decision: fetch via `GET /api/v1/eventLogs`.** No Airflow-DB dependency.
 
-That brings: a second pool, a read-only Airflow DB user + secret, a network path, and coupling to
-Airflow's internal schema across upgrades. All acceptable, but they should be a conscious,
-documented decision rather than a side effect — and the read-only grant matters, since this is a
-write-capable database that Optimus has no business writing to.
+`owner_display_name` is not exposed over REST, but it turns out not to be needed: **`extra` is
+exposed**, and `extra` alone separates human from worker rows more precisely than
+`owner_display_name` does. See "Identifying manual actions" below.
+
+Mechanics of the endpoint, read from `api_connexion/endpoints/event_log_endpoint.py`:
+
+- Filters: `dag_id` (single value only — `Log.dag_id == dag_id`, no list), `task_id`, `run_id`,
+  `owner`, `event`, `included_events` / `excluded_events` (comma-separated), `before`, `after`.
+- **Both time bounds are strict**: `Log.dttm < before` and `Log.dttm > after`.
+- `order_by` accepts `event_log_id` (→ `id`) and `when` (→ `dttm`).
+- `limit` is capped by the `[api] maximum_page_limit` config (default 100), so **pagination via
+  `offset` is mandatory**; `total_entries` is returned so truncation is detectable.
+- `extra` comes back as a **JSON-encoded string**, not a nested object
+  (`"extra": "{\"confirmed\": \"true\"}"`) — Go must unmarshal the string, then its contents.
+
+Two consequences that shape the design:
+
+1. **Strict-on-both-ends bounds create a boundary hole.** With windows `(t0, t1)` then `(t1, t2)`,
+   a row whose `dttm` is exactly `t1` is excluded from *both* (`< t1` fails, `> t1` fails).
+   Microsecond precision makes it unlikely, but "unlikely" is not a correctness argument for a
+   reconciliation feature. Overlap each window by a small epsilon and de-duplicate on
+   `event_log_id`.
+2. **Fixed closed windows make pagination safe.** Because the upper bound is fixed, rows arriving
+   mid-pagination land beyond `before` and cannot shift pages. An open-ended `after`-only watermark
+   would not have this property. This is a real advantage of the windowing approach.
 
 ### V7. There is no single Airflow
 
@@ -125,6 +143,356 @@ N Airflow instances with independent `log.id` sequences. A single global `last_p
 is incorrect — the watermark must be keyed per scheduler host, as must the DB connection.
 
 # Technical design
+
+## Identifying manual actions
+
+**Gate on `extra`; record `owner` but do not gate on it.**
+
+The precise question is "was this row written by `@action_logging`?", because that decorator only
+runs on webserver request handlers — never on the scheduler/worker path. Its REST-visible
+fingerprint is `extra`:
+
+| Source | `extra` | `owner` |
+|---|---|---|
+| worker / scheduler transition | `NULL` | DAG owner (`@someone`) |
+| human, task mark (`success`/`failed`) | `{"confirmed","past","future","upstream","downstream"}` | auth username (`google_…`) |
+| human, dagrun mark (`dagrun_*`) | `{"confirmed"}` | auth username |
+
+### Why `extra IS NOT NULL` is provably sufficient
+
+There are exactly **seven** places in Airflow 2.9.3 that write a `log` row (verified by grepping
+the installed package):
+
+| Writer | event | `extra` |
+|---|---|---|
+| `taskinstance.py:2310` | `running` | NULL |
+| `taskinstance.py:2498` | `self.state` (`success`/`failed`/…) | NULL |
+| `taskinstance.py:2565` | `self.state` | NULL |
+| `taskinstance.py:2920` | `failed` | NULL |
+| `dagrun.py:598` | `paused` | populated, `owner_display_name='Scheduler'` |
+| `utils/cli.py` (`action_cli`) | `cli_<sub_command>` | populated |
+| `www/decorators.py:137` (`action_logging`) | view function name | **always** populated |
+
+Restricted to the four target events, the only writers that can produce them are the
+`taskinstance.py` ones (always `extra = NULL`) and `action_logging` (always `extra` populated).
+`dagrun_success` / `dagrun_failed` have no model-code writer at all — only `action_logging`.
+
+So **within the four-event filter, `extra IS NOT NULL` ⟺ the row came from `action_logging`.**
+That is a structural argument, not an empirical one.
+
+Note `dagrun.py:598` also disproves the general form of the original heuristic: a **scheduler**-written
+row carries `owner_display_name = 'Scheduler'`. It is harmless here because `event='paused'` is
+filtered out, but it means `owner_display_name IS NOT NULL` should not be the primary signal.
+
+### Empirical check against production (2026-07-27)
+
+```sql
+select * from log where event in ('success','dagrun_success')
+  and owner_display_name is not null
+  and (owner not like 'google_%' or (extra is null or extra::jsonb->>'confirmed' is null))
+  and dttm > '2026-07-01T00:00:00Z' limit 1;
+```
+
+Returned **no rows**. So for every row in this deployment since 2026-07-01 that the
+`owner_display_name IS NOT NULL` filter classifies as manual, `owner LIKE 'google_%'` **and**
+`extra->>'confirmed'` is present. Both candidate discriminators hold in practice.
+
+Follow-ups run on 2026-07-27, both clean:
+
+- The inverse query (`extra IS NOT NULL AND owner_display_name IS NULL`) returned **0 rows** — no
+  anonymous-user blind spot in this deployment.
+- `confirmed` is never `'false'`: `dagrun_success` 594 / `dagrun_failed` 32, all `'true'`, since
+  2026-07-01. So the preview case (V3) does not occur in practice here — the guard stays as
+  cheap insurance, not an active fix.
+
+The remaining unverified assumption is the `owner LIKE 'google_%'` pattern itself. The decisive
+test is **ungated** (unlike the query above, it does not pre-filter on `owner_display_name`), and
+works because `extra IS NOT NULL` on these four events already proves `action_logging` wrote the
+row — so every owner it lists is definitionally a manual actor:
+
+```sql
+select owner, count(*) from log
+where event in ('success','failed','dagrun_success','dagrun_failed')
+  and extra is not null
+  and dttm > '2026-07-01T00:00:00Z'
+group by 1 order by 2 desc;
+```
+
+If every owner returned starts with `google_`, the pattern is safe for this deployment. Anything
+else in that list is precisely a manual override an `owner LIKE 'google_%'` gate would drop.
+
+Two things the original query cannot establish, by construction:
+
+1. **Selection effect.** It samples only rows already matching `owner_display_name IS NOT NULL`, so
+   it cannot detect a manual mark that has `owner_display_name` NULL and is therefore missing from
+   the sample entirely (the anonymous-user case). The direct test is the inverse query — since
+   `extra IS NOT NULL` on these events *proves* `action_logging` wrote the row, any hit is a manual
+   action the `owner_display_name` filter would silently drop:
+
+   ```sql
+   select id, dttm, event, dag_id, owner, owner_display_name, extra from log
+   where event in ('success','failed','dagrun_success','dagrun_failed')
+     and extra is not null and owner_display_name is null
+     and dttm > '2026-07-01T00:00:00Z' limit 5;
+   ```
+
+2. **Whether `confirmed` is ever `'false'`.** The query tests presence (`IS NULL`), not value. For
+   `dagrun_*` a `confirmed='false'` row is a preview that changed nothing (V3), so this has a live
+   correctness impact:
+
+   ```sql
+   select event, extra::jsonb->>'confirmed' as confirmed, count(*) from log
+   where event in ('dagrun_success','dagrun_failed')
+     and dttm > '2026-07-01T00:00:00Z' group by 1,2 order by 1,2;
+   ```
+
+### `confirmed` is load-bearing for `dagrun_*` only
+
+`confirmed` must **not** be required for the task-level events:
+
+- `_mark_dagrun_state_as_success/failed` pass `commit=confirmed`, so for `dagrun_*` a
+  `confirmed=false` row is a preview that changed nothing. Requiring `"true"` there is both
+  correct and necessary (V3).
+- `Airflow.success()` / `.failed()` **ignore `confirmed` entirely** in 2.9.3 —
+  `_mark_task_instance_state` has no such parameter. The mark applies whether or not the client
+  sends it. `extra` only contains what the client actually sent, so requiring `confirmed` on
+  task-level events would **silently drop a real override** from any client that omits it. The grid
+  UI does send it, but it is not load-bearing, which makes it a fragile gate.
+
+Final filter:
+
+```
+event ∈ {success, failed, dagrun_success, dagrun_failed}   -- pushed down via included_events
+AND extra parses as a non-null JSON object                 -- the human/worker discriminator
+AND (event NOT LIKE 'dagrun_%' OR extra["confirmed"] == "true")   -- drop no-op previews
+```
+
+### One honest limitation
+
+This identifies "arrived through the legacy `www` mark endpoint", not strictly "a human clicked in
+the UI". A script doing a form POST to `/success` produces a byte-identical row. That is acceptable
+— arguably desirable, since it is still an external override Optimus must reconcile — but the
+wording of any alert should say "manually marked", not "marked by a user in the UI".
+
+**Why not gate on `owner LIKE 'google_%'`:**
+
+- It hardcodes one SSO provider into an open-source project. Any deployment on LDAP, local FAB
+  users, or a different OAuth provider silently stops detecting overrides.
+- It fails **silently** — the feature reports "no manual changes found", which is
+  indistinguishable from success. For a correctness feature that is the worst failure mode.
+- ANDing it with the `extra` check doubles the number of ways detection can silently break, while
+  adding no discriminating power the `extra` check doesn't already have.
+
+**What `owner` is genuinely good for:**
+
+- **Attribution** — carry it through to the reconciliation log line, metric label (bounded
+  cardinality permitting) and any alert body. "Marked success by X at T" is exactly the context an
+  on-call needs. This is worth doing.
+- **Exclusions** — an optional configurable deny-list, if a service account ever starts driving
+  the legacy endpoints and should be ignored. An exclusion that fails open is safe; an inclusion
+  pattern that fails closed is not.
+
+**Upgrade tripwire.** Since `extra`'s shape is a UI form contract, not an API, validate it rather
+than trusting it: for `success`/`failed` expect the five keys
+(`confirmed`/`past`/`future`/`upstream`/`downstream`), for `dagrun_*` expect `confirmed`. On an
+unexpected shape, **process the row anyway** (fail open — `extra IS NOT NULL` already proved it is
+a manual action) but emit a warning + metric. That converts an Airflow-upgrade regression into an
+alert rather than silent data loss. Failing open matters here: the four-event filter is the
+correctness gate, the shape check is only a canary.
+
+## Windowing and watermark
+
+Confirmed design: `airflow_sync_state` stores explicit `(start_time, end_time)` windows; the next
+window is `(previous_end_time, previous_end_time + interval)`.
+
+This is a good choice — it makes gaps impossible by construction, windows explicit and re-runnable,
+and pagination stable (V6). Four things it needs to be correct:
+
+1. **Clamp the upper bound.** Only claim a window when
+   `previous_end_time + interval <= now() - settling_delay` (≈60s). Processing a window whose end
+   is too recent, then advancing past it, permanently misses rows whose transaction had not yet
+   committed when queried. This is the REST equivalent of the sequence-gap hazard.
+2. **Overlap by epsilon + de-duplicate on `event_log_id`,** because both bounds are strict (V6).
+   Query `after = start_time - ε`, and keep the highest processed `event_log_id` per window (or a
+   short-lived seen-set) to drop the re-delivered rows.
+3. **Catch-up loop.** After downtime, one window per tick falls permanently behind. Process
+   windows in a bounded loop per tick until caught up, and cap the very first window's lookback so
+   a fresh deployment doesn't try to ingest all of history.
+4. **Crash recovery** — see the table design below.
+
+## `airflow_sync_state` design
+
+```sql
+CREATE TABLE IF NOT EXISTS airflow_sync_state (
+    id                   UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    project_name         VARCHAR(100) NOT NULL,
+    start_time           TIMESTAMPTZ  NOT NULL,
+    end_time             TIMESTAMPTZ  NOT NULL,
+
+    status               VARCHAR(30)  NOT NULL,
+    attempt_count        INT          NOT NULL DEFAULT 0,
+    last_error           TEXT,
+
+    worker_id            UUID,
+    locked_until         TIMESTAMPTZ,
+
+    -- highest event_log_id applied in this window. The API *does* return this as
+    -- `event_log_id` (see the sample response above), so it is available over REST.
+    -- Needed to de-duplicate the epsilon overlap between adjacent windows.
+    max_processed_log_id BIGINT,
+
+    -- observability only, not required for correctness:
+    --   events_matched  = rows in this window that passed the manual-override filter
+    --   runs_reconciled = Optimus run rows actually updated as a result
+    -- The *gap* between them is the useful signal: matched > 0 with reconciled = 0
+    -- means resolution is broken (wrong croniter shift, unknown dag_id, …) — a failure
+    -- that is otherwise completely silent.
+    events_matched       INT,
+    runs_reconciled      INT,
+
+    created_at           TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ  NOT NULL DEFAULT now(),
+
+    CONSTRAINT uniq_airflow_sync_window UNIQUE (project_name, start_time, end_time)
+);
+CREATE INDEX IF NOT EXISTS airflow_sync_state_project_end_time_idx
+    ON airflow_sync_state (project_name, end_time DESC);
+```
+
+Types follow existing precedent (`job_run`: `VARCHAR(100)` project name, `VARCHAR(30)` status,
+`uuid_generate_v4()` PK, plain varchar status rather than a PG enum).
+
+### Why a composite UNIQUE rather than a concatenated `sync_id`
+
+A string key of the form `<project>_<start>_<end>` works, but makes uniqueness depend on **every
+pod formatting the timestamp identically**. That is a live hazard here: this deployment's psql
+renders `dttm` as `+07` while the API returns `+00:00`, so `…T10:00:00Z` and `…T17:00:00+07:00`
+denote the same instant but are different strings — and therefore different `sync_id`s, which would
+let two pods each "own" the same window.
+
+`UNIQUE (project_name, start_time, end_time)` on `TIMESTAMPTZ` columns removes the class of bug
+entirely, because Postgres compares instants, not text. Keep a derived `sync_id` for log lines if
+useful, but do not let it carry uniqueness.
+
+### Status values
+
+Three terminal-or-not states, not four:
+
+| status | meaning |
+|---|---|
+| `in_progress` | claimed by a pod; `worker_id` + `locked_until` say who and until when |
+| `success` | all pages fetched and applied; watermark may advance past it |
+| `failed` | retries exhausted; needs an alert (see below) |
+
+`retrying` is better modelled as data than as a state — it is just `in_progress` with
+`attempt_count > 0`. Collapsing it removes a set of invalid transitions and means the re-claim query
+does not have to match two different statuses.
+
+### Claiming — the insert *is* the lock
+
+```sql
+INSERT INTO airflow_sync_state
+    (project_name, start_time, end_time, status, attempt_count, worker_id, locked_until)
+VALUES ($1, $2, $3, 'in_progress', 1, $4, now() + $5)
+ON CONFLICT (project_name, start_time, end_time) DO NOTHING;
+```
+
+`RowsAffected() == 1` ⇒ this pod owns the window. `0` ⇒ another pod owns it, or it is already
+terminal ⇒ skip. No read beforehand, so there is no check-then-act race.
+
+### Re-claiming after a pod dies
+
+Without this, a pod that crashes mid-window leaves the row `in_progress` forever and **every other
+pod skips it permanently**, wedging that project's sync:
+
+```sql
+UPDATE airflow_sync_state
+   SET worker_id = $1, locked_until = now() + $2,
+       attempt_count = attempt_count + 1, updated_at = now()
+ WHERE project_name = $3
+   AND status = 'in_progress'
+   AND locked_until < now()
+   AND attempt_count < $4
+RETURNING id, start_time, end_time;
+```
+
+Set `locked_until` above p99 window-processing time. When `attempt_count` reaches the cap, mark
+`failed`.
+
+### Completing — fenced
+
+```sql
+UPDATE airflow_sync_state
+   SET status = 'success', max_processed_log_id = $1, events_matched = $2,
+       runs_reconciled = $3, updated_at = now()
+ WHERE id = $4 AND worker_id = $5 AND locked_until > now();
+```
+
+0 rows ⇒ the lease expired and another pod re-claimed the window ⇒ discard progress and log. This
+is why reconciliation writes must be idempotent.
+
+### Watermark, and what to do about a poisoned window
+
+```sql
+SELECT max(end_time) FROM airflow_sync_state
+ WHERE project_name = $1 AND status IN ('success', 'failed');
+```
+
+Including `failed` is a deliberate choice: excluding it would make one permanently-failing window
+block the project's sync forever, so *all* later manual overrides go undetected — strictly worse
+than a bounded gap. So: retry with backoff, and on exhaustion mark `failed`, **alert**, and let the
+watermark move past it. The `failed` rows are the durable record of exactly which intervals were
+never reconciled, and can be re-run by resetting their status.
+
+### Serial within a project, parallel across projects
+
+This falls out of the above without extra machinery. Because the next window is always derived from
+`max(end_time)` over terminal rows, two pods ticking concurrently compute the *same* window and the
+unique constraint picks one winner; the loser skips. A pod cannot run ahead to window N+1 while N is
+still `in_progress`, because N is not terminal and so does not move the watermark. Different
+projects are independent rows, so they proceed in parallel naturally.
+
+With one project and 5 pods, 4 will no-op each tick. That is fine — the wasted work is a single
+failed insert.
+
+### Volume: ~99% of fetched rows are discarded, so window size decides feasibility
+
+A production `eventLogs` call filtered to the four events reported `total_entries: 107737`, against
+only 626 genuinely-manual `dagrun_*` rows in a comparable period. The reason is V2: worker task
+transitions also write bare `success`/`failed`, and there is **no server-side filter for
+`extra IS NOT NULL`** (nor a `LIKE` on `owner` — the API's `owner` filter is exact-match only). So
+the manual/worker split can only happen client-side, and the discard rate is ~99%.
+
+This is not fatal, because volume scales with window width:
+
+- 107737 rows over ~26 days ≈ **~29 rows per 10-minute window** — a single page.
+- But rows are not uniform. Optimus fleets cluster schedules (midnight UTC, top of hour), so a
+  peak window can be orders of magnitude above the mean.
+
+Therefore: **implement real pagination** (`offset`, ordered by `event_log_id`, loop until
+`total_entries` is exhausted) rather than assuming one page, and size the window from measured peak
+rather than mean:
+
+```sql
+select date_trunc('hour', dttm) as hour, count(*) from log
+where event in ('success','failed','dagrun_success','dagrun_failed')
+  and dttm > now() - interval '7 days'
+group by 1 order by 2 desc limit 5;
+```
+
+Peak-hour count ÷ 6 ≈ rows per 10-minute window; ÷ `[api] maximum_page_limit` (default **100**)
+gives the page count for the worst window. If that is unpleasant, options are a shorter window,
+raising `maximum_page_limit` on the Airflow side (affects all API consumers), or restricting
+server-side to `dagrun_success,dagrun_failed` only — those have **no** worker writer at all, so
+they need no client-side discard, at the cost of missing task-level marks.
+
+**Keying: per project or per scheduler host?** `eventLogs` only filters a **single** `dag_id`
+(V6), so a per-project worker must fetch the whole window and map `dag_id` → project client-side.
+Where several Optimus projects share one `SCHEDULER_HOST` that means each project re-fetches the
+same rows. Options: key by `scheduler_host` and fan out to projects after fetching, or keep
+per-project keying and accept the duplication. Per-project is simpler and isolates failures; it is
+the right call **if hosts are effectively 1:1 with projects** in this deployment — worth
+confirming, since it is cheap now and awkward to change later.
 
 ## Point 5 — synchronisation between replicas (revised)
 
@@ -137,59 +505,94 @@ is incorrect — the watermark must be keyed per scheduler host, as must the DB 
 3. `pg_advisory_xact_lock` avoids the leak but forces the cycle into one long transaction, holding
    a connection and generating bloat.
 
-**Use the existing lease pattern** — mirror `GetExpiredSLAsForProcessing`
-(`internal/store/postgres/scheduler/sla_repository.go:124`). Co-locate lease and watermark in one
-row keyed per scheduler host (V7), so claim + watermark read are atomic:
+**The window-insert claim above replaces the lease for mutual exclusion.** Because the identifier
+is `(project_name, start_time, end_time)`, `INSERT … ON CONFLICT DO NOTHING` gated on
+`RowsAffected()` already guarantees exactly-one-replica-per-window, with no lock held and nothing
+to release. It is a better fit here than the SLA worker's `UPDATE`-based lease, which assumes a
+pre-existing row to claim.
 
-```sql
-UPDATE airflow_sync_state
-   SET worker_signature = $1, worker_lock_until = now() + $2, updated_at = now()
- WHERE scheduler_host = $3
-   AND (worker_lock_until IS NULL OR worker_lock_until < now())
-RETURNING last_processed_log_id, last_processed_dttm;
-```
+The lease concepts still needed, scoped to the claimed window row:
 
-Gate on `RowsAffected() == 1`; losers skip the cycle. Crash recovery is automatic via expiry.
+- `locked_until` — so a crashed replica's `in_progress` window becomes re-claimable rather than
+  being lost. Set it above p99 window-processing time.
+- `worker_signature` — used to **fence the completion write**, so a replica whose `locked_until`
+  expired mid-window cannot mark it complete after another replica re-claimed it:
 
-**Fence the write-back** — a slow worker whose lease expired must not clobber a newer watermark:
+  ```sql
+  UPDATE airflow_sync_state
+     SET status = 'completed', completed_at = now(), updated_at = now()
+   WHERE project_name = $1 AND start_time = $2 AND end_time = $3
+     AND worker_signature = $4
+     AND locked_until > now();
+  ```
 
-```sql
-UPDATE airflow_sync_state
-   SET last_processed_log_id = $1, last_processed_dttm = $2, updated_at = now()
- WHERE scheduler_host = $3
-   AND worker_signature = $4
-   AND worker_lock_until > now();
-```
+  0 rows affected ⇒ ownership lost mid-window ⇒ discard progress, log, let the re-claimer redo it.
+  This is why writes must be idempotent (see edge case 2).
 
-0 rows affected ⇒ lease lost mid-cycle ⇒ discard this cycle's progress and log it.
+There is one read-then-write race left: two replicas can independently compute the same next window
+from `max(end_time)` and both attempt the insert. The unique constraint resolves it — one gets 0
+rows and skips. That is correct, not a bug, but the code must treat 0 rows as "someone else has
+it", not as an error.
 
-Bound each cycle's batch so it cannot outlive the lease, and set `worker_lock_until` above p99
-cycle time. Note `server/optimus.go:247` cancels worker contexts then immediately closes the DB
-pool without waiting, so check `ctx.Err()` between steps or every shutdown logs spurious errors.
+Note `server/optimus.go:247` cancels worker contexts then immediately closes the DB pool without
+waiting, so check `ctx.Err()` between pages or every shutdown logs spurious closed-pool errors.
 
 ## Point 6 — codebase changes (revised)
 
 | File | Change |
 |---|---|
-| `migrations/000NNN_create_airflow_sync_state.{up,down}.sql` | `scheduler_host TEXT PRIMARY KEY`, `last_processed_log_id BIGINT`, `last_processed_dttm TIMESTAMPTZ`, `worker_signature UUID`, `worker_lock_until TIMESTAMPTZ`, timestamps |
-| `internal/store/postgres/scheduler/airflow_sync_state_repository.go` | new: `ClaimForProcessing`, `CommitWatermark`, both fenced |
-| `ext/scheduler/airflow/audit_log_reader.go` (new, in `package airflow`) | the Airflow-DB read. Keep it behind an interface so the service is testable and a future REST implementation can swap in |
+| `migrations/000NNN_create_airflow_sync_state.{up,down}.sql` | see the DDL in "`airflow_sync_state` design" |
+| `internal/store/postgres/scheduler/airflow_sync_state_repository.go` | new: `GetWatermark`, `ClaimWindow` (insert/on-conflict), `ReclaimStaleWindow`, `CompleteWindow` (fenced), `FailWindow` |
+| `ext/scheduler/airflow/airflow.go` + `client.go` | add `GetEventLogs(ctx, tnnt, window, includedEvents, limit, offset)` using the existing `airflowRequest` + `unmarshalAs[T]` style. Must live in `package airflow` (`Client.Invoke` takes the unexported request type). Add a client timeout — the shared `&http.Client{}` has none |
+| `ext/scheduler/airflow/model.go` | `EventLog` response struct + `extra` double-unmarshal helper + `toManualOverride()` mapper |
 | `internal/store/postgres/scheduler/job_run_repository.go` | additive: lookup by `(project, job_name, scheduled_at)` in batch; batch state update |
 | `internal/store/postgres/scheduler/job_operator_repository.go` | additive: fetch/update newest child by `(job_run_id, name)`. Keep the `operatorTypeToTableName` seam |
 | `core/scheduler/service/airflow_state_sync_service.go` | new: parse rows → resolve entity → apply write-scope rules |
 | `core/scheduler/service/airflow_state_sync_worker.go` | new: ticker + lease + per-host fan-out, modelled on `sla_worker.go:54` |
 | `core/scheduler/job_run.go` | shared domain types (`scheduler` cannot import `service`) |
 | `core/scheduler/status.go` | Airflow→Optimus state map + ignore-list (see below) |
-| `config/config_server.go` | `AirflowSyncConfig`: interval, lock duration, per-host DSNs, lookback cap, batch size. `mapstructure` + `default:` tags |
+| `config/config_server.go` | `AirflowSyncConfig`: window interval, settling delay, lock duration, initial lookback cap, page size, max windows per tick, optional owner deny-list. `mapstructure` + `default:` tags on every field (a zero interval panics `NewTicker`) |
 | `server/optimus.go` | wire next to the SLA worker (~line 479), guarded by `interval > 0` |
 | `config.sample.yaml`, `dev/optimus.values.yaml` | document new keys |
 
-Deviations from the original: a dedicated repository for lease+watermark rather than piling onto
-`job_run_repository.go`, and the Airflow-side read isolated behind its own interface rather than
-extending `client.go` (which is REST-shaped — `Client.Invoke` takes the unexported
-`airflowRequest`, so a DB reader does not belong there).
+Deviation from the original: a dedicated repository for the window state rather than piling onto
+`job_run_repository.go`. Otherwise this now matches the original point-6 layout, since the Airflow
+read is REST and belongs in `client.go`/`airflow.go` after all.
+
+**Unresolved questions 3, 5 and 7 from the first draft are now closed:** fetch is via REST, so
+there is no Airflow DSN to supply or rotate, and no second connection pool.
 
 ## Entity resolution
+
+Confirmed against a real API response (2026-07-27), which is worth quoting because it settles
+several details at once:
+
+```json
+{ "event": "success", "event_log_id": 91255988,
+  "execution_date": "2026-07-23T00:00:00+00:00", "extra": null,
+  "owner": "hilda.huang@test.com",
+  "task_id": "wait_project.schema.name-mc2mc",
+  "when": "2026-07-24T00:00:04.497221+00:00" }          // worker row
+
+{ "event": "success", "event_log_id": 91885625,
+  "execution_date": null,
+  "extra": "{\"confirmed\": \"true\", \"past\": \"false\", ...}",
+  "owner": "google_109294631035232612844", "task_id": "mc2mc",
+  "run_id": "scheduled__2026-07-24T18:00:00+00:00",
+  "when": "2026-07-26T09:38:16.170441+00:00" }          // manual row
+```
+
+- **`execution_date` is populated on worker rows but NULL on manual rows** — so the manual path
+  must resolve time from `run_id` only. (`action_logging` sets `execution_date` only when the
+  request carries it, and the legacy mark form sends `dag_run_id`.) Do not be misled into using
+  `execution_date` because it is present on the rows you are filtering *out*.
+- `task_id` prefixes behave as expected: `wait_…` (sensor) and bare `mc2mc` (task).
+- `when` is normalised to **UTC** by the API even though `dttm` renders as `+07` in psql, so send
+  `after`/`before` as explicit UTC ISO8601.
+- `extra` arrives as a **JSON-encoded string**, confirming the double-unmarshal.
+- Worker rows also carry an `owner` (the DAG owner — an email here, not an `@handle`). So `owner`
+  identifies the *actor* only when `extra` is populated; never present it as "who did this"
+  otherwise.
 
 1. `dag_id` → Optimus job. On a shared Airflow, `dag_id` is only unique per project — resolve via
    the project owning that `SCHEDULER_HOST`, and no-op on unknown DAGs.
@@ -224,29 +627,109 @@ extending `client.go` (which is REST-shaped — `Client.Invoke` takes the unexpo
   DAG; Airflow recomputes the dag-run state and the DAG-level callback normally still fires, so
   `job_run` often self-heals. Rolling up risks declaring a job complete while downstream tasks are
   still running. (`IsAllTerminated` / `IsAnyFailure` in `status.go` remain available if wanted.)
-- **Emit state-change events.** Call `raiseJobRunStateChangeEvent`
-  (`core/scheduler/service/job_run_service.go:960`) so downstream consumers don't desync — but
-  decide deliberately whether it should alert (see unresolved question 1).
+- **Emit state-change events, but suppress user-facing alerts.** Call
+  `raiseJobRunStateChangeEvent` (`core/scheduler/service/job_run_service.go:960`) so downstream
+  consumers don't desync — see "Alerting" below for why the notification itself should be
+  suppressed, and the existing mechanism for doing it.
+
+## Alerting on reconciled changes
+
+Reconciliation mutates `job_run.status`, which is an input to notifications, the SLA worker and the
+potential-SLA-breach predictor. Writing state without deciding this produces surprising pages:
+
+| Scenario | Naive behaviour | Wanted |
+|---|---|---|
+| Optimus `failed` → human marked success → reconciler writes `success` | fires a "job success" notification hours late | no notification; ideally *resolve* the earlier failure alert if Siren's firing/resolved semantics are used |
+| Optimus `running` → human marked the DAG failed → reconciler writes `failed` | fires a fresh failure alert for a failure the human caused deliberately and already knows about | no notification |
+| Stale `running` → reconciled to a terminal state | the SLA predictor may immediately raise a breach for a run that ended hours ago | no breach alert |
+
+In every case the state change originates from a deliberate human action **inside Airflow**, so the
+person who caused it already knows. Recommendation for v1: **update state and emit the internal
+state-change event, but do not notify.** Surface reconciliation through a metric
+(`airflow_state_reconciled_total{event,from_state,to_state}`) and a log line carrying `owner`, so
+the team can see it without anyone being paged.
+
+There is already an idiomatic mechanism: `scheduler.Event` carries a **`SkipAlerting bool`**
+(`core/scheduler/event.go`), used today by `filterSLAObjects`
+(`core/scheduler/service/job_run_service.go:867`). Reuse it rather than inventing a bypass.
+
+Deliberately deferred: mapping `failed`→`success` onto an alert *resolution* is desirable but needs
+Siren's resolve semantics wired up, so treat it as a follow-up rather than v1.
 
 ## Edge cases
 
 **Correctness**
-1. **Sequence gap.** Transaction A takes `id` 100, B takes 101 and commits first. A read at that
-   instant sees 101, advances the watermark past 100, and 100 is skipped forever. Mitigate with a
-   settling delay — only process rows with `dttm < now() - 60s`. The same delay avoids racing
-   in-flight callbacks.
+1. **Late-committing rows.** A row's `dttm` is stamped at request time but becomes visible only on
+   commit, so a window queried too soon can miss rows that belong to it — and the window then
+   advances past them forever. The settling delay in "Windowing" item 1 is the mitigation; it is
+   not optional.
 2. Ordering — apply rows in ascending `id`, and make writes idempotent so a replayed cycle is a
    no-op. Production data shows genuinely messy sequences (a `dagrun_success`, then a task
    `success`, then another `dagrun_success` 20s apart on the same run).
-3. Clock skew between Optimus and Airflow if `dttm` is used for resume; keep a safety overlap and
-   de-duplicate on `id`.
-4. `airflow db clean` truncates `log`; the watermark must tolerate its rows vanishing.
+3. **Clock skew.** Windows are computed from Optimus's clock but filter on Airflow's `dttm`. If
+   Airflow's clock runs behind, freshly-written rows fall below a window Optimus already closed.
+   The settling delay absorbs small skew; larger skew needs monitoring. Also send explicit
+   UTC offsets in `after`/`before` — `timezone.parse()` will accept a naive string and assume a
+   default, and production `dttm` renders as `+07`.
+4. `airflow db clean` truncates `log`; an empty window is normal and must not be treated as an
+   error or block window advancement.
+4b. **Pagination.** `limit` is capped by `[api] maximum_page_limit` (default 100). Page with
+   `offset` ordered by `event_log_id`, and use the returned `total_entries` to know when to stop —
+   a window with more rows than one page is otherwise silently truncated.
 5. `map_index` (dynamic task mapping) is not modelled by Optimus's child tables — ignore
    explicitly rather than by accident.
 
 **Scope / mapping**
-6. `custom-backfill_*` and `replayed__*` runs both appear in the data, and a human marking a
-   *replayed* run success is a real observed case — decide whether these are in scope.
+6. **v1 processes all four observed run_id shapes**: `scheduled__*`, `manual__*`, `replayed__*`,
+   `custom-backfill_*`. Implemented as a positive `run_id` prefix allow-list
+   (`scheduler.HasRecognisedRunIDPrefix`), not a deny-list, so an unrecognised future prefix is
+   skipped-and-counted rather than mis-parsed.
+
+   This was initially narrowed to `scheduled__*` only, over a **replay collision** concern:
+   Optimus's replay worker actively writes state for `replayed__` runs, and production data showed a
+   human marking such a run success — apparently two writers on one row. That concern didn't survive
+   closer reading of the replay/backfill code: `replayRepo`/`backfillRepo` only ever write to their
+   own tracking tables (`replay_request`/`replay_run`, `backfill`); `job_run`/`task_run`/`sensor_run`/
+   `hook_run` are updated exclusively through the normal Airflow callback path
+   (`__lib.py notify_event` → `RegisterJobEvent` → `UpdateJobState`) regardless of whether a run was
+   scheduled, replayed, or backfilled. So there is no second writer to arbitrate against — the only
+   race is the same normal-callback-vs-manual-override race that already exists for `scheduled__`
+   runs, already covered by the `updated_at` freshness check (see "Write-scope rules").
+
+   The croniter shift (`ExecutionDate` → `Schedule.GetNextSchedule`) is identical across all four
+   shapes once the run_id's embedded timestamp is extracted — verified against a live instance for
+   `scheduled__` (see "Demo" below) and holds by construction for the others, since it's the same
+   `execution_date → next tick` arithmetic `__lib.py get_scheduled_at` and
+   `ext/scheduler/airflow/client.go`'s `getJobRuns` both already use elsewhere in this codebase.
+   `custom-backfill_<uuid>__<timestamp>` is the one irregular shape: split on the **last** `__`, not
+   a fixed prefix strip, since the UUID's hyphens never produce a literal `__` — confirmed against a
+   real run_id (`custom-backfill_76515cc3-b3aa-440f-b998-04e6f4935ea3__2026-07-25T09:38:53+00:00`).
+
+   `manual__*` runs frequently have no `job_run` row in Optimus at all (an ad-hoc trigger with no
+   corresponding schedule); this needs no special case — the existing `GetByScheduledAt` → NotFound →
+   skip (`reason="no_job_run"`) path already handles it, since v1 never creates rows.
+
+   **Count what you skip.** `airflow_state_reconcile_skipped_total{reason="run_type"}` still exists
+   for whatever prefix shows up beyond these four. Otherwise "no manual overrides found" is
+   indistinguishable from "N overrides found on an unrecognised run_id shape and all were dropped" —
+   and since the feature exists to remove false-positive alerts, a silently-skipped override means
+   the false positive persists.
+
+6b. **Demo (2026-07-28), confirms the croniter shift end-to-end on real infrastructure**: marked a
+   real `scheduled__2026-07-27T05:00:00+00:00` Airflow run failed via the actual grid UI (not a
+   simulated audit row). The reconciler correctly computed Optimus's `job_run.scheduled_at` as
+   `2026-07-28T05:00:00` (next tick after the run_id's embedded timestamp, per the job's `0 5 * * *`
+   interval) and flipped that row from `success` to `failed`. Its `task_run` child, already terminal
+   (`success`) before the override, was correctly left untouched — the asymmetric-cascade rule
+   (finding V5) confirmed live: mirroring `set_dag_run_state_to_failed`, which never rewrites an
+   already-finished task instance.
+
+6c. **Clear operations are out of scope by construction**, since `clear` / `dagrun_clear` (and their
+   REST equivalents) are not in the four-event filter — nothing to implement. That is the right
+   default: a cleared task re-runs and emits normal callbacks, so Optimus self-heals. What is given
+   up is the case where a cleared task never re-runs — paused DAG, exhausted pool, or the task
+   removed from the DAG — leaving stale state indefinitely. Supporting it later is not just a filter
+   change: Airflow clears to `None`, which has no Optimus equivalent.
 7. Renamed/deleted jobs and non-Optimus DAGs on a shared Airflow must no-op quietly.
 8. Task-group marks (`group_id` instead of `task_id`) hit the same endpoints and log `task_id`
    NULL — detect and skip, or expand.
@@ -281,16 +764,40 @@ extending `client.go` (which is REST-shaped — `Client.Invoke` takes the unexpo
 - **Push from `__lib.py`** — cannot help; manual overrides are exactly the case where no task code
   runs.
 
+# Decisions taken
+
+- Fetch via REST `eventLogs`; no Airflow-DB dependency.
+- Manual detection: four bare events + `extra` populated + `confirmed='true'`, with `owner LIKE
+  'google_%'` as a confirmed-safe additional signal in this deployment.
+- Windowed sync state keyed by `(project_name, start_time, end_time)`, claimed by
+  `INSERT … ON CONFLICT DO NOTHING`.
+- `SCHEDULER_HOST` is 1:1 with project here, so keying by project is correct.
+- **v1 scope is all four observed run_id shapes** (`scheduled__*`, `manual__*`, `replayed__*`,
+  `custom-backfill_*`), via a positive allow-list. Only `clear` operations are out, by construction
+  (not in the four-event filter). The initial `scheduled__*`-only narrowing was reversed after
+  establishing the replay/backfill workers never write to `job_run`/`task_run` themselves (see
+  finding 6 above) — there was no actual collision to avoid.
+- Reconciliation updates state and emits the internal job-run-state-change event
+  (`emitJobRunStateChange`, mirroring `raiseJobRunStateChangeEvent`) but never calls the gRPC
+  handler's notifier fan-out (`ext/notify/alertmanager` etc.) at all, so no user-facing alert is
+  possible by construction — not something gated by `Event.SkipAlerting` (that flag lives on the
+  inbound-callback `scheduler.Event` used by `EventsService`/SLA-miss filtering, a different code
+  path this reconciler never goes through, since it calls repositories directly rather than
+  replaying a synthetic event through `JobRunService.UpdateJobState`).
+- `airflow_sync_state` carries `max_processed_log_id` (from the API's `event_log_id`) plus
+  `events_matched` / `runs_reconciled` for observability.
+- Bulk-flagged rows (`past`/`future`/`upstream`/`downstream` = `true`) are scoped out in v1: counted
+  in `airflow_state_reconcile_skipped_total{reason="bulk_flag"}`, not applied. A single such row can
+  mean many changed task instances, possibly in other DAG runs, which the audit log cannot
+  enumerate — attempting to apply it risks acting on an incomplete/wrong picture, so skip-and-count
+  is the safe default. Re-visit only if the metric shows material volume.
+
+All items in this section are now decided; nothing left blocking implementation.
+
 # Unresolved questions
 
-1. **Should reconciliation alert?** Suppress on `failed`→`success`; what about a late
-   `running`→`failed`? Product decision.
-2. Are `clear` operations in scope? A cleared task re-runs and self-heals via callbacks, but a
-   cleared-then-never-scheduled task leaves a stale row.
-3. Bulk-flagged rows (V4): scope out with a metric, or trigger a state re-read?
-4. Backfill (`custom-backfill_*`) and replay (`replayed__*`) runs in scope?
-5. REST-driven (`api.*`) overrides from non-Optimus tooling in scope?
-6. Poll interval and lookback defaults (10 min proposed; interacts with the settling delay in
-   edge case 1).
-7. How are per-host Airflow DSNs supplied and rotated — server config, or a per-project secret
-   alongside `SCHEDULER_AUTH`?
+1. REST-driven (`api.*`) overrides from non-Optimus tooling — in scope? Not blocking v1 (the filter
+   already excludes them by construction); revisit if a real need surfaces.
+2. Window interval, settling delay and initial-lookback defaults (10 min proposed for the window),
+   informed by the measured peak rows/window — tune during implementation, not a design blocker.
+3. Follow-up: should `failed`→`success` *resolve* an existing Siren alert rather than being silent?

--- a/docs/docs/rfcs/20260727_manual_state_override_reconciliation.md
+++ b/docs/docs/rfcs/20260727_manual_state_override_reconciliation.md
@@ -455,6 +455,32 @@ projects are independent rows, so they proceed in parallel naturally.
 With one project and 5 pods, 4 will no-op each tick. That is fine — the wasted work is a single
 failed insert.
 
+**Confirmed against production topology: there are multiple projects, not one**, and the skew
+across them is large — one project accounts for the large majority of active jobs, with the rest
+ranging down to a small handful each, several of them non-production variants. This matters
+because `AirflowSyncConfig` is one global struct applied identically to every project's ticker
+cycle — there is no per-project override — so any window/lock/concurrency sizing decision has to
+be checked against the *busiest* project, not an average.
+
+It also means the "serial within a project, parallel across projects" property above needed one
+more piece to hold up in practice: `tick()` originally iterated every project sequentially in a
+single goroutine per pod. With one project this cost nothing; with many, a project whose Airflow
+instance was slow or unreachable delayed every project listed after it in that same pod's tick —
+for up to `LockDuration` — before the rest even got a chance to run that tick. Fixed by fanning
+`tick()` out with a bounded worker pool (new config field `MaxConcurrentProjects`, default 5): the
+unique-constraint claim already made cross-project processing *safe* to parallelize, this closes
+the gap where one pod's own sequential loop was the actual bottleneck. Verified with a unit test
+asserting concurrency stays bounded by `MaxConcurrentProjects` and every project is still
+processed exactly once per tick (`core/scheduler/service/airflow_state_sync_worker_test.go`).
+
+A related gap surfaced at the same time: the Airflow HTTP client
+(`ext/scheduler/airflow/client.go`) has no request timeout of its own (`&http.Client{}`). A
+genuinely hung request would have blocked that window's goroutine forever rather than surfacing
+as an attempt error — the lease would still eventually expire and get reclaimed by another
+replica, but the original goroutine would leak. `processWindow` now wraps the reconcile call in
+`context.WithTimeout(ctx, LockDuration)`, so a stuck call is cancelled in line with when its lease
+would lapse anyway.
+
 ### Volume: ~99% of fetched rows are discarded, so window size decides feasibility
 
 A production `eventLogs` call filtered to the four events reported `total_entries: 107737`, against
@@ -486,13 +512,30 @@ raising `maximum_page_limit` on the Airflow side (affects all API consumers), or
 server-side to `dagrun_success,dagrun_failed` only — those have **no** worker writer at all, so
 they need no client-side discard, at the cost of missing task-level marks.
 
-**Keying: per project or per scheduler host?** `eventLogs` only filters a **single** `dag_id`
-(V6), so a per-project worker must fetch the whole window and map `dag_id` → project client-side.
-Where several Optimus projects share one `SCHEDULER_HOST` that means each project re-fetches the
-same rows. Options: key by `scheduler_host` and fan out to projects after fetching, or keep
-per-project keying and accept the duplication. Per-project is simpler and isolates failures; it is
-the right call **if hosts are effectively 1:1 with projects** in this deployment — worth
-confirming, since it is cheap now and awkward to change later.
+**Measured against the busiest project in this deployment:**
+
+```
+          hour          | count
+------------------------+-------
+ 2026-07-28 03:00:00+07 |  2611
+ 2026-07-29 03:00:00+07 |  2606
+ 2026-07-25 03:00:00+07 |  2496
+ 2026-07-28 12:00:00+07 |  2447
+ 2026-07-27 03:00:00+07 |  2440
+```
+
+≈2,611 rows/hour peak ÷ 6 ≈ 435 rows in the worst 10-minute window ≈ 5 pages at the 100-row page
+cap. That confirms the originally-proposed 10-minute window remains safe without shrinking it,
+even against the largest project in this deployment — no further tuning needed on window size
+itself.
+
+**Keying: per project or per scheduler host? Resolved: per project, confirmed against production.**
+`eventLogs` only filters a **single** `dag_id` (V6), so a per-project worker must fetch the whole
+window and map `dag_id` → project client-side; where several Optimus projects share one
+`SCHEDULER_HOST` that would mean each project re-fetches the same rows. Production confirms
+`SCHEDULER_HOST` is 1:1 with project — many independent projects, each with its own independent
+Airflow instance — so per-project keying has no duplication cost here and is the simpler,
+failure-isolating choice kept in the final design.
 
 ## Point 5 — synchronisation between replicas (revised)
 
@@ -543,7 +586,7 @@ waiting, so check `ctx.Err()` between pages or every shutdown logs spurious clos
 |---|---|
 | `migrations/000NNN_create_airflow_sync_state.{up,down}.sql` | see the DDL in "`airflow_sync_state` design" |
 | `internal/store/postgres/scheduler/airflow_sync_state_repository.go` | new: `GetWatermark`, `ClaimWindow` (insert/on-conflict), `ReclaimStaleWindow`, `CompleteWindow` (fenced), `FailWindow` |
-| `ext/scheduler/airflow/airflow.go` + `client.go` | add `GetEventLogs(ctx, tnnt, window, includedEvents, limit, offset)` using the existing `airflowRequest` + `unmarshalAs[T]` style. Must live in `package airflow` (`Client.Invoke` takes the unexported request type). Add a client timeout — the shared `&http.Client{}` has none |
+| `ext/scheduler/airflow/airflow.go` + `client.go` | add `GetManualEventLogs(ctx, tnnt, window, includedEvents, limit, offset)` using the existing `airflowRequest` + `unmarshalAs[T]` style. Must live in `package airflow` (`Client.Invoke` takes the unexported request type). Add a client timeout — the shared `&http.Client{}` has none |
 | `ext/scheduler/airflow/model.go` | `EventLog` response struct + `extra` double-unmarshal helper + `toManualOverride()` mapper |
 | `internal/store/postgres/scheduler/job_run_repository.go` | additive: lookup by `(project, job_name, scheduled_at)` in batch; batch state update |
 | `internal/store/postgres/scheduler/job_operator_repository.go` | additive: fetch/update newest child by `(job_run_id, name)`. Keep the `operatorTypeToTableName` seam |
@@ -791,6 +834,18 @@ Siren's resolve semantics wired up, so treat it as a follow-up rather than v1.
   mean many changed task instances, possibly in other DAG runs, which the audit log cannot
   enumerate — attempting to apply it risks acting on an incomplete/wrong picture, so skip-and-count
   is the safe default. Re-visit only if the metric shows material volume.
+- **Bounded per-tick project concurrency.** Production has many projects, not the one assumed while
+  reasoning about "serial within a project, parallel across projects" above — `tick()` now fans out
+  across projects with a bounded worker pool (`MaxConcurrentProjects`, default 5) instead of a
+  single sequential loop, so one slow/unreachable project's Airflow instance no longer delays every
+  project listed after it within the same pod's tick.
+- **Per-window reconcile timeout.** `processWindow` bounds the reconcile call to
+  `context.WithTimeout(ctx, LockDuration)`, since the Airflow HTTP client has no timeout of its own
+  and would otherwise leak a goroutine per genuinely-hung request instead of surfacing as a
+  retryable attempt error.
+- New metric `airflow_sync_windows_failed_total{project}`: `FailExhaustedWindows` giving up on a
+  window was previously only a log line — with 19 independent projects/Airflow instances as
+  separate failure domains, that needed to be alertable per project, not just grep-able.
 
 All items in this section are now decided; nothing left blocking implementation.
 
@@ -798,6 +853,4 @@ All items in this section are now decided; nothing left blocking implementation.
 
 1. REST-driven (`api.*`) overrides from non-Optimus tooling — in scope? Not blocking v1 (the filter
    already excludes them by construction); revisit if a real need surfaces.
-2. Window interval, settling delay and initial-lookback defaults (10 min proposed for the window),
-   informed by the measured peak rows/window — tune during implementation, not a design blocker.
-3. Follow-up: should `failed`→`success` *resolve* an existing Siren alert rather than being silent?
+2. Follow-up: should `failed`→`success` *resolve* an existing Siren alert rather than being silent?

--- a/ext/scheduler/airflow/event_log.go
+++ b/ext/scheduler/airflow/event_log.go
@@ -1,0 +1,188 @@
+package airflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/goto/optimus/core/scheduler"
+	"github.com/goto/optimus/core/tenant"
+	"github.com/goto/optimus/internal/errors"
+)
+
+const (
+	eventLogsURL = "api/v1/eventLogs"
+
+	// eventLogPageSize is Airflow's own [api] maximum_page_limit default; requesting more
+	// gets silently clamped server-side (Airflow returns 200, not an error, per
+	// airflow/api_connexion/parameters.py check_limit), so there is no benefit to asking
+	// for more and it would just make the clamp implicit instead of explicit here.
+	eventLogPageSize = 100
+
+	eventTaskSuccess   = "success"
+	eventTaskFailed    = "failed"
+	eventDagRunSuccess = "dagrun_success"
+	eventDagRunFailed  = "dagrun_failed"
+)
+
+// manualOverrideEventNames is pushed down to Airflow via included_events so the server does
+// as much of the filtering as it can; extra/confirmed/run_id filtering still has to happen
+// client-side (see the RFC's "Volume" section for why: Airflow does not expose an
+// extra-is-not-null filter, so this still returns worker-written rows for these same event
+// names and callers must not assume every returned row is a manual override).
+var manualOverrideEventNames = []string{eventTaskSuccess, eventTaskFailed, eventDagRunSuccess, eventDagRunFailed}
+
+type eventLogListResponse struct {
+	EventLogs    []eventLogEntry `json:"event_logs"`
+	TotalEntries int             `json:"total_entries"`
+}
+
+type eventLogEntry struct {
+	EventLogID int64   `json:"event_log_id"`
+	DagID      *string `json:"dag_id"`
+	TaskID     *string `json:"task_id"`
+	RunID      *string `json:"run_id"`
+	Event      string  `json:"event"`
+	Owner      string  `json:"owner"`
+	// Extra is a JSON-encoded string, not a nested object -- Airflow's eventLogs schema
+	// returns it that way (confirmed against a live 2.9.3 response).
+	Extra *string `json:"extra"`
+	When  string  `json:"when"`
+}
+
+// GetEventLogs fetches every manual state override recorded in this project's Airflow audit
+// log within [after, before), paginating until Airflow's own total_entries is exhausted. Both
+// bounds are strict on the Airflow side (dttm < before, dttm > after); callers doing windowed
+// polling are responsible for any overlap/de-duplication across adjacent windows -- this
+// method just reports what a single [after, before) query returns.
+//
+// See docs/docs/rfcs/20260727_manual_state_override_reconciliation.md for why the four bare
+// event names plus a populated `extra` (and, for dagrun_* events, extra["confirmed"]=="true")
+// are what identify a manual override, as opposed to an ordinary worker-driven transition.
+func (s *Scheduler) GetEventLogs(ctx context.Context, projectName tenant.ProjectName, after, before time.Time) ([]scheduler.ManualOverrideEvent, error) {
+	spanCtx, span := startChildSpan(ctx, "GetEventLogs")
+	defer span.End()
+
+	schdAuth, err := s.getSchedulerAuth(spanCtx, projectName)
+	if err != nil {
+		return nil, err
+	}
+
+	var events []scheduler.ManualOverrideEvent
+	offset := 0
+	for {
+		page, err := s.fetchEventLogPage(spanCtx, schdAuth, after, before, offset)
+		if err != nil {
+			return nil, errors.Wrap(EntityAirflow, "failure while fetching airflow event logs", err)
+		}
+
+		for i := range page.EventLogs {
+			event, ok, err := toManualOverrideEvent(page.EventLogs[i])
+			if err != nil {
+				// one malformed row should not block the rest of the window from being
+				// reconciled -- log and move on rather than aborting the whole fetch.
+				s.l.Warn("skipping unparseable airflow event log row", "event_log_id", page.EventLogs[i].EventLogID, "error", err)
+				continue
+			}
+			if ok {
+				events = append(events, event)
+			}
+		}
+
+		offset += len(page.EventLogs)
+		if len(page.EventLogs) == 0 || offset >= page.TotalEntries {
+			break
+		}
+	}
+	return events, nil
+}
+
+func (s *Scheduler) fetchEventLogPage(ctx context.Context, schdAuth SchedulerAuth, after, before time.Time, offset int) (*eventLogListResponse, error) {
+	params := url.Values{}
+	params.Add("after", after.UTC().Format(time.RFC3339))
+	params.Add("before", before.UTC().Format(time.RFC3339))
+	params.Add("included_events", strings.Join(manualOverrideEventNames, ","))
+	params.Add("order_by", "event_log_id")
+	params.Add("limit", strconv.Itoa(eventLogPageSize))
+	params.Add("offset", strconv.Itoa(offset))
+
+	req := airflowRequest{
+		path:   eventLogsURL,
+		method: http.MethodGet,
+		query:  params.Encode(),
+	}
+
+	resp, err := s.client.Invoke(ctx, req, schdAuth)
+	if err != nil {
+		return nil, err
+	}
+	return unmarshalAs[eventLogListResponse](resp)
+}
+
+// toManualOverrideEvent maps one raw eventLogs row onto scheduler.ManualOverrideEvent.
+// ok is false when the row should be skipped without error: a worker-written row (extra is
+// nil -- for these four event names extra is only ever populated by Airflow's
+// action_logging), an unconfirmed dagrun preview that changed nothing, or a run_id outside
+// v1's scope.
+func toManualOverrideEvent(e eventLogEntry) (event scheduler.ManualOverrideEvent, ok bool, err error) {
+	if e.Extra == nil {
+		return scheduler.ManualOverrideEvent{}, false, nil
+	}
+
+	var extraFields map[string]string
+	if err := json.Unmarshal([]byte(*e.Extra), &extraFields); err != nil {
+		return scheduler.ManualOverrideEvent{}, false, fmt.Errorf("event_log_id %d: unparseable extra: %w", e.EventLogID, err)
+	}
+
+	isDagRunEvent := e.Event == eventDagRunSuccess || e.Event == eventDagRunFailed
+	if isDagRunEvent {
+		// _mark_dagrun_state_as_success/failed pass commit=confirmed, so a confirmed=false
+		// row is a preview that changed nothing in Airflow -- logged, but nothing to
+		// reconcile. Task-level success/failed ignore `confirmed` entirely in 2.9.3 and
+		// always apply, so this check must not be applied to those two events.
+		if extraFields["confirmed"] != "true" {
+			return scheduler.ManualOverrideEvent{}, false, nil
+		}
+	}
+
+	if e.RunID == nil {
+		return scheduler.ManualOverrideEvent{}, false, nil
+	}
+
+	when, err := time.Parse(time.RFC3339, e.When)
+	if err != nil {
+		return scheduler.ManualOverrideEvent{}, false, fmt.Errorf("event_log_id %d: unparseable when %q: %w", e.EventLogID, e.When, err)
+	}
+
+	var dagID, taskID string
+	if e.DagID != nil {
+		dagID = *e.DagID
+	}
+	if e.TaskID != nil {
+		taskID = *e.TaskID
+	}
+
+	manualOverride := scheduler.ManualOverrideEvent{
+		LogID:  e.EventLogID,
+		Event:  e.Event,
+		DagID:  dagID,
+		TaskID: taskID,
+		RunID:  *e.RunID,
+		Owner:  e.Owner,
+		When:   when,
+	}
+
+	// Allow-list, not deny-list: an unrecognised run_id prefix is skipped rather than
+	// guessed at, so an Airflow run-id convention we haven't seen gets noticed (via the
+	// service layer's skip metric) instead of mis-parsed.
+	if !manualOverride.HasRecognisedRunIDPrefix() {
+		return scheduler.ManualOverrideEvent{}, false, nil
+	}
+
+	return manualOverride, true, nil
+}

--- a/ext/scheduler/airflow/event_log.go
+++ b/ext/scheduler/airflow/event_log.go
@@ -32,9 +32,7 @@ const (
 
 // manualOverrideEventNames is pushed down to Airflow via included_events so the server does
 // as much of the filtering as it can; extra/confirmed/run_id filtering still has to happen
-// client-side (see the RFC's "Volume" section for why: Airflow does not expose an
-// extra-is-not-null filter, so this still returns worker-written rows for these same event
-// names and callers must not assume every returned row is a manual override).
+// client-side
 var manualOverrideEventNames = []string{eventTaskSuccess, eventTaskFailed, eventDagRunSuccess, eventDagRunFailed}
 
 type eventLogListResponse struct {
@@ -55,17 +53,16 @@ type eventLogEntry struct {
 	When  string  `json:"when"`
 }
 
-// GetEventLogs fetches every manual state override recorded in this project's Airflow audit
+// GetManualEventLogs fetches every manual state override recorded in this project's Airflow audit
 // log within [after, before), paginating until Airflow's own total_entries is exhausted. Both
 // bounds are strict on the Airflow side (dttm < before, dttm > after); callers doing windowed
 // polling are responsible for any overlap/de-duplication across adjacent windows -- this
 // method just reports what a single [after, before) query returns.
 //
-// See docs/docs/rfcs/20260727_manual_state_override_reconciliation.md for why the four bare
-// event names plus a populated `extra` (and, for dagrun_* events, extra["confirmed"]=="true")
+// Four bare event names plus a populated `extra` (and, for dagrun_* events, extra["confirmed"]=="true")
 // are what identify a manual override, as opposed to an ordinary worker-driven transition.
-func (s *Scheduler) GetEventLogs(ctx context.Context, projectName tenant.ProjectName, after, before time.Time) ([]scheduler.ManualOverrideEvent, error) {
-	spanCtx, span := startChildSpan(ctx, "GetEventLogs")
+func (s *Scheduler) GetManualEventLogs(ctx context.Context, projectName tenant.ProjectName, after, before time.Time) ([]scheduler.ManualOverrideEvent, error) {
+	spanCtx, span := startChildSpan(ctx, "GetManualEventLogs")
 	defer span.End()
 
 	schdAuth, err := s.getSchedulerAuth(spanCtx, projectName)
@@ -142,9 +139,7 @@ func toManualOverrideEvent(e eventLogEntry) (event scheduler.ManualOverrideEvent
 	isDagRunEvent := e.Event == eventDagRunSuccess || e.Event == eventDagRunFailed
 	if isDagRunEvent {
 		// _mark_dagrun_state_as_success/failed pass commit=confirmed, so a confirmed=false
-		// row is a preview that changed nothing in Airflow -- logged, but nothing to
-		// reconcile. Task-level success/failed ignore `confirmed` entirely in 2.9.3 and
-		// always apply, so this check must not be applied to those two events.
+		// row is a preview that changed nothing in Airflow -- logged, but nothing to reconcile.
 		if extraFields["confirmed"] != "true" {
 			return scheduler.ManualOverrideEvent{}, false, nil
 		}
@@ -177,7 +172,7 @@ func toManualOverrideEvent(e eventLogEntry) (event scheduler.ManualOverrideEvent
 		When:   when,
 	}
 
-	// Allow-list, not deny-list: an unrecognised run_id prefix is skipped rather than
+	// Allow-list, not deny-list: an unrecognized run_id prefix is skipped rather than
 	// guessed at, so an Airflow run-id convention we haven't seen gets noticed (via the
 	// service layer's skip metric) instead of mis-parsed.
 	if !manualOverride.HasRecognisedRunIDPrefix() {

--- a/ext/store/maxcompute/external_table_spec_test.go
+++ b/ext/store/maxcompute/external_table_spec_test.go
@@ -99,7 +99,7 @@ func TestExternalSourceValidate(t *testing.T) {
 		//	assert.NotNil(t, err)
 		//	assert.ErrorContains(t, err, "source uri list is empty")
 		// })
-		//t.Run("returns error when uri is invalid", func(t *testing.T) {
+		// t.Run("returns error when uri is invalid", func(t *testing.T) {
 		//	es := maxcompute.ExternalSource{
 		//		SourceType: "GOOGLE_SHEETS",
 		//		SourceURIs: []string{""},

--- a/ext/store/maxcompute/external_table_spec_test.go
+++ b/ext/store/maxcompute/external_table_spec_test.go
@@ -108,7 +108,7 @@ func TestExternalSourceValidate(t *testing.T) {
 		//	err := es.Validate()
 		//	assert.NotNil(t, err)
 		//	assert.ErrorContains(t, err, "uri is empty")
-		//})
+		// })
 	})
 	t.Run("returns no error when valid", func(t *testing.T) {
 		es := maxcompute.ExternalSource{

--- a/ext/store/maxcompute/external_table_spec_test.go
+++ b/ext/store/maxcompute/external_table_spec_test.go
@@ -89,7 +89,7 @@ func TestExternalSourceValidate(t *testing.T) {
 			assert.NotNil(t, err)
 			assert.ErrorContains(t, err, "source type is empty")
 		})
-		//t.Run("returns error when uri list is empty", func(t *testing.T) {
+		// t.Run("returns error when uri list is empty", func(t *testing.T) {
 		//	es := maxcompute.ExternalSource{
 		//		SourceType: "GOOGLE_SHEETS",
 		//		SourceURIs: []string{},
@@ -98,7 +98,7 @@ func TestExternalSourceValidate(t *testing.T) {
 		//	err := es.Validate()
 		//	assert.NotNil(t, err)
 		//	assert.ErrorContains(t, err, "source uri list is empty")
-		//})
+		// })
 		//t.Run("returns error when uri is invalid", func(t *testing.T) {
 		//	es := maxcompute.ExternalSource{
 		//		SourceType: "GOOGLE_SHEETS",

--- a/internal/store/postgres/migrations/000086_create_airflow_sync_state_table.down.sql
+++ b/internal/store/postgres/migrations/000086_create_airflow_sync_state_table.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS airflow_sync_state_project_end_time_idx;
+DROP TABLE IF EXISTS airflow_sync_state;

--- a/internal/store/postgres/migrations/000086_create_airflow_sync_state_table.up.sql
+++ b/internal/store/postgres/migrations/000086_create_airflow_sync_state_table.up.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS airflow_sync_state (
+    id             UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+
+    project_name   VARCHAR(100) NOT NULL,
+    start_time     TIMESTAMPTZ NOT NULL,
+    end_time       TIMESTAMPTZ NOT NULL,
+
+    status         VARCHAR(30) NOT NULL,
+    attempt_count  INT NOT NULL DEFAULT 0,
+    last_error     TEXT,
+
+    worker_id      UUID,
+    locked_until   TIMESTAMPTZ,
+
+    -- highest Airflow eventLogs `event_log_id` applied in this window, used to
+    -- de-duplicate the small overlap between adjacent windows
+    max_processed_log_id BIGINT,
+    events_matched        INT,
+    runs_reconciled       INT,
+
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT airflow_sync_state_project_window_unique UNIQUE (project_name, start_time, end_time)
+);
+
+CREATE INDEX IF NOT EXISTS airflow_sync_state_project_end_time_idx
+    ON airflow_sync_state (project_name, end_time DESC);

--- a/internal/store/postgres/scheduler/airflow_sync_state_repository.go
+++ b/internal/store/postgres/scheduler/airflow_sync_state_repository.go
@@ -76,11 +76,11 @@ func (a *AirflowSyncStateRepository) ReclaimStaleWindow(ctx context.Context, pro
 			ORDER BY start_time ASC
 			LIMIT 1
 		)
-		RETURNING id, project_name, start_time, end_time, status, attempt_count, worker_id, locked_until`
+		RETURNING id, project_name, start_time, end_time, status, attempt_count, last_error, worker_id, locked_until`
 
 	var w airflowSyncStateRow
 	err := a.db.QueryRow(ctx, query, workerID, lockDuration, projectName, scheduler.AirflowSyncInProgress, maxAttempts).Scan(
-		&w.ID, &w.ProjectName, &w.StartTime, &w.EndTime, &w.Status, &w.AttemptCount, &w.WorkerID, &w.LockedUntil)
+		&w.ID, &w.ProjectName, &w.StartTime, &w.EndTime, &w.Status, &w.AttemptCount, &w.LastError, &w.WorkerID, &w.LockedUntil)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil //nolint:nilnil

--- a/internal/store/postgres/scheduler/airflow_sync_state_repository.go
+++ b/internal/store/postgres/scheduler/airflow_sync_state_repository.go
@@ -1,0 +1,169 @@
+package scheduler
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/goto/optimus/core/scheduler"
+	"github.com/goto/optimus/core/tenant"
+	"github.com/goto/optimus/internal/errors"
+)
+
+// AirflowSyncStateRepository backs the per-project window claim used by the
+// manual-state-override reconciliation worker. See
+// docs/docs/rfcs/20260727_manual_state_override_reconciliation.md for the design this
+// implements: a claimed window row is the mutex (no advisory locks), fenced by
+// worker_id + locked_until so a crashed worker's window becomes re-claimable rather than
+// wedging the project's sync forever.
+type AirflowSyncStateRepository struct {
+	db *pgxpool.Pool
+}
+
+func NewAirflowSyncStateRepository(pool *pgxpool.Pool) *AirflowSyncStateRepository {
+	return &AirflowSyncStateRepository{db: pool}
+}
+
+// GetWatermark returns the end_time of the most recently terminal (success or failed)
+// window for the project, or nil if none exist yet. failed windows count towards the
+// watermark deliberately: excluding them would let one permanently-failing window block
+// all later windows for the project from ever being attempted.
+func (a *AirflowSyncStateRepository) GetWatermark(ctx context.Context, projectName tenant.ProjectName) (*time.Time, error) {
+	query := `SELECT max(end_time) FROM airflow_sync_state WHERE project_name = $1 AND status IN ($2, $3)`
+
+	var watermark *time.Time
+	err := a.db.QueryRow(ctx, query, projectName, scheduler.AirflowSyncSuccess, scheduler.AirflowSyncFailed).Scan(&watermark)
+	if err != nil {
+		return nil, errors.Wrap(scheduler.EntityAirflowSync, "error getting airflow sync watermark", err)
+	}
+	return watermark, nil
+}
+
+// ClaimWindow attempts to claim [startTime, endTime) for the project. The insert is the
+// claim: a conflict means some worker (this replica in an earlier attempt, or another
+// replica) already owns or has finished this window, so the caller should skip it rather
+// than treat that as an error.
+func (a *AirflowSyncStateRepository) ClaimWindow(ctx context.Context, projectName tenant.ProjectName, startTime, endTime time.Time, workerID uuid.UUID, lockDuration time.Duration) (id uuid.UUID, claimed bool, err error) {
+	query := `
+		INSERT INTO airflow_sync_state (project_name, start_time, end_time, status, attempt_count, worker_id, locked_until)
+		VALUES ($1, $2, $3, $4, 1, $5, now() + $6)
+		ON CONFLICT (project_name, start_time, end_time) DO NOTHING
+		RETURNING id`
+
+	err = a.db.QueryRow(ctx, query, projectName, startTime, endTime, scheduler.AirflowSyncInProgress, workerID, lockDuration).Scan(&id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return uuid.Nil, false, nil
+		}
+		return uuid.Nil, false, errors.Wrap(scheduler.EntityAirflowSync, "error claiming airflow sync window", err)
+	}
+	return id, true, nil
+}
+
+// ReclaimStaleWindow re-claims the single oldest window left `in_progress` past its
+// locked_until (a worker that died mid-window) for the project, provided it has not yet
+// exhausted maxAttempts. It returns nil, nil if there is nothing to reclaim.
+func (a *AirflowSyncStateRepository) ReclaimStaleWindow(ctx context.Context, projectName tenant.ProjectName, workerID uuid.UUID, lockDuration time.Duration, maxAttempts int) (*scheduler.AirflowSyncWindow, error) {
+	query := `
+		UPDATE airflow_sync_state
+		SET worker_id = $1, locked_until = now() + $2, attempt_count = attempt_count + 1, updated_at = now()
+		WHERE id = (
+			SELECT id FROM airflow_sync_state
+			WHERE project_name = $3 AND status = $4 AND locked_until < now() AND attempt_count < $5
+			ORDER BY start_time ASC
+			LIMIT 1
+		)
+		RETURNING id, project_name, start_time, end_time, status, attempt_count, worker_id, locked_until`
+
+	var w airflowSyncStateRow
+	err := a.db.QueryRow(ctx, query, workerID, lockDuration, projectName, scheduler.AirflowSyncInProgress, maxAttempts).Scan(
+		&w.ID, &w.ProjectName, &w.StartTime, &w.EndTime, &w.Status, &w.AttemptCount, &w.WorkerID, &w.LockedUntil)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil //nolint:nilnil
+		}
+		return nil, errors.Wrap(scheduler.EntityAirflowSync, "error reclaiming stale airflow sync window", err)
+	}
+	return w.toSchedulerWindow()
+}
+
+// FailExhaustedWindows marks every window left `in_progress` past its locked_until that has
+// already reached maxAttempts as failed, so it stops being retried and the watermark can
+// advance past it. It returns how many were failed, for the caller to alert on.
+func (a *AirflowSyncStateRepository) FailExhaustedWindows(ctx context.Context, projectName tenant.ProjectName, maxAttempts int, lastError string) (int64, error) {
+	query := `
+		UPDATE airflow_sync_state
+		SET status = $1, last_error = $2, updated_at = now()
+		WHERE project_name = $3 AND status = $4 AND locked_until < now() AND attempt_count >= $5`
+
+	tag, err := a.db.Exec(ctx, query, scheduler.AirflowSyncFailed, lastError, projectName, scheduler.AirflowSyncInProgress, maxAttempts)
+	if err != nil {
+		return 0, errors.Wrap(scheduler.EntityAirflowSync, "error failing exhausted airflow sync windows", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+// CompleteWindow marks a window success, fenced on worker_id + an unexpired lock so a
+// worker that lost its lease mid-window (reclaimed by another replica) cannot overwrite
+// that replica's progress. 0 rows affected means exactly that happened; the caller should
+// discard its progress rather than treat it as an error.
+func (a *AirflowSyncStateRepository) CompleteWindow(ctx context.Context, id, workerID uuid.UUID, maxProcessedLogID *int64, eventsMatched, runsReconciled int) (bool, error) {
+	query := `
+		UPDATE airflow_sync_state
+		SET status = $1, max_processed_log_id = $2, events_matched = $3, runs_reconciled = $4, updated_at = now()
+		WHERE id = $5 AND worker_id = $6 AND locked_until > now()`
+
+	tag, err := a.db.Exec(ctx, query, scheduler.AirflowSyncSuccess, maxProcessedLogID, eventsMatched, runsReconciled, id, workerID)
+	if err != nil {
+		return false, errors.Wrap(scheduler.EntityAirflowSync, "error completing airflow sync window", err)
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
+// RecordAttemptError annotates a window with the error from its most recent attempt,
+// without changing its status/lock -- ReclaimStaleWindow/FailExhaustedWindows own those
+// transitions. Fenced the same way as CompleteWindow so a lease-losing worker cannot stamp
+// a stale error over a newer owner's progress.
+func (a *AirflowSyncStateRepository) RecordAttemptError(ctx context.Context, id, workerID uuid.UUID, lastError string) error {
+	query := `UPDATE airflow_sync_state SET last_error = $1, updated_at = now() WHERE id = $2 AND worker_id = $3 AND locked_until > now()`
+
+	_, err := a.db.Exec(ctx, query, lastError, id, workerID)
+	return errors.WrapIfErr(scheduler.EntityAirflowSync, "error recording airflow sync attempt error", err)
+}
+
+type airflowSyncStateRow struct {
+	ID           uuid.UUID
+	ProjectName  string
+	StartTime    time.Time
+	EndTime      time.Time
+	Status       string
+	AttemptCount int
+	LastError    *string
+	WorkerID     uuid.UUID
+	LockedUntil  time.Time
+}
+
+func (w airflowSyncStateRow) toSchedulerWindow() (*scheduler.AirflowSyncWindow, error) {
+	projectName, err := tenant.ProjectNameFrom(w.ProjectName)
+	if err != nil {
+		return nil, err
+	}
+	lastError := ""
+	if w.LastError != nil {
+		lastError = *w.LastError
+	}
+	return &scheduler.AirflowSyncWindow{
+		ID:           w.ID,
+		ProjectName:  projectName,
+		StartTime:    w.StartTime,
+		EndTime:      w.EndTime,
+		Status:       scheduler.AirflowSyncStatus(w.Status),
+		AttemptCount: w.AttemptCount,
+		LastError:    lastError,
+		WorkerID:     w.WorkerID,
+		LockedUntil:  w.LockedUntil,
+	}, nil
+}

--- a/internal/store/postgres/scheduler/airflow_sync_state_repository.go
+++ b/internal/store/postgres/scheduler/airflow_sync_state_repository.go
@@ -14,9 +14,8 @@ import (
 )
 
 // AirflowSyncStateRepository backs the per-project window claim used by the
-// manual-state-override reconciliation worker. See
-// docs/docs/rfcs/20260727_manual_state_override_reconciliation.md for the design this
-// implements: a claimed window row is the mutex (no advisory locks), fenced by
+// manual-state-override reconciliation worker.
+// A claimed window row is the mutex (no advisory locks), fenced by
 // worker_id + locked_until so a crashed worker's window becomes re-claimable rather than
 // wedging the project's sync forever.
 type AirflowSyncStateRepository struct {

--- a/internal/store/postgres/scheduler/airflow_sync_state_repository_test.go
+++ b/internal/store/postgres/scheduler/airflow_sync_state_repository_test.go
@@ -1,0 +1,299 @@
+//go:build !unit_test
+
+package scheduler_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goto/optimus/core/scheduler"
+	"github.com/goto/optimus/core/tenant"
+	postgres "github.com/goto/optimus/internal/store/postgres/scheduler"
+)
+
+// airflow_sync_state has no foreign keys to project/job (see
+// docs/docs/rfcs/20260727_manual_state_override_reconciliation.md), so these tests use
+// bare project names without needing addJobs' project/namespace/job fixtures.
+func TestPostgresAirflowSyncStateRepository(t *testing.T) {
+	ctx := context.Background()
+	currentTime := time.Now().UTC().Truncate(time.Second)
+
+	t.Run("ClaimWindow", func(t *testing.T) {
+		t.Run("claims a fresh window", func(t *testing.T) {
+			db := dbSetup()
+			repo := postgres.NewAirflowSyncStateRepository(db)
+			projectName := tenant.ProjectName("proj-claim-fresh")
+			workerID := uuid.New()
+
+			id, claimed, err := repo.ClaimWindow(ctx, projectName, currentTime, currentTime.Add(time.Minute), workerID, time.Minute)
+			assert.NoError(t, err)
+			assert.True(t, claimed)
+			assert.NotEqual(t, uuid.Nil, id)
+		})
+
+		t.Run("second claim on the same window is rejected, not errored", func(t *testing.T) {
+			db := dbSetup()
+			repo := postgres.NewAirflowSyncStateRepository(db)
+			projectName := tenant.ProjectName("proj-claim-conflict")
+			start, end := currentTime, currentTime.Add(time.Minute)
+
+			id1, claimed1, err := repo.ClaimWindow(ctx, projectName, start, end, uuid.New(), time.Minute)
+			assert.NoError(t, err)
+			assert.True(t, claimed1)
+
+			id2, claimed2, err := repo.ClaimWindow(ctx, projectName, start, end, uuid.New(), time.Minute)
+			assert.NoError(t, err)
+			assert.False(t, claimed2)
+			assert.Equal(t, uuid.Nil, id2)
+			assert.NotEqual(t, id1, id2)
+		})
+
+		t.Run("different projects can claim overlapping windows independently", func(t *testing.T) {
+			db := dbSetup()
+			repo := postgres.NewAirflowSyncStateRepository(db)
+			start, end := currentTime, currentTime.Add(time.Minute)
+
+			_, claimed1, err := repo.ClaimWindow(ctx, tenant.ProjectName("proj-a"), start, end, uuid.New(), time.Minute)
+			assert.NoError(t, err)
+			assert.True(t, claimed1)
+
+			_, claimed2, err := repo.ClaimWindow(ctx, tenant.ProjectName("proj-b"), start, end, uuid.New(), time.Minute)
+			assert.NoError(t, err)
+			assert.True(t, claimed2)
+		})
+	})
+
+	t.Run("GetWatermark", func(t *testing.T) {
+		t.Run("returns nil when the project has no windows yet", func(t *testing.T) {
+			db := dbSetup()
+			repo := postgres.NewAirflowSyncStateRepository(db)
+
+			watermark, err := repo.GetWatermark(ctx, tenant.ProjectName("proj-no-history"))
+			assert.NoError(t, err)
+			assert.Nil(t, watermark)
+		})
+
+		t.Run("an in_progress window does not move the watermark", func(t *testing.T) {
+			db := dbSetup()
+			repo := postgres.NewAirflowSyncStateRepository(db)
+			projectName := tenant.ProjectName("proj-inprogress-only")
+
+			_, claimed, err := repo.ClaimWindow(ctx, projectName, currentTime, currentTime.Add(time.Minute), uuid.New(), time.Minute)
+			assert.NoError(t, err)
+			assert.True(t, claimed)
+
+			watermark, err := repo.GetWatermark(ctx, projectName)
+			assert.NoError(t, err)
+			assert.Nil(t, watermark)
+		})
+
+		t.Run("a completed window advances the watermark to its end_time", func(t *testing.T) {
+			db := dbSetup()
+			repo := postgres.NewAirflowSyncStateRepository(db)
+			projectName := tenant.ProjectName("proj-completed")
+			end := currentTime.Add(time.Minute)
+			workerID := uuid.New()
+
+			id, claimed, err := repo.ClaimWindow(ctx, projectName, currentTime, end, workerID, time.Minute)
+			assert.NoError(t, err)
+			assert.True(t, claimed)
+
+			completed, err := repo.CompleteWindow(ctx, id, workerID, nil, 0, 0)
+			assert.NoError(t, err)
+			assert.True(t, completed)
+
+			watermark, err := repo.GetWatermark(ctx, projectName)
+			assert.NoError(t, err)
+			if assert.NotNil(t, watermark) {
+				assert.True(t, watermark.Equal(end), "expected watermark %s to equal window end_time %s", watermark, end)
+			}
+		})
+
+		t.Run("a failed window still advances the watermark, so it does not block later windows", func(t *testing.T) {
+			db := dbSetup()
+			repo := postgres.NewAirflowSyncStateRepository(db)
+			projectName := tenant.ProjectName("proj-failed-advances")
+			end := currentTime.Add(time.Minute)
+
+			// negative lock duration => locked_until is already in the past, so the claimed
+			// window is immediately eligible for FailExhaustedWindows with maxAttempts=1
+			// (attempt_count is 1 right after ClaimWindow).
+			_, claimed, err := repo.ClaimWindow(ctx, projectName, currentTime, end, uuid.New(), -time.Minute)
+			assert.NoError(t, err)
+			assert.True(t, claimed)
+
+			failedCount, err := repo.FailExhaustedWindows(ctx, projectName, 1, "boom")
+			assert.NoError(t, err)
+			assert.EqualValues(t, 1, failedCount)
+
+			watermark, err := repo.GetWatermark(ctx, projectName)
+			assert.NoError(t, err)
+			if assert.NotNil(t, watermark) {
+				assert.True(t, watermark.Equal(end))
+			}
+		})
+	})
+
+	t.Run("ReclaimStaleWindow", func(t *testing.T) {
+		t.Run("returns nil when there is nothing stale", func(t *testing.T) {
+			db := dbSetup()
+			repo := postgres.NewAirflowSyncStateRepository(db)
+			projectName := tenant.ProjectName("proj-nothing-stale")
+
+			_, claimed, err := repo.ClaimWindow(ctx, projectName, currentTime, currentTime.Add(time.Minute), uuid.New(), time.Minute)
+			assert.NoError(t, err)
+			assert.True(t, claimed)
+
+			reclaimed, err := repo.ReclaimStaleWindow(ctx, projectName, uuid.New(), time.Minute, 3)
+			assert.NoError(t, err)
+			assert.Nil(t, reclaimed)
+		})
+
+		t.Run("reclaims a window whose lock already expired, bumping attempt_count", func(t *testing.T) {
+			db := dbSetup()
+			repo := postgres.NewAirflowSyncStateRepository(db)
+			projectName := tenant.ProjectName("proj-stale-reclaim")
+			start, end := currentTime, currentTime.Add(time.Minute)
+
+			// negative lock duration => already stale the moment it's claimed
+			id, claimed, err := repo.ClaimWindow(ctx, projectName, start, end, uuid.New(), -time.Minute)
+			assert.NoError(t, err)
+			assert.True(t, claimed)
+
+			newWorkerID := uuid.New()
+			reclaimed, err := repo.ReclaimStaleWindow(ctx, projectName, newWorkerID, time.Minute, 3)
+			assert.NoError(t, err)
+			if assert.NotNil(t, reclaimed) {
+				assert.Equal(t, id, reclaimed.ID)
+				assert.Equal(t, newWorkerID, reclaimed.WorkerID)
+				assert.Equal(t, 2, reclaimed.AttemptCount) // 1 at claim, +1 on reclaim
+				assert.Equal(t, scheduler.AirflowSyncInProgress, reclaimed.Status)
+			}
+		})
+
+		t.Run("does not reclaim a window that already exhausted max attempts", func(t *testing.T) {
+			db := dbSetup()
+			repo := postgres.NewAirflowSyncStateRepository(db)
+			projectName := tenant.ProjectName("proj-exhausted-no-reclaim")
+
+			_, claimed, err := repo.ClaimWindow(ctx, projectName, currentTime, currentTime.Add(time.Minute), uuid.New(), -time.Minute)
+			assert.NoError(t, err)
+			assert.True(t, claimed)
+
+			// maxAttempts=1: attempt_count is already 1 right after claiming, so this must not reclaim.
+			reclaimed, err := repo.ReclaimStaleWindow(ctx, projectName, uuid.New(), time.Minute, 1)
+			assert.NoError(t, err)
+			assert.Nil(t, reclaimed)
+		})
+	})
+
+	t.Run("CompleteWindow", func(t *testing.T) {
+		t.Run("succeeds when the worker still holds the lease", func(t *testing.T) {
+			db := dbSetup()
+			repo := postgres.NewAirflowSyncStateRepository(db)
+			projectName := tenant.ProjectName("proj-complete-ok")
+			workerID := uuid.New()
+
+			id, claimed, err := repo.ClaimWindow(ctx, projectName, currentTime, currentTime.Add(time.Minute), workerID, time.Minute)
+			assert.NoError(t, err)
+			assert.True(t, claimed)
+
+			logID := int64(42)
+			completed, err := repo.CompleteWindow(ctx, id, workerID, &logID, 3, 2)
+			assert.NoError(t, err)
+			assert.True(t, completed)
+		})
+
+		t.Run("fails when a different worker attempts to complete it", func(t *testing.T) {
+			db := dbSetup()
+			repo := postgres.NewAirflowSyncStateRepository(db)
+			projectName := tenant.ProjectName("proj-complete-wrong-worker")
+
+			id, claimed, err := repo.ClaimWindow(ctx, projectName, currentTime, currentTime.Add(time.Minute), uuid.New(), time.Minute)
+			assert.NoError(t, err)
+			assert.True(t, claimed)
+
+			completed, err := repo.CompleteWindow(ctx, id, uuid.New(), nil, 0, 0)
+			assert.NoError(t, err)
+			assert.False(t, completed)
+		})
+
+		t.Run("fails when the lease already expired, even for the original worker", func(t *testing.T) {
+			db := dbSetup()
+			repo := postgres.NewAirflowSyncStateRepository(db)
+			projectName := tenant.ProjectName("proj-complete-expired-lease")
+			workerID := uuid.New()
+
+			// negative lock duration => the lease is already expired by the time we try to complete it,
+			// simulating a worker that took too long and got its window reclaimed by someone else.
+			id, claimed, err := repo.ClaimWindow(ctx, projectName, currentTime, currentTime.Add(time.Minute), workerID, -time.Minute)
+			assert.NoError(t, err)
+			assert.True(t, claimed)
+
+			completed, err := repo.CompleteWindow(ctx, id, workerID, nil, 0, 0)
+			assert.NoError(t, err)
+			assert.False(t, completed)
+		})
+	})
+
+	t.Run("RecordAttemptError", func(t *testing.T) {
+		t.Run("annotates last_error while the lease is still valid, visible after it later becomes reclaimable", func(t *testing.T) {
+			db := dbSetup()
+			repo := postgres.NewAirflowSyncStateRepository(db)
+			projectName := tenant.ProjectName("proj-record-error")
+			workerID := uuid.New()
+
+			// claim with a still-valid lease so the fenced write below has something to succeed
+			// against -- a negative lock duration here (as elsewhere in this file, to simulate
+			// staleness) would make RecordAttemptError's own fence reject it before we even get
+			// to observe it, testing the wrong thing.
+			id, claimed, err := repo.ClaimWindow(ctx, projectName, currentTime, currentTime.Add(time.Minute), workerID, time.Minute)
+			assert.NoError(t, err)
+			assert.True(t, claimed)
+
+			err = repo.RecordAttemptError(ctx, id, workerID, "boom: airflow unreachable")
+			assert.NoError(t, err)
+
+			// backdate the lease directly (bypassing the repository) to deterministically simulate
+			// "time passed and the lease expired", so ReclaimStaleWindow can pick it up and we can
+			// observe the annotated LastError through its return value.
+			_, err = db.Exec(ctx, "UPDATE airflow_sync_state SET locked_until = now() - interval '1 minute' WHERE id = $1", id)
+			assert.NoError(t, err)
+
+			reclaimed, err := repo.ReclaimStaleWindow(ctx, projectName, uuid.New(), time.Minute, 5)
+			assert.NoError(t, err)
+			if assert.NotNil(t, reclaimed) {
+				assert.Equal(t, "boom: airflow unreachable", reclaimed.LastError)
+				assert.Equal(t, scheduler.AirflowSyncInProgress, reclaimed.Status)
+			}
+		})
+
+		t.Run("is a no-op when a different worker no longer holds the lease", func(t *testing.T) {
+			db := dbSetup()
+			repo := postgres.NewAirflowSyncStateRepository(db)
+			projectName := tenant.ProjectName("proj-record-error-wrong-worker")
+			workerID := uuid.New()
+
+			id, claimed, err := repo.ClaimWindow(ctx, projectName, currentTime, currentTime.Add(time.Minute), workerID, time.Minute)
+			assert.NoError(t, err)
+			assert.True(t, claimed)
+
+			// a different worker id should not be able to stamp an error on a lease it doesn't hold
+			err = repo.RecordAttemptError(ctx, id, uuid.New(), "should not stick")
+			assert.NoError(t, err)
+
+			_, err = db.Exec(ctx, "UPDATE airflow_sync_state SET locked_until = now() - interval '1 minute' WHERE id = $1", id)
+			assert.NoError(t, err)
+
+			reclaimed, err := repo.ReclaimStaleWindow(ctx, projectName, uuid.New(), time.Minute, 5)
+			assert.NoError(t, err)
+			if assert.NotNil(t, reclaimed) {
+				assert.Empty(t, reclaimed.LastError)
+			}
+		})
+	})
+}

--- a/internal/store/postgres/scheduler/job_operator_repository.go
+++ b/internal/store/postgres/scheduler/job_operator_repository.go
@@ -69,6 +69,7 @@ func (o *operatorRun) toOperatorRun() (*scheduler.OperatorRun, error) {
 		Status:       status,
 		StartTime:    o.StartTime,
 		EndTime:      o.EndTime,
+		UpdatedAt:    o.UpdatedAt,
 	}, nil
 }
 
@@ -78,9 +79,9 @@ func (o *OperatorRunRepository) GetOperatorRun(ctx context.Context, name string,
 	if err != nil {
 		return nil, err
 	}
-	getJobRunByID := "SELECT " + jobOperatorColumns + " FROM " + operatorTableName + " j where job_run_id = $1 and name = $2 order by created_at desc limit 1"
+	getJobRunByID := "SELECT " + jobOperatorColumns + ", updated_at FROM " + operatorTableName + " j where job_run_id = $1 and name = $2 order by created_at desc limit 1"
 	err = o.db.QueryRow(ctx, getJobRunByID, jobRunID, name).
-		Scan(&opRun.ID, &opRun.Name, &opRun.JobRunID, &opRun.Status, &opRun.StartTime, &opRun.EndTime)
+		Scan(&opRun.ID, &opRun.Name, &opRun.JobRunID, &opRun.Status, &opRun.StartTime, &opRun.EndTime, &opRun.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, errors.NotFound(scheduler.EntityJobRun, "no record for "+operatorType.String()+"/"+name+" for job_run ID: "+jobRunID.String())
@@ -88,6 +89,39 @@ func (o *OperatorRunRepository) GetOperatorRun(ctx context.Context, name string,
 		return nil, errors.Wrap(scheduler.EntityJobRun, "error while getting operator run", err)
 	}
 	return opRun.toOperatorRun()
+}
+
+// ListLatestOperatorRunsByJobRunID returns the newest row per distinct operator name for the
+// given job_run_id and operator type. Used by the airflow-sync reconciler to mirror
+// Airflow's own dagrun-level cascade (only non-terminal children get overwritten), which
+// needs to see every child's *current* status first -- unlike GetOperatorRun, which only
+// looks up one already-known name.
+func (o *OperatorRunRepository) ListLatestOperatorRunsByJobRunID(ctx context.Context, operatorType scheduler.OperatorType, jobRunID uuid.UUID) ([]*scheduler.OperatorRun, error) {
+	operatorTableName, err := operatorTypeToTableName(operatorType)
+	if err != nil {
+		return nil, err
+	}
+	query := "SELECT DISTINCT ON (name) " + jobOperatorColumns + ", updated_at FROM " + operatorTableName + " WHERE job_run_id = $1 ORDER BY name, created_at DESC"
+	rows, err := o.db.Query(ctx, query, jobRunID)
+	if err != nil {
+		return nil, errors.Wrap(scheduler.EntityJobRun, "error while listing operator runs", err)
+	}
+	defer rows.Close()
+
+	var operatorRuns []*scheduler.OperatorRun
+	for rows.Next() {
+		var opRun operatorRun
+		if err := rows.Scan(&opRun.ID, &opRun.Name, &opRun.JobRunID, &opRun.Status, &opRun.StartTime, &opRun.EndTime, &opRun.UpdatedAt); err != nil {
+			return nil, errors.Wrap(scheduler.EntityJobRun, "error scanning operator run", err)
+		}
+		opRun.OperatorType = operatorType.String()
+		schedulerOpRun, err := opRun.toOperatorRun()
+		if err != nil {
+			return nil, err
+		}
+		operatorRuns = append(operatorRuns, schedulerOpRun)
+	}
+	return operatorRuns, nil
 }
 
 func (o *OperatorRunRepository) CreateOperatorRun(ctx context.Context, name string, operatorType scheduler.OperatorType, jobRunID uuid.UUID, startTime time.Time) error {

--- a/internal/store/postgres/scheduler/job_operator_repository_test.go
+++ b/internal/store/postgres/scheduler/job_operator_repository_test.go
@@ -81,6 +81,76 @@ func TestPostgresJobOperatorRepository(t *testing.T) {
 		})
 	})
 
+	t.Run("ListLatestOperatorRunsByJobRunID", func(t *testing.T) {
+		t.Run("returns the latest row per operator name, scoped to the given operator type", func(t *testing.T) {
+			db := dbSetup()
+			_ = addJobs(ctx, t, db)
+			jobRunRepo := postgres.NewJobRunRepository(db, nil)
+			err := jobRunRepo.Create(ctx, tnnt, jobAName, scheduledAt, intr, slaDefinitionInSec)
+			assert.Nil(t, err)
+
+			jobRun, err := jobRunRepo.GetByScheduledAt(ctx, tnnt, jobAName, scheduledAt)
+			assert.Nil(t, err)
+
+			operatorRunRepo := postgres.NewOperatorRunRepository(db)
+
+			// first attempt for "task-a": fails, then gets retried as a new row
+			err = operatorRunRepo.CreateOperatorRun(ctx, "task-a", scheduler.OperatorTask, jobRun.ID, operatorStartTime)
+			assert.Nil(t, err)
+			firstAttempt, err := operatorRunRepo.GetOperatorRun(ctx, "task-a", scheduler.OperatorTask, jobRun.ID)
+			assert.Nil(t, err)
+			err = operatorRunRepo.UpdateOperatorRun(ctx, scheduler.OperatorTask, firstAttempt.ID, operatorEndTime, scheduler.StateFailed)
+			assert.Nil(t, err)
+
+			// sleep so the retry's created_at strictly sorts after the first attempt's
+			time.Sleep(10 * time.Millisecond)
+			err = operatorRunRepo.CreateOperatorRun(ctx, "task-a", scheduler.OperatorTask, jobRun.ID, operatorStartTime.Add(time.Minute))
+			assert.Nil(t, err)
+
+			// a different operator name in the same table
+			err = operatorRunRepo.CreateOperatorRun(ctx, "task-b", scheduler.OperatorTask, jobRun.ID, operatorStartTime)
+			assert.Nil(t, err)
+
+			// same job run, different operator-type table -- must not leak into the task list
+			err = operatorRunRepo.CreateOperatorRun(ctx, "wait_upstream", scheduler.OperatorSensor, jobRun.ID, operatorStartTime)
+			assert.Nil(t, err)
+
+			runs, err := operatorRunRepo.ListLatestOperatorRunsByJobRunID(ctx, scheduler.OperatorTask, jobRun.ID)
+			assert.Nil(t, err)
+			assert.Len(t, runs, 2)
+
+			byName := map[string]*scheduler.OperatorRun{}
+			for _, r := range runs {
+				byName[r.Name] = r
+			}
+
+			taskA, ok := byName["task-a"]
+			assert.True(t, ok)
+			assert.Equal(t, scheduler.StateRunning, taskA.Status) // the retry, not the failed first attempt
+			assert.Equal(t, scheduler.OperatorTask, taskA.OperatorType)
+
+			taskB, ok := byName["task-b"]
+			assert.True(t, ok)
+			assert.Equal(t, scheduler.OperatorTask, taskB.OperatorType)
+		})
+
+		t.Run("returns an empty slice when the job run has no operator runs of that type", func(t *testing.T) {
+			db := dbSetup()
+			_ = addJobs(ctx, t, db)
+			jobRunRepo := postgres.NewJobRunRepository(db, nil)
+			err := jobRunRepo.Create(ctx, tnnt, jobAName, scheduledAt, intr, slaDefinitionInSec)
+			assert.Nil(t, err)
+
+			jobRun, err := jobRunRepo.GetByScheduledAt(ctx, tnnt, jobAName, scheduledAt)
+			assert.Nil(t, err)
+
+			operatorRunRepo := postgres.NewOperatorRunRepository(db)
+			runs, err := operatorRunRepo.ListLatestOperatorRunsByJobRunID(ctx, scheduler.OperatorTask, jobRun.ID)
+			assert.Nil(t, err)
+			assert.Empty(t, runs)
+		})
+	})
+
 	t.Run("UpdateOperatorRun", func(t *testing.T) {
 		t.Run("updates a specific operator run by job id", func(t *testing.T) {
 			db := dbSetup()

--- a/internal/store/postgres/scheduler/job_run_repository.go
+++ b/internal/store/postgres/scheduler/job_run_repository.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	columnsToStore = `job_name, namespace_name, project_name, scheduled_at, start_time, end_time, window_start, window_end, status, sla_definition, sla_alert`
-	jobRunColumns  = `id, ` + columnsToStore + `, monitoring`
+	jobRunColumns  = `id, ` + columnsToStore + `, monitoring, created_at, updated_at`
 	dbTimeFormat   = "2006-01-02 15:04:05.000000+00"
 )
 
@@ -101,7 +101,7 @@ func (j *JobRunRepository) GetByID(ctx context.Context, id scheduler.JobRunID) (
 	getJobRunByID := `SELECT ` + jobRunColumns + ` FROM job_run where id = $1`
 	err := j.db.QueryRow(ctx, getJobRunByID, id.UUID()).
 		Scan(&jr.ID, &jr.JobName, &jr.NamespaceName, &jr.ProjectName, &jr.ScheduledAt, &jr.StartTime, &jr.EndTime,
-			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring)
+			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.CreatedAt, &jr.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, errors.NotFound(scheduler.EntityJobRun, "no record for job run id "+id.UUID().String())
@@ -117,10 +117,10 @@ func (j *JobRunRepository) GetLatestRun(ctx context.Context, project tenant.Proj
 	if runState != nil {
 		stateClause = fmt.Sprintf(" and status = '%s'", runState)
 	}
-	getLatestRun := fmt.Sprintf("SELECT %s, created_at FROM job_run j where project_name = $1 and job_name = $2 %s order by scheduled_at desc limit 1", jobRunColumns, stateClause)
+	getLatestRun := fmt.Sprintf("SELECT %s FROM job_run j where project_name = $1 and job_name = $2 %s order by scheduled_at desc limit 1", jobRunColumns, stateClause)
 	err := j.db.QueryRow(ctx, getLatestRun, project, jobName).
 		Scan(&jr.ID, &jr.JobName, &jr.NamespaceName, &jr.ProjectName, &jr.ScheduledAt, &jr.StartTime, &jr.EndTime,
-			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.CreatedAt)
+			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.CreatedAt, &jr.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, errors.NotFound(scheduler.EntityJobRun, "no record for job:"+jobName.String()+stateClause)
@@ -141,7 +141,7 @@ func (j *JobRunRepository) GetRunsByInterval(ctx context.Context, project tenant
 	for rows.Next() {
 		var jr jobRun
 		err := rows.Scan(&jr.ID, &jr.JobName, &jr.NamespaceName, &jr.ProjectName, &jr.ScheduledAt, &jr.StartTime, &jr.EndTime,
-			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring)
+			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.CreatedAt, &jr.UpdatedAt)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return []*scheduler.JobRun{}, nil
@@ -163,7 +163,7 @@ func (j *JobRunRepository) GetRunsByTimeRange(ctx context.Context, project tenan
 	if runState != nil {
 		stateClause = fmt.Sprintf(" and status = '%s'", runState)
 	}
-	getLatestRun := fmt.Sprintf("SELECT %s, created_at FROM job_run j where project_name = $1 and job_name = $2 and scheduled_at >= $3 and scheduled_at <= $4 %s", jobRunColumns, stateClause)
+	getLatestRun := fmt.Sprintf("SELECT %s FROM job_run j where project_name = $1 and job_name = $2 and scheduled_at >= $3 and scheduled_at <= $4 %s", jobRunColumns, stateClause)
 	rows, err := j.db.Query(ctx, getLatestRun, project, jobName, since, until)
 	if err != nil {
 		return nil, errors.Wrap(scheduler.EntityJobRun, "error while getting job runs", err)
@@ -171,7 +171,7 @@ func (j *JobRunRepository) GetRunsByTimeRange(ctx context.Context, project tenan
 	for rows.Next() {
 		var jr jobRun
 		err := rows.Scan(&jr.ID, &jr.JobName, &jr.NamespaceName, &jr.ProjectName, &jr.ScheduledAt, &jr.StartTime, &jr.EndTime,
-			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.CreatedAt)
+			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.CreatedAt, &jr.UpdatedAt)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return []*scheduler.JobRun{}, nil
@@ -190,7 +190,7 @@ func (j *JobRunRepository) GetRunsByTimeRange(ctx context.Context, project tenan
 func (j *JobRunRepository) GetByScheduledAt(ctx context.Context, t tenant.Tenant, jobName scheduler.JobName, scheduledAt time.Time) (*scheduler.JobRun, error) {
 	var jr jobRun
 	// todo: check if `order by created_at desc limit 1` is required
-	getJobRunByScheduledAt := `SELECT ` + jobRunColumns + `, created_at, updated_at FROM job_run j where project_name = $1 and namespace_name = $2 and job_name = $3 and scheduled_at = $4 order by created_at desc limit 1`
+	getJobRunByScheduledAt := `SELECT ` + jobRunColumns + ` FROM job_run j where project_name = $1 and namespace_name = $2 and job_name = $3 and scheduled_at = $4 order by created_at desc limit 1`
 	err := j.db.QueryRow(ctx, getJobRunByScheduledAt, t.ProjectName(), t.NamespaceName(), jobName, scheduledAt).
 		Scan(&jr.ID, &jr.JobName, &jr.NamespaceName, &jr.ProjectName, &jr.ScheduledAt, &jr.StartTime, &jr.EndTime,
 			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.CreatedAt, &jr.UpdatedAt)
@@ -210,7 +210,7 @@ func (j *JobRunRepository) GetByScheduledTimes(ctx context.Context, t tenant.Ten
 		scheduledTimesString = append(scheduledTimesString, scheduleTime.UTC().Format(dbTimeFormat))
 	}
 
-	getJobRunByScheduledTimesTemp := `SELECT ` + jobRunColumns + `,created_at FROM job_run j where project_name = $1 and namespace_name = $2 and job_name = $3 and scheduled_at in ('` + strings.Join(scheduledTimesString, "', '") + `')`
+	getJobRunByScheduledTimesTemp := `SELECT ` + jobRunColumns + ` FROM job_run j where project_name = $1 and namespace_name = $2 and job_name = $3 and scheduled_at in ('` + strings.Join(scheduledTimesString, "', '") + `')`
 	rows, err := j.db.Query(ctx, getJobRunByScheduledTimesTemp, t.ProjectName(), t.NamespaceName(), jobName.String())
 	if err != nil {
 		return nil, errors.Wrap(scheduler.EntityJobRun, "error while getting job runs", err)
@@ -218,7 +218,7 @@ func (j *JobRunRepository) GetByScheduledTimes(ctx context.Context, t tenant.Ten
 	for rows.Next() {
 		var jr jobRun
 		err := rows.Scan(&jr.ID, &jr.JobName, &jr.NamespaceName, &jr.ProjectName, &jr.ScheduledAt, &jr.StartTime, &jr.EndTime,
-			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.CreatedAt)
+			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.CreatedAt, &jr.UpdatedAt)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return nil, errors.NotFound(scheduler.EntityJobRun, "no record of job run :"+jobName.String()+" for schedule Times : "+strings.Join(scheduledTimesString, ", "))

--- a/internal/store/postgres/scheduler/job_run_repository.go
+++ b/internal/store/postgres/scheduler/job_run_repository.go
@@ -92,6 +92,7 @@ func (j *jobRun) toJobRun() (*scheduler.JobRun, error) {
 		WindowEnd:     windowEnd,
 		SLADefinition: j.SLADefinition,
 		Monitoring:    monitoring,
+		UpdatedAt:     j.UpdatedAt,
 	}, nil
 }
 
@@ -189,10 +190,10 @@ func (j *JobRunRepository) GetRunsByTimeRange(ctx context.Context, project tenan
 func (j *JobRunRepository) GetByScheduledAt(ctx context.Context, t tenant.Tenant, jobName scheduler.JobName, scheduledAt time.Time) (*scheduler.JobRun, error) {
 	var jr jobRun
 	// todo: check if `order by created_at desc limit 1` is required
-	getJobRunByScheduledAt := `SELECT ` + jobRunColumns + `, created_at FROM job_run j where project_name = $1 and namespace_name = $2 and job_name = $3 and scheduled_at = $4 order by created_at desc limit 1`
+	getJobRunByScheduledAt := `SELECT ` + jobRunColumns + `, created_at, updated_at FROM job_run j where project_name = $1 and namespace_name = $2 and job_name = $3 and scheduled_at = $4 order by created_at desc limit 1`
 	err := j.db.QueryRow(ctx, getJobRunByScheduledAt, t.ProjectName(), t.NamespaceName(), jobName, scheduledAt).
 		Scan(&jr.ID, &jr.JobName, &jr.NamespaceName, &jr.ProjectName, &jr.ScheduledAt, &jr.StartTime, &jr.EndTime,
-			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.CreatedAt)
+			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.CreatedAt, &jr.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, errors.NotFound(scheduler.EntityJobRun, "no record for job:"+jobName.String()+" scheduled at: "+scheduledAt.String())

--- a/server/optimus.go
+++ b/server/optimus.go
@@ -493,13 +493,14 @@ func (s *OptimusServer) setupHandlers() error {
 			s.logger, newScheduler, jobProviderRepo, jobRunRepo, operatorRunRepository, s.eventHandler)
 		airflowStateSyncWorker := schedulerService.NewAirflowStateSyncWorker(s.logger, tProjectService, airflowSyncStateRepo, airflowStateSyncService,
 			schedulerService.AirflowStateSyncConfig{
-				WindowInterval:    time.Second * time.Duration(s.conf.AirflowSync.WindowIntervalInSeconds),
-				SettlingDelay:     time.Second * time.Duration(s.conf.AirflowSync.SettlingDelayInSeconds),
-				LockDuration:      time.Second * time.Duration(s.conf.AirflowSync.LockDurationInSeconds),
-				InitialLookback:   time.Second * time.Duration(s.conf.AirflowSync.InitialLookbackInSeconds),
-				OverlapEpsilon:    time.Second * time.Duration(s.conf.AirflowSync.OverlapEpsilonInSeconds),
-				MaxAttempts:       s.conf.AirflowSync.MaxAttempts,
-				MaxWindowsPerTick: s.conf.AirflowSync.MaxWindowsPerTick,
+				WindowInterval:        time.Second * time.Duration(s.conf.AirflowSync.WindowIntervalInSeconds),
+				SettlingDelay:         time.Second * time.Duration(s.conf.AirflowSync.SettlingDelayInSeconds),
+				LockDuration:          time.Second * time.Duration(s.conf.AirflowSync.LockDurationInSeconds),
+				InitialLookback:       time.Second * time.Duration(s.conf.AirflowSync.InitialLookbackInSeconds),
+				OverlapEpsilon:        time.Second * time.Duration(s.conf.AirflowSync.OverlapEpsilonInSeconds),
+				MaxAttempts:           s.conf.AirflowSync.MaxAttempts,
+				MaxWindowsPerTick:     s.conf.AirflowSync.MaxWindowsPerTick,
+				MaxConcurrentProjects: s.conf.AirflowSync.MaxConcurrentProjects,
 			})
 		airflowSyncWorkerCtx, closeAirflowSyncWorker := context.WithCancel(context.Background())
 		s.cleanupFn = append(s.cleanupFn, closeAirflowSyncWorker)

--- a/server/optimus.go
+++ b/server/optimus.go
@@ -494,13 +494,10 @@ func (s *OptimusServer) setupHandlers() error {
 		airflowStateSyncWorker := schedulerService.NewAirflowStateSyncWorker(s.logger, tProjectService, airflowSyncStateRepo, airflowStateSyncService,
 			schedulerService.AirflowStateSyncConfig{
 				WindowInterval:        time.Second * time.Duration(s.conf.AirflowSync.WindowIntervalInSeconds),
-				SettlingDelay:         time.Second * time.Duration(s.conf.AirflowSync.SettlingDelayInSeconds),
 				LockDuration:          time.Second * time.Duration(s.conf.AirflowSync.LockDurationInSeconds),
-				InitialLookback:       time.Second * time.Duration(s.conf.AirflowSync.InitialLookbackInSeconds),
-				OverlapEpsilon:        time.Second * time.Duration(s.conf.AirflowSync.OverlapEpsilonInSeconds),
-				MaxAttempts:           s.conf.AirflowSync.MaxAttempts,
-				MaxWindowsPerTick:     s.conf.AirflowSync.MaxWindowsPerTick,
 				MaxConcurrentProjects: s.conf.AirflowSync.MaxConcurrentProjects,
+				MaxAttempts:           s.conf.AirflowSync.MaxAttempts,
+				ExcludeProjects:       s.conf.AirflowSync.ExcludeProjects,
 			})
 		airflowSyncWorkerCtx, closeAirflowSyncWorker := context.WithCancel(context.Background())
 		s.cleanupFn = append(s.cleanupFn, closeAirflowSyncWorker)

--- a/server/optimus.go
+++ b/server/optimus.go
@@ -483,6 +483,29 @@ func (s *OptimusServer) setupHandlers() error {
 		time.Minute*time.Duration(s.conf.SLAConfig.WorkerIntervalMinutes),
 		time.Minute*time.Duration(s.conf.SLAConfig.LockDurationMinutes))
 
+	// manual-state-override reconciliation, see
+	// docs/docs/rfcs/20260727_manual_state_override_reconciliation.md. Opt-in: a zero
+	// WindowIntervalInSeconds (the default, since AirflowSyncConfig has no `default` tag on
+	// it) leaves this off entirely.
+	if s.conf.AirflowSync.WindowIntervalInSeconds > 0 {
+		airflowSyncStateRepo := schedulerRepo.NewAirflowSyncStateRepository(s.dbPool)
+		airflowStateSyncService := schedulerService.NewAirflowStateSyncService(
+			s.logger, newScheduler, jobProviderRepo, jobRunRepo, operatorRunRepository, s.eventHandler)
+		airflowStateSyncWorker := schedulerService.NewAirflowStateSyncWorker(s.logger, tProjectService, airflowSyncStateRepo, airflowStateSyncService,
+			schedulerService.AirflowStateSyncConfig{
+				WindowInterval:    time.Second * time.Duration(s.conf.AirflowSync.WindowIntervalInSeconds),
+				SettlingDelay:     time.Second * time.Duration(s.conf.AirflowSync.SettlingDelayInSeconds),
+				LockDuration:      time.Second * time.Duration(s.conf.AirflowSync.LockDurationInSeconds),
+				InitialLookback:   time.Second * time.Duration(s.conf.AirflowSync.InitialLookbackInSeconds),
+				OverlapEpsilon:    time.Second * time.Duration(s.conf.AirflowSync.OverlapEpsilonInSeconds),
+				MaxAttempts:       s.conf.AirflowSync.MaxAttempts,
+				MaxWindowsPerTick: s.conf.AirflowSync.MaxWindowsPerTick,
+			})
+		airflowSyncWorkerCtx, closeAirflowSyncWorker := context.WithCancel(context.Background())
+		s.cleanupFn = append(s.cleanupFn, closeAirflowSyncWorker)
+		airflowStateSyncWorker.ScheduleAirflowStateSync(airflowSyncWorkerCtx)
+	}
+
 	resourceWorkerCtx, closeResourceWorker := context.WithCancel(context.Background())
 	s.cleanupFn = append(s.cleanupFn, closeResourceWorker)
 

--- a/tests/setup/database.go
+++ b/tests/setup/database.go
@@ -143,6 +143,7 @@ func TruncateTablesWith(pool *pgxpool.Pool) {
 	pool.Exec(ctx, "TRUNCATE TABLE sensor_run CASCADE")
 	pool.Exec(ctx, "TRUNCATE TABLE task_run CASCADE")
 	pool.Exec(ctx, "TRUNCATE TABLE hook_run CASCADE")
+	pool.Exec(ctx, "TRUNCATE TABLE airflow_sync_state CASCADE")
 
 	pool.Exec(ctx, "TRUNCATE TABLE job CASCADE")
 


### PR DESCRIPTION
## Add manual-state-override reconciliation for Airflow-side job runs

### Summary
- When an engineer manually marks a task/DAG run in Airflow's UI (bypassing the normal
  callback path), Optimus's `job_run`/`task_run`/`sensor_run`/`hook_run` rows go stale,
  producing false-positive incompleteness alerts. This adds an opt-in background worker
  that polls each project's Airflow audit log (`GET /api/v1/eventLogs`), identifies
  genuine human overrides, and reconciles Optimus's state to match.
- Manual overrides are detected via the four legacy `www` mark events
  (`success`/`failed`/`dagrun_success`/`dagrun_failed`) with a populated `extra` field
  (only ever set by Airflow's `action_logging`, never by ordinary worker transitions) and
  `confirmed=true` for the dagrun-level pair — no direct Airflow DB access required.
- Concurrency uses a windowed claim table (`airflow_sync_state`, keyed on
  `(project_name, start_time, end_time)`, claimed via `INSERT ... ON CONFLICT DO NOTHING`)
  rather than Postgres advisory locks, so multiple server replicas process different
  projects in parallel while staying serial within a project and self-healing after a
  crashed replica.
- Write-scope is deliberately conservative: never fabricates `job_run`/operator rows,
  never regresses a state fresher than the override, and mirrors Airflow's own asymmetric
  cascade on `dagrun_failed` (only touches non-terminal children, exactly like
  `set_dag_run_state_to_failed`) rather than force-setting everything.

### Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint` all clean (zero findings in new/changed code)
- [x] Full unit test suite green (`go test -tags=unit_test ./...`)
- [x] End-to-end verified on the local dev harness (colima + real Airflow 2.9.3 + real Optimus):
      manually marked a real `scheduled__` DAG run failed via the actual Airflow grid UI,
      confirmed `job_run` was stale immediately after, then confirmed the worker's next
      window reconciled it to `failed` while the already-terminal `task_run` child was
      correctly left untouched (asymmetric-cascade protection)
- [x] Integration tests against a live DB for the new/changed repository methods
      (`internal/store/postgres/scheduler` has no `unit_test`-tagged coverage for these)
- [ ] End-to-end verification for `manual__`/`replayed__`/`custom-backfill_*` run_id shapes
      specifically (only `scheduled__` was exercised live; the others share the same code
      path but haven't been demoed against a real instance)
- [ ] Design doc: `docs/docs/rfcs/20260727_manual_state_override_reconciliation.md`