### PR TITLE
fix: support replay run attribution

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -78,3 +78,27 @@ log:
 #     bq2api: EXECUTION_PROJECT
 #     clevertap: EXECUTION_PROJECT
 #     transporterTask: EXECUTION_PROJECT
+
+# run_attribution:
+#   # Kill switch for the Airflow dependency only. Off by default: turn on per environment once
+#   # the SCHEDULER_AUTH credential has `can_read on Audit Logs`. Attributing runs to Optimus's
+#   # own replay and backfill requests is a local DB lookup and is always active; with this off a
+#   # manual run is still recorded as manual, its actor is just left unidentified.
+#   audit_resolution_enabled: false
+#   # Airflow audit log owners that are Optimus itself. Optimus's own replay and backfill calls
+#   # into Airflow are audited too, so leaving this unset would attribute every replay to the
+#   # service account instead of the requesting user. Must match the SCHEDULER_AUTH username.
+#   service_account_owners:
+#     - optimus
+#   # How far before a run's start time to search Airflow's audit log. Needs to cover the gap
+#   # between a user clicking Clear and the task actually starting: a scheduler loop plus queue
+#   # and pool wait.
+#   audit_lookback_minutes: 30
+#   audit_page_limit: 100
+#   # Attribution is resolved in detached goroutines, never on the event ingestion path. When all
+#   # slots are busy the run is still recorded as manual, with the actor left unidentified,
+#   # rather than blocking event ingestion or queueing unbounded work.
+#   max_concurrent_resolves: 16
+#   resolve_timeout_seconds: 30
+#   resolve_retry_max: 3
+#   resolve_retry_backoff_ms: 500

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -94,11 +94,17 @@ log:
 #   # between a user clicking Clear and the task actually starting: a scheduler loop plus queue
 #   # and pool wait.
 #   audit_lookback_minutes: 30
+#   # Bounds the dag-scoped audit query so it stays indexed on the log table's timestamp. Generous
+#   # by design: it is for query efficiency, not for deciding which run an event belongs to.
+#   identify_lookback_hours: 24
 #   audit_page_limit: 100
-#   # Attribution is resolved in detached goroutines, never on the event ingestion path. When all
-#   # slots are busy the run is still recorded as manual, with the actor left unidentified,
-#   # rather than blocking event ingestion or queueing unbounded work.
+#   # Concurrent calls into Airflow. Tasks of one cleared dag run share a single lookup and do not
+#   # each consume a slot, so this bounds load on the Airflow webserver.
 #   max_concurrent_resolves: 16
+#   # In-flight resolver goroutines. Attribution is resolved off the event ingestion path, so this
+#   # is only a memory backstop for a prolonged Airflow outage; beyond it a run is still recorded
+#   # as manual, with the actor left unidentified.
+#   max_pending_resolves: 512
 #   resolve_timeout_seconds: 30
 #   resolve_retry_max: 3
 #   resolve_retry_backoff_ms: 500

--- a/config/config_server.go
+++ b/config/config_server.go
@@ -167,9 +167,14 @@ type RunAttributionConfig struct {
 	// ResolveTimeoutSeconds bounds one audit resolution, including its retries. The resolver
 	// runs detached from the request that triggered it, so this is the only thing that ends it.
 	ResolveTimeoutSeconds int `mapstructure:"resolve_timeout_seconds" default:"30"`
-	// MaxConcurrentResolves caps in-flight resolutions. When saturated Optimus records the run
-	// as manual with an unresolved actor rather than queueing work or blocking event ingestion.
+	// MaxConcurrentResolves caps concurrent calls *into Airflow*. Resolutions collapsed by
+	// singleflight — every task of one cleared dag run shares a single lookup — do not consume a
+	// slot, so this bounds load on the Airflow webserver rather than counting waiters.
 	MaxConcurrentResolves int `mapstructure:"max_concurrent_resolves" default:"16"`
+	// MaxPendingResolves caps in-flight resolver goroutines. Most are cheap waiters, so this
+	// exists only so a prolonged Airflow outage cannot grow memory without bound. Beyond it a run
+	// is still recorded as manual, with the actor left unidentified.
+	MaxPendingResolves    int `mapstructure:"max_pending_resolves" default:"512"`
 	ResolveRetryMax       int `mapstructure:"resolve_retry_max" default:"3"`
 	ResolveRetryBackoffMs int `mapstructure:"resolve_retry_backoff_ms" default:"500"`
 
@@ -177,6 +182,10 @@ type RunAttributionConfig struct {
 	// must cover the delay between a user's click and the task actually starting, which
 	// includes a scheduler loop plus queue and pool wait.
 	AuditLookbackMinutes int `mapstructure:"audit_lookback_minutes" default:"30"`
+	// IdentifyLookbackHours bounds the dag-scoped audit query so it stays indexed on the log
+	// table's timestamp. Generous by design: it exists for query efficiency, not to decide which
+	// run an event belongs to — AuditLookbackMinutes does that.
+	IdentifyLookbackHours int `mapstructure:"identify_lookback_hours" default:"24"`
 	// AuditPageLimit caps rows fetched per audit query.
 	AuditPageLimit int `mapstructure:"audit_page_limit" default:"100"`
 

--- a/config/config_server.go
+++ b/config/config_server.go
@@ -19,6 +19,7 @@ type ServerConfig struct {
 	UpstreamResolvers         []UpstreamResolver        `mapstructure:"upstream_resolvers"`
 	Replay                    ReplayConfig              `mapstructure:"replay"`
 	Backfill                  BackfillConfig            `mapstructure:"backfill"`
+	RunAttribution            RunAttributionConfig      `mapstructure:"run_attribution"`
 	Publisher                 *Publisher                `mapstructure:"publisher"`
 	JobSyncIntervalMinutes    int                       `mapstructure:"job_sync_interval_minutes"`
 	ExternalTables            ExternalTablesConfig      `mapstructure:"external_tables"`
@@ -145,6 +146,44 @@ type ReplayConfig struct {
 
 type BackfillConfig struct {
 	ExecutionIntervalInSeconds int `mapstructure:"execution_interval_in_seconds" default:"300"`
+}
+
+// RunAttributionConfig governs how Optimus decides why a task or hook run is executing and
+// who is answerable for it.
+//
+// The Airflow audit event names this relies on are not configurable: they are properties of a
+// given Airflow version, established by reading its source, and a wrong value here would
+// silently produce unattributed runs rather than an error.
+type RunAttributionConfig struct {
+	// AuditResolutionEnabled gates only the part that calls Airflow's audit log to find out who
+	// triggered or cleared a run by hand. Off by default so the Airflow dependency can be turned
+	// on per environment once the credential has `can_read on Audit Logs`.
+	//
+	// Attributing runs to Optimus's own replay and backfill requests is unaffected: that is a
+	// local database lookup and is always active. With this off, a manual run is still recorded
+	// as manual, only its actor is left unidentified.
+	AuditResolutionEnabled bool `mapstructure:"audit_resolution_enabled" default:"false"`
+
+	// ResolveTimeoutSeconds bounds one audit resolution, including its retries. The resolver
+	// runs detached from the request that triggered it, so this is the only thing that ends it.
+	ResolveTimeoutSeconds int `mapstructure:"resolve_timeout_seconds" default:"30"`
+	// MaxConcurrentResolves caps in-flight resolutions. When saturated Optimus records the run
+	// as manual with an unresolved actor rather than queueing work or blocking event ingestion.
+	MaxConcurrentResolves int `mapstructure:"max_concurrent_resolves" default:"16"`
+	ResolveRetryMax       int `mapstructure:"resolve_retry_max" default:"3"`
+	ResolveRetryBackoffMs int `mapstructure:"resolve_retry_backoff_ms" default:"500"`
+
+	// AuditLookbackMinutes is how far before a run's start time to search the audit log. It
+	// must cover the delay between a user's click and the task actually starting, which
+	// includes a scheduler loop plus queue and pool wait.
+	AuditLookbackMinutes int `mapstructure:"audit_lookback_minutes" default:"30"`
+	// AuditPageLimit caps rows fetched per audit query.
+	AuditPageLimit int `mapstructure:"audit_page_limit" default:"100"`
+
+	// ServiceAccountOwners are audit log owners that are Optimus itself. Optimus's own replay
+	// and backfill calls into Airflow are audited too, so without this every replay would be
+	// attributed to the service account. Deployment specific, hence configurable.
+	ServiceAccountOwners []string `mapstructure:"service_account_owners"`
 }
 
 type Publisher struct {

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -329,6 +329,15 @@ func (s *ConfigTestSuite) initExpectedServerConfig() {
 		},
 	}
 	s.expectedServerConfig.Backfill.ExecutionIntervalInSeconds = 300
+	s.expectedServerConfig.RunAttribution = config.RunAttributionConfig{
+		AuditResolutionEnabled: false,
+		ResolveTimeoutSeconds:  30,
+		MaxConcurrentResolves:  16,
+		ResolveRetryMax:        3,
+		ResolveRetryBackoffMs:  500,
+		AuditLookbackMinutes:   30,
+		AuditPageLimit:         100,
+	}
 }
 
 func (*ConfigTestSuite) initServerConfigEnv() {

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -333,9 +333,11 @@ func (s *ConfigTestSuite) initExpectedServerConfig() {
 		AuditResolutionEnabled: false,
 		ResolveTimeoutSeconds:  30,
 		MaxConcurrentResolves:  16,
+		MaxPendingResolves:     512,
 		ResolveRetryMax:        3,
 		ResolveRetryBackoffMs:  500,
 		AuditLookbackMinutes:   30,
+		IdentifyLookbackHours:  24,
 		AuditPageLimit:         100,
 	}
 }

--- a/core/scheduler/job_run.go
+++ b/core/scheduler/job_run.go
@@ -47,6 +47,9 @@ type JobRun struct {
 	WindowEnd     *time.Time
 	SLADefinition int64
 
+	// SchedulerRunID is Airflow's dag run id for this run, e.g. scheduled__2024-01-01T00:00:00+00:00.
+	SchedulerRunID string
+
 	Monitoring map[string]any
 }
 
@@ -70,6 +73,13 @@ type OperatorRun struct {
 	Status       State
 	StartTime    time.Time
 	EndTime      *time.Time
+
+	// RunType and TriggeredBy record why this attempt ran and who is answerable for it.
+	RunType     RunType
+	TriggeredBy string
+	// Attempt is Airflow's task instance try_number. It increases monotonically across both
+	// scheduler retries and manual clears, so it cannot on its own distinguish the two.
+	Attempt int
 }
 
 type AlertAttrs struct {

--- a/core/scheduler/run_attribution.go
+++ b/core/scheduler/run_attribution.go
@@ -38,6 +38,10 @@ const (
 	AttributionOptimusReplay = "optimus_replay"
 	// AttributionAuditRunID: an Airflow audit row matched on both dag_id and run_id. Exact.
 	AttributionAuditRunID = "airflow_audit_run_id"
+	// AttributionAuditDagID: an Airflow audit row named this DAG but not which run of it, so the
+	// correlation window is what ties it to this attempt. Weaker than a run_id match, far stronger
+	// than a dag-less bulk action.
+	AttributionAuditDagID = "airflow_audit_dag_id"
 	// AttributionAuditHeuristic: correlated only by time against audit rows that carry no
 	// dag_id or run_id, as produced by Airflow's bulk list-page clears. Low confidence.
 	AttributionAuditHeuristic = "airflow_audit_heuristic"

--- a/core/scheduler/run_attribution.go
+++ b/core/scheduler/run_attribution.go
@@ -1,0 +1,161 @@
+package scheduler
+
+import (
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/goto/optimus/core/tenant"
+)
+
+const (
+	EntityRunAttribution = "runAttribution"
+
+	// RunTypeScheduled is a run the Airflow scheduler started off the DAG's cron.
+	RunTypeScheduled RunType = "scheduled"
+	// RunTypeReplay is a run created or cleared by an Optimus replay request.
+	RunTypeReplay RunType = "replay"
+	// RunTypeBackfill is a run created by an Optimus custom backfill request.
+	RunTypeBackfill RunType = "backfill"
+	// RunTypeManual is a run triggered or cleared by a human directly in Airflow.
+	RunTypeManual RunType = "manual"
+
+	// TriggeredByScheduler is the trigger recorded for ordinary cron-driven runs.
+	TriggeredByScheduler = "scheduler"
+	// TriggeredByUnidentified is recorded when a run is known to be manual but the actor
+	// could not be established from the Airflow audit log.
+	TriggeredByUnidentified = "unidentified_user"
+
+	// SourceTypeReplay et al. identify which Optimus entity, if any, caused the run.
+	SourceTypeReplay   = "replay"
+	SourceTypeBackfill = "backfill"
+	SourceTypeManual   = "manual"
+
+	// AttributionOptimusBackfill: scheduler run id carried the backfill UUID. Exact.
+	AttributionOptimusBackfill = "optimus_backfill"
+	// AttributionOptimusReplay: scheduled_at fell inside a recent replay window. Exact.
+	AttributionOptimusReplay = "optimus_replay"
+	// AttributionAuditRunID: an Airflow audit row matched on both dag_id and run_id. Exact.
+	AttributionAuditRunID = "airflow_audit_run_id"
+	// AttributionAuditHeuristic: correlated only by time against audit rows that carry no
+	// dag_id or run_id, as produced by Airflow's bulk list-page clears. Low confidence.
+	AttributionAuditHeuristic = "airflow_audit_heuristic"
+	// AttributionInherited: copied from the previous attempt, which the scheduler retried.
+	AttributionInherited = "inherited"
+	// AttributionUnidentified: no usable signal, or several candidate actors.
+	AttributionUnidentified = "unidentified"
+	// AttributionPending: the resolver goroutine has not written a result. Terminal in
+	// practice, since nothing rescans these.
+	AttributionPending = "pending"
+
+	// dagRunIDPrefixManual is the prefix Airflow puts on run ids it generates for runs
+	// triggered outside the scheduler, e.g. from the UI's Trigger DAG button.
+	// DagRunType.generate_run_id formats as "<type>__<logical date>", so the separator is
+	// two underscores, not one.
+	dagRunIDPrefixManual = "manual__"
+)
+
+// RunType records what caused a task or hook run to execute.
+type RunType string
+
+func (r RunType) String() string { return string(r) }
+
+// RunAttribution is the outcome of deciding why an operator run is executing and who is
+// answerable for it.
+type RunAttribution struct {
+	RunType     RunType
+	TriggeredBy string
+	SourceType  string
+	Attribution string
+
+	ReplayID   *uuid.UUID
+	BackfillID *uuid.UUID
+
+	AuditEvent   string
+	AuditEventID *int64
+	AuditExtra   string
+}
+
+// ScheduledAttribution is the default for a run the scheduler started on its own. No
+// operator_run_trigger_source row is written for these.
+func ScheduledAttribution() RunAttribution {
+	return RunAttribution{
+		RunType:     RunTypeScheduled,
+		TriggeredBy: TriggeredByScheduler,
+	}
+}
+
+// IsScheduled reports whether this attribution needs no link row.
+func (r RunAttribution) IsScheduled() bool { return r.RunType == RunTypeScheduled }
+
+// NeedsAuditResolution reports whether the actor still has to be looked up in Airflow's
+// audit log.
+func (r RunAttribution) NeedsAuditResolution() bool { return r.Attribution == AttributionPending }
+
+// IsManualDagRunID reports whether the Airflow dag run id was generated for a run started
+// outside the scheduler, which in practice means somebody used the Trigger DAG button.
+// Optimus's own replay and backfill run ids use their own prefixes and are matched first,
+// so they do not reach this check.
+func IsManualDagRunID(schedulerRunID string) bool {
+	return strings.HasPrefix(schedulerRunID, dagRunIDPrefixManual)
+}
+
+// TriggerSource is a persisted link from an operator run to the cause of that run.
+type TriggerSource struct {
+	ID uuid.UUID
+
+	OperatorRunID  uuid.UUID
+	OperatorType   OperatorType
+	JobRunID       uuid.UUID
+	SchedulerRunID string
+
+	Attribution RunAttribution
+
+	ResolveAttempts int
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// AuditEvent is one row of Airflow's event log, i.e. its record of a user action.
+//
+// dag_id, task_id and run_id are populated by Airflow only when the originating HTTP
+// request carried them as query or form parameters, so they are absent for bulk actions
+// taken from the /dagrun/list/ and /taskinstance/list/ pages and for REST calls that pass
+// their arguments in a JSON body.
+type AuditEvent struct {
+	EventLogID    int64
+	When          time.Time
+	Event         string
+	Owner         string
+	DagID         string
+	TaskID        string
+	RunID         string
+	ExecutionDate *time.Time
+	Extra         string
+}
+
+// HasDagContext reports whether this audit row can be tied to a specific DAG, which
+// decides whether it is usable for exact matching or only for temporal correlation.
+func (a *AuditEvent) HasDagContext() bool { return a.DagID != "" }
+
+// AuditEventFilter is a query against Airflow's event log.
+//
+// Empty string and zero time fields are omitted from the request. IncludedEvents and
+// ExcludedEvents require Airflow 2.9.0 or later.
+type AuditEventFilter struct {
+	Tenant tenant.Tenant
+
+	DagID  string
+	RunID  string
+	TaskID string
+
+	After  time.Time
+	Before time.Time
+
+	IncludedEvents []string
+	ExcludedEvents []string
+
+	Limit int
+}

--- a/core/scheduler/service/deployment_service_test.go
+++ b/core/scheduler/service/deployment_service_test.go
@@ -84,7 +84,7 @@ func TestDeploymentService(t *testing.T) {
 			defer jobRepo.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger,
-				jobRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+				jobRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 			err := runService.UploadToScheduler(ctx, proj1Name)
 			assert.NotNil(t, err)
@@ -100,7 +100,7 @@ func TestDeploymentService(t *testing.T) {
 			defer priorityResolver.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger,
-				jobRepo, nil, nil, nil, nil, nil, priorityResolver, nil, nil, nil, feats, nil, nil)
+				jobRepo, nil, nil, nil, nil, nil, priorityResolver, nil, nil, nil, feats, nil, nil, nil)
 
 			err := runService.UploadToScheduler(ctx, proj1Name)
 			assert.NotNil(t, err)
@@ -121,7 +121,7 @@ func TestDeploymentService(t *testing.T) {
 			defer mScheduler.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil,
-				mScheduler, priorityResolver, nil, nil, nil, feats, nil, nil)
+				mScheduler, priorityResolver, nil, nil, nil, feats, nil, nil, nil)
 
 			err := runService.UploadToScheduler(ctx, proj1Name)
 			assert.NotNil(t, err)
@@ -149,7 +149,7 @@ func TestDeploymentService(t *testing.T) {
 			defer mScheduler.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil,
-				mScheduler, priorityResolver, nil, nil, nil, feats, nil, nil)
+				mScheduler, priorityResolver, nil, nil, nil, feats, nil, nil, nil)
 
 			err := runService.UploadToScheduler(ctx, proj1Name)
 			assert.Nil(t, err)
@@ -174,7 +174,7 @@ func TestDeploymentService(t *testing.T) {
 			defer mScheduler.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil,
-				mScheduler, priorityResolver, nil, nil, nil, feats, nil, nil)
+				mScheduler, priorityResolver, nil, nil, nil, feats, nil, nil, nil)
 
 			err := runService.UploadToScheduler(ctx, proj1Name)
 			assert.NotNil(t, err)
@@ -198,7 +198,7 @@ func TestDeploymentService(t *testing.T) {
 			defer mScheduler.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil,
-				mScheduler, priorityResolver, nil, nil, nil, feats, nil, nil)
+				mScheduler, priorityResolver, nil, nil, nil, feats, nil, nil, nil)
 
 			err := runService.UploadJobs(ctx, tnnt1, jobNamesToUpload, jobNamesToDelete)
 			assert.Error(t, err)
@@ -220,7 +220,7 @@ func TestDeploymentService(t *testing.T) {
 			defer mScheduler.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil,
-				mScheduler, priorityResolver, nil, nil, nil, feats, nil, nil)
+				mScheduler, priorityResolver, nil, nil, nil, feats, nil, nil, nil)
 
 			err := runService.UploadJobs(ctx, tnnt1, jobNamesToUpload, jobNamesToDelete)
 			assert.Error(t, err)
@@ -243,7 +243,7 @@ func TestDeploymentService(t *testing.T) {
 			defer mScheduler.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil,
-				mScheduler, priorityResolver, nil, nil, nil, feats, nil, nil)
+				mScheduler, priorityResolver, nil, nil, nil, feats, nil, nil, nil)
 
 			err := runService.UploadJobs(ctx, tnnt1, jobNamesToUpload, jobNamesToDelete)
 			assert.Error(t, err)
@@ -257,7 +257,7 @@ func TestDeploymentService(t *testing.T) {
 			defer mScheduler.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger, nil, nil, nil, nil, nil,
-				mScheduler, nil, nil, nil, nil, feats, nil, nil)
+				mScheduler, nil, nil, nil, nil, feats, nil, nil, nil)
 
 			err := runService.UploadJobs(ctx, tnnt1, jobNamesToUpload, jobNamesToDelete)
 			assert.Error(t, err)
@@ -281,7 +281,7 @@ func TestDeploymentService(t *testing.T) {
 			defer mScheduler.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil,
-				mScheduler, priorityResolver, nil, nil, nil, feats, nil, nil)
+				mScheduler, priorityResolver, nil, nil, nil, feats, nil, nil, nil)
 
 			err := runService.UploadJobs(ctx, tnnt1, jobNamesToUpload, jobNamesToDelete)
 			assert.Nil(t, err)
@@ -304,7 +304,7 @@ func TestDeploymentService(t *testing.T) {
 			defer mScheduler.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil,
-				mScheduler, priorityResolver, nil, nil, nil, feats, nil, nil)
+				mScheduler, priorityResolver, nil, nil, nil, feats, nil, nil, nil)
 
 			err := runService.UploadJobs(ctx, tnnt1, jobNamesToUpload, jobNamesToDelete)
 			assert.Nil(t, err)
@@ -318,7 +318,7 @@ func TestDeploymentService(t *testing.T) {
 			defer mScheduler.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger, nil, nil, nil, nil, nil,
-				mScheduler, nil, nil, nil, nil, feats, nil, nil)
+				mScheduler, nil, nil, nil, nil, feats, nil, nil, nil)
 
 			err := runService.UploadJobs(ctx, tnnt1, jobNamesToUpload, jobNamesToDelete)
 			assert.Nil(t, err)
@@ -342,7 +342,7 @@ func TestDeploymentService(t *testing.T) {
 			defer mScheduler.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil,
-				mScheduler, priorityResolver, nil, nil, nil, feats, nil, nil)
+				mScheduler, priorityResolver, nil, nil, nil, feats, nil, nil, nil)
 
 			err := runService.UploadJobs(ctx, tnnt1, jobNamesToUpload, jobNamesToDelete)
 			assert.ErrorContains(t, err, upstreamErr)

--- a/core/scheduler/service/export_run_attribution_test.go
+++ b/core/scheduler/service/export_run_attribution_test.go
@@ -1,0 +1,16 @@
+// The standard Go export_test pattern: this file is part of package service, not service_test,
+// because the hook below has to reach a private field. Nothing here ships in the binary.
+//
+//nolint:testpackage // must be in-package to set the unexported resolved field
+package service
+
+import "sync"
+
+// WaitGroupForTest makes the detached resolver joinable so tests can assert on its outcome
+// without sleeping. Only compiled into the test binary; production code never sets this, and
+// the resolver skips the bookkeeping when it is nil.
+func (s *RunAttributionService) WaitGroupForTest() *sync.WaitGroup {
+	wg := &sync.WaitGroup{}
+	s.resolved = wg
+	return wg
+}

--- a/core/scheduler/service/job_run_service.go
+++ b/core/scheduler/service/job_run_service.go
@@ -1181,7 +1181,7 @@ func (*JobRunService) attributionInputFrom(event *scheduler.Event, operatorType 
 // classifyRun decides why a run is executing. Attribution is best effort by nature, so a
 // failure to classify degrades to 'scheduled' rather than rejecting the event.
 func (s *JobRunService) classifyRun(ctx context.Context, in AttributionInput) scheduler.RunAttribution {
-	if s.runAttributionService == nil {
+	if s.runAttributionService == nil || in.OperatorType == scheduler.OperatorSensor {
 		return scheduler.ScheduledAttribution()
 	}
 	return s.runAttributionService.Classify(ctx, in)
@@ -1293,9 +1293,6 @@ func (s *JobRunService) UpdateJobState(ctx context.Context, event *scheduler.Eve
 	case scheduler.JobSuccessEvent, scheduler.JobFailureEvent:
 		return s.updateJobRun(ctx, event)
 	case scheduler.SensorStartEvent:
-		// Sensors are not attributed: they are upstream waits, and a sensor start is frequent
-		// enough that the extra lookup is not worth what it would tell us. Their columns exist
-		// only so all three operator tables keep one shared schema and one shared query builder.
 		return s.createOperatorRun(ctx, event, scheduler.OperatorSensor, nil)
 	case scheduler.SensorSuccessEvent, scheduler.SensorRetryEvent, scheduler.SensorFailEvent:
 		return s.updateOperatorRun(ctx, event, scheduler.OperatorSensor)

--- a/core/scheduler/service/job_run_service.go
+++ b/core/scheduler/service/job_run_service.go
@@ -78,6 +78,7 @@ type JobRunRepository interface {
 	UpdateState(ctx context.Context, jobRunID uuid.UUID, jobRunStatus scheduler.State) error
 	UpdateSLA(ctx context.Context, jobName scheduler.JobName, project tenant.ProjectName, scheduledTimes []time.Time) error
 	UpdateMonitoring(ctx context.Context, jobRunID uuid.UUID, monitoring map[string]any) error
+	UpdateSchedulerRunID(ctx context.Context, jobRunID uuid.UUID, schedulerRunID string) error
 	GetRunSummaryByIdentifiers(ctx context.Context, identifiers []scheduler.JobRunIdentifier) ([]*scheduler.JobRunSummary, error)
 }
 
@@ -88,7 +89,7 @@ type JobReplayRepository interface {
 
 type OperatorRunRepository interface {
 	GetOperatorRun(ctx context.Context, operatorName string, operator scheduler.OperatorType, jobRunID uuid.UUID) (*scheduler.OperatorRun, error)
-	CreateOperatorRun(ctx context.Context, operatorName string, operator scheduler.OperatorType, jobRunID uuid.UUID, startTime time.Time) error
+	CreateOperatorRun(ctx context.Context, operatorName string, operator scheduler.OperatorType, jobRunID uuid.UUID, startTime time.Time, attribution scheduler.RunAttribution, attempt int) (uuid.UUID, error)
 	UpdateOperatorRun(ctx context.Context, operator scheduler.OperatorType, jobRunID uuid.UUID, eventTime time.Time, state scheduler.State) error
 }
 
@@ -141,6 +142,14 @@ type JobRunService struct {
 	features         config.FeaturesConfig
 
 	durationEstimatorService DurationEstimator
+	// runAttributionService may be nil, in which case every run is recorded as scheduled.
+	runAttributionService RunAttributor
+}
+
+// RunAttributor decides why an operator run is executing and records the answer.
+type RunAttributor interface {
+	Classify(ctx context.Context, in AttributionInput) scheduler.RunAttribution
+	Record(ctx context.Context, in AttributionInput, operatorRunID uuid.UUID, attribution scheduler.RunAttribution) error
 }
 
 var DagRunIDRegex = regexp.MustCompile(`(.*?)(_(.+))?__(.+)`)
@@ -850,6 +859,8 @@ func (s *JobRunService) updateJobRun(ctx context.Context, event *scheduler.Event
 		s.l.Error("error updating job run with id [%s]: %s", jobRun.ID, err)
 		return err
 	}
+	// Also recorded here so that jobs whose only events are dag level still get a dag run id.
+	s.syncSchedulerRunID(ctx, jobRun, event)
 	jobRun.State = event.Status
 	s.raiseJobRunStateChangeEvent(jobRun)
 	monitoringValues := s.getMonitoringValues(event)
@@ -1075,7 +1086,7 @@ func (s *JobRunService) getExistingOperatorRun(ctx context.Context, event *sched
 	return existingOperatorRun, nil
 }
 
-func (s *JobRunService) createOperatorRun(ctx context.Context, event *scheduler.Event, operatorType scheduler.OperatorType) error {
+func (s *JobRunService) createOperatorRun(ctx context.Context, event *scheduler.Event, operatorType scheduler.OperatorType, previousRun *scheduler.OperatorRun) error {
 	jobRun, err := s.getJobRunByScheduledAt(ctx, event.Tenant, event.JobName, event.JobScheduledAt)
 	if err != nil {
 		s.l.Error("error getting job run by scheduled time [%s]: %s", event.JobScheduledAt, err)
@@ -1096,13 +1107,93 @@ func (s *JobRunService) createOperatorRun(ctx context.Context, event *scheduler.
 		s.raiseJobRunStateChangeEvent(jobRun)
 	}
 
-	err = s.operatorRunRepo.CreateOperatorRun(ctx, event.OperatorName, operatorType, jobRun.ID, event.EventTime)
+	s.syncSchedulerRunID(ctx, jobRun, event)
+
+	attributionInput := s.attributionInputFrom(event, operatorType, jobRun, previousRun)
+	attribution := s.classifyRun(ctx, attributionInput)
+
+	operatorRunID, err := s.operatorRunRepo.CreateOperatorRun(ctx, event.OperatorName, operatorType, jobRun.ID,
+		event.EventTime, attribution, attributionInput.Attempt)
 	if err != nil {
 		s.l.Error("error registering operator run job [%s], type [%s], operator [%s] : %s", event.JobName, operatorType, event.OperatorName, err)
 		return err
 	}
 
-	return err
+	s.recordRunAttribution(ctx, attributionInput, operatorRunID, attribution)
+
+	return nil
+}
+
+// syncSchedulerRunID keeps job_run.scheduler_run_id in step with Airflow's dag run id.
+//
+// It is written here rather than at Create time because job_run rows are created lazily and
+// keyed on (project, job, scheduled_at), so a row can outlive a dag run that is deleted and
+// recreated. Only writes when the value actually changed, and never fails the event: losing
+// the dag run id costs some attribution precision, not the run record itself.
+func (s *JobRunService) syncSchedulerRunID(ctx context.Context, jobRun *scheduler.JobRun, event *scheduler.Event) {
+	schedulerRunID := schedulerRunIDFrom(event)
+	if schedulerRunID == "" || jobRun.SchedulerRunID == schedulerRunID {
+		return
+	}
+	if err := s.repo.UpdateSchedulerRunID(ctx, jobRun.ID, schedulerRunID); err != nil {
+		s.l.Error("error recording scheduler run id [%s] on job run [%s]: %s", schedulerRunID, jobRun.ID, err)
+		return
+	}
+	jobRun.SchedulerRunID = schedulerRunID
+}
+
+// schedulerRunIDFrom reads Airflow's dag run id out of the event payload. Absent on SLA miss
+// and on any hand-crafted event that omits the event context.
+func schedulerRunIDFrom(event *scheduler.Event) string {
+	if event.EventContext == nil {
+		return ""
+	}
+	return event.EventContext.DagRun.RunID
+}
+
+// attemptFrom reads Airflow's task instance try_number. It rises across both scheduler retries
+// and manual clears, so it records which attempt this is without saying who caused it.
+func attemptFrom(event *scheduler.Event) int {
+	if event.EventContext == nil {
+		return 1
+	}
+	if attempt := event.EventContext.OperatorRunInstance.TryNumber; attempt > 0 {
+		return attempt
+	}
+	return 1
+}
+
+func (*JobRunService) attributionInputFrom(event *scheduler.Event, operatorType scheduler.OperatorType, jobRun *scheduler.JobRun, previousRun *scheduler.OperatorRun) AttributionInput {
+	return AttributionInput{
+		Tenant:         event.Tenant,
+		JobName:        event.JobName,
+		OperatorName:   event.OperatorName,
+		OperatorType:   operatorType,
+		JobRunID:       jobRun.ID,
+		ScheduledAt:    event.JobScheduledAt,
+		SchedulerRunID: schedulerRunIDFrom(event),
+		Attempt:        attemptFrom(event),
+		StartTime:      event.EventTime,
+		PreviousRun:    previousRun,
+	}
+}
+
+// classifyRun decides why a run is executing. Attribution is best effort by nature, so a
+// failure to classify degrades to 'scheduled' rather than rejecting the event.
+func (s *JobRunService) classifyRun(ctx context.Context, in AttributionInput) scheduler.RunAttribution {
+	if s.runAttributionService == nil {
+		return scheduler.ScheduledAttribution()
+	}
+	return s.runAttributionService.Classify(ctx, in)
+}
+
+func (s *JobRunService) recordRunAttribution(ctx context.Context, in AttributionInput, operatorRunID uuid.UUID, attribution scheduler.RunAttribution) {
+	if s.runAttributionService == nil || attribution.IsScheduled() {
+		return
+	}
+	if err := s.runAttributionService.Record(ctx, in, operatorRunID, attribution); err != nil {
+		s.l.Error("error recording trigger source for operator run [%s]: %s", operatorRunID, err)
+	}
 }
 
 func (s *JobRunService) getOperatorRun(ctx context.Context, event *scheduler.Event, operatorType scheduler.OperatorType, jobRunID uuid.UUID) (*scheduler.OperatorRun, error) {
@@ -1116,7 +1207,9 @@ func (s *JobRunService) getOperatorRun(ctx context.Context, event *scheduler.Eve
 		s.l.Warn("operator is not found, creating it")
 
 		// TODO: consider moving below call outside as the caller is a 'getter'
-		err = s.createOperatorRun(ctx, event, operatorType)
+		// No previous run to inherit from: this path is reached when a terminal event arrives
+		// for an operator whose start event Optimus never saw.
+		err = s.createOperatorRun(ctx, event, operatorType, nil)
 		if err != nil {
 			s.l.Error("error creating operator run: %s", err)
 			return nil, err
@@ -1200,16 +1293,20 @@ func (s *JobRunService) UpdateJobState(ctx context.Context, event *scheduler.Eve
 	case scheduler.JobSuccessEvent, scheduler.JobFailureEvent:
 		return s.updateJobRun(ctx, event)
 	case scheduler.SensorStartEvent:
-		return s.createOperatorRun(ctx, event, scheduler.OperatorSensor)
+		// Sensors are not attributed: they are upstream waits, and a sensor start is frequent
+		// enough that the extra lookup is not worth what it would tell us. Their columns exist
+		// only so all three operator tables keep one shared schema and one shared query builder.
+		return s.createOperatorRun(ctx, event, scheduler.OperatorSensor, nil)
 	case scheduler.SensorSuccessEvent, scheduler.SensorRetryEvent, scheduler.SensorFailEvent:
 		return s.updateOperatorRun(ctx, event, scheduler.OperatorSensor)
 	case scheduler.TaskStartEvent, scheduler.HookStartEvent:
-
+		// Read the previous attempt before inserting this one. Its status is what distinguishes
+		// a scheduler retry from a run somebody cleared by hand in Airflow.
 		existingOperatorRun, err := s.getExistingOperatorRun(ctx, event)
 		if err != nil {
 			return err
 		}
-		err = s.createOperatorRun(ctx, event, event.EventContext.OperatorType)
+		err = s.createOperatorRun(ctx, event, event.EventContext.OperatorType, existingOperatorRun)
 		if err != nil {
 			return err
 		}
@@ -1273,6 +1370,7 @@ func NewJobRunService(logger log.Logger, jobRepo JobRepository, jobRunRepo JobRu
 	operatorRunRepo OperatorRunRepository, slaRepo SLARepository, scheduler Scheduler, resolver PriorityResolver,
 	compiler JobInputCompiler, eventHandler EventHandler, projectGetter ProjectGetter, features config.FeaturesConfig,
 	durationEstimatorService DurationEstimator, backfillRepo BackfillRepository,
+	runAttributionService RunAttributor,
 ) *JobRunService {
 	return &JobRunService{
 		l:                        logger,
@@ -1289,6 +1387,7 @@ func NewJobRunService(logger log.Logger, jobRepo JobRepository, jobRunRepo JobRu
 		features:                 features,
 		durationEstimatorService: durationEstimatorService,
 		backfillRepo:             backfillRepo,
+		runAttributionService:    runAttributionService,
 	}
 }
 

--- a/core/scheduler/service/job_run_service_test.go
+++ b/core/scheduler/service/job_run_service_test.go
@@ -68,7 +68,7 @@ func TestJobRunService(t *testing.T) {
 	t.Run("UpdateJobState", func(t *testing.T) {
 		t.Run("should reject unregistered events", func(t *testing.T) {
 			runService := service.NewJobRunService(logger,
-				nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+				nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 			event := &scheduler.Event{
 				JobName: jobName,
@@ -99,7 +99,7 @@ func TestJobRunService(t *testing.T) {
 				defer jobRepo.AssertExpectations(t)
 
 				runService := service.NewJobRunService(logger,
-					jobRepo, jobRunRepository, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+					jobRepo, jobRunRepository, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 				event := &scheduler.Event{
 					JobName:        jobName,
@@ -148,7 +148,7 @@ func TestJobRunService(t *testing.T) {
 				defer jobRunRepository.AssertExpectations(t)
 
 				runService := service.NewJobRunService(logger,
-					jobRepo, jobRunRepository, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+					jobRepo, jobRunRepository, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 				event := &scheduler.Event{
 					JobName:        jobName,
@@ -240,7 +240,7 @@ func TestJobRunService(t *testing.T) {
 				defer eventHandler.AssertExpectations(t)
 
 				runService := service.NewJobRunService(logger,
-					jobRepo, jobRunRepo, nil, operatorRunRepo, nil, nil, nil, nil, eventHandler, projectGetter, feats, nil, nil)
+					jobRepo, jobRunRepo, nil, operatorRunRepo, nil, nil, nil, nil, eventHandler, projectGetter, feats, nil, nil, nil)
 
 				err = runService.UpdateJobState(ctx, event)
 				assert.Nil(t, err)
@@ -283,7 +283,7 @@ func TestJobRunService(t *testing.T) {
 				defer eventHandler.AssertExpectations(t)
 
 				runService := service.NewJobRunService(logger,
-					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, eventHandler, nil, feats, nil, nil)
+					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, eventHandler, nil, feats, nil, nil, nil)
 
 				err := runService.UpdateJobState(ctx, event)
 				assert.Nil(t, err)
@@ -344,7 +344,7 @@ func TestJobRunService(t *testing.T) {
 					defer jobRunRepo.AssertExpectations(t)
 
 					runService := service.NewJobRunService(logger,
-						nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+						nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 					err := runService.UpdateJobState(ctx, event)
 					assert.NotNil(t, err)
@@ -365,7 +365,7 @@ func TestJobRunService(t *testing.T) {
 					projectGetter.On("Get", ctx, projName).Return(project, nil)
 
 					runService := service.NewJobRunService(logger,
-						jobRepo, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, projectGetter, feats, nil, nil)
+						jobRepo, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, projectGetter, feats, nil, nil, nil)
 
 					err := runService.UpdateJobState(ctx, event)
 					assert.NotNil(t, err)
@@ -386,7 +386,7 @@ func TestJobRunService(t *testing.T) {
 					defer jobRepo.AssertExpectations(t)
 
 					runService := service.NewJobRunService(logger,
-						jobRepo, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, projectGetter, feats, nil, nil)
+						jobRepo, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, projectGetter, feats, nil, nil, nil)
 
 					err := runService.UpdateJobState(ctx, event)
 					assert.NotNil(t, err)
@@ -414,7 +414,7 @@ func TestJobRunService(t *testing.T) {
 					defer jobRepo.AssertExpectations(t)
 
 					runService := service.NewJobRunService(logger,
-						jobRepo, jobRunRepo, nil, nil, nil, nil, nil, nil, eventHandler, projectGetter, feats, nil, nil)
+						jobRepo, jobRunRepo, nil, nil, nil, nil, nil, nil, eventHandler, projectGetter, feats, nil, nil, nil)
 
 					err := runService.UpdateJobState(ctx, event)
 					assert.Nil(t, err)
@@ -444,7 +444,7 @@ func TestJobRunService(t *testing.T) {
 				defer jobRunRepo.AssertExpectations(t)
 
 				runService := service.NewJobRunService(logger,
-					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 				err := runService.UpdateJobState(ctx, event)
 				assert.NotNil(t, err)
@@ -471,7 +471,7 @@ func TestJobRunService(t *testing.T) {
 				defer jobRunRepo.AssertExpectations(t)
 
 				runService := service.NewJobRunService(logger,
-					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 				err := runService.UpdateJobState(ctx, event)
 				assert.NotNil(t, err)
@@ -498,7 +498,7 @@ func TestJobRunService(t *testing.T) {
 				defer jobRunRepo.AssertExpectations(t)
 
 				runService := service.NewJobRunService(logger,
-					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 				err := runService.UpdateJobState(ctx, event)
 				assert.NotNil(t, err)
@@ -560,7 +560,7 @@ func TestJobRunService(t *testing.T) {
 						Return(&job, nil)
 
 					runService := service.NewJobRunService(logger,
-						jobRepo, jobRunRepo, nil, operatorRunRepository, nil, nil, nil, nil, eventHandler, nil, feats, nil, nil)
+						jobRepo, jobRunRepo, nil, operatorRunRepository, nil, nil, nil, nil, eventHandler, nil, feats, nil, nil, nil)
 
 					err := runService.UpdateJobState(ctx, event)
 					assert.Nil(t, err)
@@ -619,7 +619,7 @@ func TestJobRunService(t *testing.T) {
 					defer eventHandler.AssertExpectations(t)
 
 					runService := service.NewJobRunService(logger,
-						nil, jobRunRepo, nil, operatorRunRepository, nil, nil, nil, nil, eventHandler, nil, feats, nil, nil)
+						nil, jobRunRepo, nil, operatorRunRepository, nil, nil, nil, nil, eventHandler, nil, feats, nil, nil, nil)
 
 					err := runService.UpdateJobState(ctx, event)
 					assert.NotNil(t, err)
@@ -649,7 +649,7 @@ func TestJobRunService(t *testing.T) {
 					defer eventHandler.AssertExpectations(t)
 
 					runService := service.NewJobRunService(logger,
-						nil, jobRunRepo, nil, operatorRunRepository, nil, nil, nil, nil, eventHandler, nil, feats, nil, nil)
+						nil, jobRunRepo, nil, operatorRunRepository, nil, nil, nil, nil, eventHandler, nil, feats, nil, nil, nil)
 
 					err := runService.UpdateJobState(ctx, event)
 					assert.NotNil(t, err)
@@ -684,7 +684,7 @@ func TestJobRunService(t *testing.T) {
 					defer slaRepo.AssertExpectations(t)
 
 					runService := service.NewJobRunService(logger,
-						nil, jobRunRepo, nil, operatorRunRepository, slaRepo, nil, nil, nil, nil, nil, feats, nil, nil)
+						nil, jobRunRepo, nil, operatorRunRepository, slaRepo, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 					err := runService.UpdateJobState(ctx, event)
 					assert.Nil(t, err)
@@ -714,7 +714,7 @@ func TestJobRunService(t *testing.T) {
 				defer jobRunRepo.AssertExpectations(t)
 
 				runService := service.NewJobRunService(logger,
-					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 				err := runService.UpdateJobState(ctx, event)
 				assert.NotNil(t, err)
@@ -755,7 +755,7 @@ func TestJobRunService(t *testing.T) {
 				// operatorRunRepository.On("UpdateOperatorRun", ctx, scheduler.OperatorSensor, operatorRun.ID, eventTime, "success").Return(nil)
 				defer operatorRunRepository.AssertExpectations(t)
 				runService := service.NewJobRunService(logger,
-					nil, jobRunRepo, nil, operatorRunRepository, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+					nil, jobRunRepo, nil, operatorRunRepository, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 				err := runService.UpdateJobState(ctx, event)
 				assert.NotNil(t, err)
@@ -822,7 +822,7 @@ func TestJobRunService(t *testing.T) {
 				defer jobRunRepo.AssertExpectations(t)
 
 				runService := service.NewJobRunService(logger,
-					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 				err := runService.UpdateJobState(ctx, event)
 				assert.Nil(t, err)
@@ -845,7 +845,7 @@ func TestJobRunService(t *testing.T) {
 			defer jobRepo.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger,
-				jobRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+				jobRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 			executorInput, err := runService.JobRunInput(ctx, projName, jobName, scheduler.RunConfig{})
 			assert.Nil(t, executorInput)
 			assert.NotNil(t, err)
@@ -905,7 +905,7 @@ func TestJobRunService(t *testing.T) {
 			defer jobInputCompiler.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger,
-				jobRepo, jobRunRepo, jobReplayRepo, nil, nil, nil, nil, jobInputCompiler, nil, nil, feats, nil, nil)
+				jobRepo, jobRunRepo, jobReplayRepo, nil, nil, nil, nil, jobInputCompiler, nil, nil, feats, nil, nil, nil)
 			executorInput, err := runService.JobRunInput(ctx, projName, jobName, runConfig)
 
 			assert.Equal(t, &dummyExecutorInput, executorInput)
@@ -967,7 +967,7 @@ func TestJobRunService(t *testing.T) {
 			defer jobInputCompiler.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger,
-				jobRepo, jobRunRepo, jobReplayRepo, nil, nil, nil, nil, jobInputCompiler, nil, nil, feats, nil, nil)
+				jobRepo, jobRunRepo, jobReplayRepo, nil, nil, nil, nil, jobInputCompiler, nil, nil, feats, nil, nil, nil)
 			executorInput, err := runService.JobRunInput(ctx, projName, jobName, runConfig)
 
 			assert.Equal(t, &dummyExecutorInput, executorInput)
@@ -1022,7 +1022,7 @@ func TestJobRunService(t *testing.T) {
 			defer jobInputCompiler.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger,
-				jobRepo, jobRunRepo, jobReplayRepo, nil, nil, nil, nil, jobInputCompiler, nil, nil, feats, nil, nil)
+				jobRepo, jobRunRepo, jobReplayRepo, nil, nil, nil, nil, jobInputCompiler, nil, nil, feats, nil, nil, nil)
 			executorInput, err := runService.JobRunInput(ctx, projName, jobName, runConfig)
 
 			assert.Equal(t, &dummyExecutorInput, executorInput)
@@ -1076,7 +1076,7 @@ func TestJobRunService(t *testing.T) {
 			defer jobInputCompiler.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger,
-				jobRepo, jobRunRepo, jobReplayRepo, nil, nil, nil, nil, jobInputCompiler, nil, nil, feats, nil, nil)
+				jobRepo, jobRunRepo, jobReplayRepo, nil, nil, nil, nil, jobInputCompiler, nil, nil, feats, nil, nil, nil)
 			executorInput, err := runService.JobRunInput(ctx, projName, jobName, runConfig)
 
 			assert.Nil(t, err)
@@ -1111,7 +1111,7 @@ func TestJobRunService(t *testing.T) {
 			defer jobRepo.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger,
-				jobRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+				jobRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 			returnedRuns, _, err := runService.GetJobRuns(ctx, projName, jobName, criteria)
 			assert.Error(t, err)
 			assert.ErrorContains(t, err, "unable to get job details for jobName: sample_select, project:proj")
@@ -1158,7 +1158,7 @@ func TestJobRunService(t *testing.T) {
 			defer jobRunRepo.AssertExpectations(t)
 
 			runService := service.NewJobRunService(logger,
-				jobRepo, jobRunRepo, nil, nil, nil, sch, nil, nil, nil, projectGetter, feats, nil, nil)
+				jobRepo, jobRunRepo, nil, nil, nil, sch, nil, nil, nil, projectGetter, feats, nil, nil, nil)
 			var err error
 			var returnedRuns []*scheduler.JobRunStatus
 			returnedRuns, _, err = runService.GetJobRuns(ctx, projName, jobName, criteria)
@@ -1306,7 +1306,7 @@ func TestJobRunService(t *testing.T) {
 					defer jobRunRepo.AssertExpectations(t)
 
 					runService := service.NewJobRunService(logger,
-						jobRepo, jobRunRepo, nil, nil, nil, sch, nil, nil, nil, projectGetter, feats, nil, nil)
+						jobRepo, jobRunRepo, nil, nil, nil, sch, nil, nil, nil, projectGetter, feats, nil, nil, nil)
 					returnedRuns, _, err := runService.GetJobRuns(ctx, projName, jobName, scenario.input)
 					assert.Nil(t, err)
 					assert.Equal(t, scenario.expectedResult, returnedRuns)
@@ -1387,7 +1387,7 @@ func TestJobRunService(t *testing.T) {
 			sch.On("GetJobRuns", ctx, tnnt, criteria, jobCron).Return(runs, nil)
 			defer sch.AssertExpectations(t)
 
-			runService := service.NewJobRunService(logger, jobRepo, jobRunRepo, nil, nil, nil, sch, nil, nil, nil, projectGetter, feats, nil, nil)
+			runService := service.NewJobRunService(logger, jobRepo, jobRunRepo, nil, nil, nil, sch, nil, nil, nil, projectGetter, feats, nil, nil, nil)
 			returnedRuns, _, err := runService.GetJobRuns(ctx, projName, jobName, jobQuery)
 			assert.Nil(t, err)
 			assert.Equal(t, 2, len(returnedRuns))
@@ -1421,7 +1421,7 @@ func TestJobRunService(t *testing.T) {
 			jobRepo.On("GetJobDetails", ctx, projName, jobName).Return(&jobWithDetails, nil)
 			defer jobRepo.AssertExpectations(t)
 
-			runService := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+			runService := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 			returnedRuns, _, err := runService.GetJobRuns(ctx, projName, jobName, jobQuery)
 			assert.Error(t, err)
 			assert.ErrorContains(t, err, "unable to parse job cron interval: expected exactly 5 fields, found 2: [invalid interval]")
@@ -1455,7 +1455,7 @@ func TestJobRunService(t *testing.T) {
 			jobRepo.On("GetJobDetails", ctx, projName, jobName).Return(&jobWithDetails, nil)
 			defer jobRepo.AssertExpectations(t)
 
-			runService := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+			runService := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 			returnedRuns, _, err := runService.GetJobRuns(ctx, projName, jobName, jobQuery)
 			assert.Error(t, err)
 			assert.ErrorContains(t, err, "cannot get job runs, job interval is empty")
@@ -1491,7 +1491,7 @@ func TestJobRunService(t *testing.T) {
 			jobRepo := new(JobRepository)
 			jobRepo.On("GetJobDetails", ctx, projName, jobName).Return(&jobWithDetails, nil)
 			defer jobRepo.AssertExpectations(t)
-			runService := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil, nil, nil, nil, nil, projectGetter, feats, nil, nil)
+			runService := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil, nil, nil, nil, nil, projectGetter, feats, nil, nil, nil)
 			returnedRuns, _, err := runService.GetJobRuns(ctx, projName, jobName, jobQuery)
 			assert.Error(t, err)
 			assert.ErrorContains(t, err, "job schedule startDate not found in job")
@@ -1544,7 +1544,7 @@ func TestJobRunService(t *testing.T) {
 			jobRepo.On("GetJobDetails", ctx, projName, jobName).Return(&jobWithDetails, nil)
 			defer jobRepo.AssertExpectations(t)
 
-			runService := service.NewJobRunService(logger, jobRepo, jobRunRepo, nil, nil, nil, sch, nil, nil, nil, nil, feats, nil, nil)
+			runService := service.NewJobRunService(logger, jobRepo, jobRunRepo, nil, nil, nil, sch, nil, nil, nil, nil, feats, nil, nil, nil)
 			returnedRuns, _, err := runService.GetJobRuns(ctx, projName, jobName, criteria)
 			assert.Nil(t, err)
 			assert.Equal(t, runs, returnedRuns)
@@ -1764,7 +1764,7 @@ func TestJobRunService(t *testing.T) {
 					defer jobRunRepo.AssertExpectations(t)
 
 					runService := service.NewJobRunService(logger,
-						jobRepo, jobRunRepo, nil, nil, nil, sch, nil, nil, nil, projectGetter, features, nil, nil)
+						jobRepo, jobRunRepo, nil, nil, nil, sch, nil, nil, nil, projectGetter, features, nil, nil, nil)
 					returnedRuns, msg, err := runService.GetJobRuns(ctx, projName, jobName, jobQuery)
 					if scenario.expectedErr != nil {
 						assert.Equal(t, scenario.expectedErr, err)
@@ -1790,7 +1790,7 @@ func TestJobRunService(t *testing.T) {
 				defer jobRunRepo.AssertExpectations(t)
 
 				runService := service.NewJobRunService(logger,
-					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 				returnedRuns, count := runService.FilterRunsV3(ctx, tnnt, criteria)
 				assert.Equal(t, -1, count)
 				assert.Nil(t, returnedRuns)
@@ -1814,7 +1814,7 @@ func TestJobRunService(t *testing.T) {
 				defer jobRunRepo.AssertExpectations(t)
 
 				runService := service.NewJobRunService(logger,
-					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 				returnedRuns, count := runService.FilterRunsV3(ctx, tnnt, criteria)
 				assert.Equal(t, 1, count)
 				assert.Equal(t, 1, len(returnedRuns))
@@ -1838,7 +1838,7 @@ func TestJobRunService(t *testing.T) {
 				defer jobRunRepo.AssertExpectations(t)
 
 				runService := service.NewJobRunService(logger,
-					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 				returnedRuns, count := runService.FilterRunsV3(ctx, tnnt, criteria)
 				assert.Equal(t, 0, count)
 				assert.Equal(t, 1, len(returnedRuns))
@@ -1869,7 +1869,7 @@ func TestJobRunService(t *testing.T) {
 				defer jobRunRepo.AssertExpectations(t)
 
 				runService := service.NewJobRunService(logger,
-					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 				returnedRuns, count := runService.FilterRunsV3(ctx, tnnt, criteria)
 				assert.Equal(t, 1, count)
 				assert.Equal(t, 3, len(returnedRuns))
@@ -1916,7 +1916,7 @@ func TestJobRunService(t *testing.T) {
 				defer jobRunRepo.AssertExpectations(t)
 
 				runService := service.NewJobRunService(logger,
-					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 				returnedRuns, count := runService.FilterRunsV3(ctx, tnnt, criteria)
 				assert.Equal(t, 1, count)
 				assert.Equal(t, 5, len(returnedRuns))
@@ -1958,7 +1958,7 @@ func TestJobRunService(t *testing.T) {
 				defer jobRunRepo.AssertExpectations(t)
 
 				runService := service.NewJobRunService(logger,
-					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+					nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 				returnedRuns, count := runService.FilterRunsV3(ctx, tnnt, criteria)
 				assert.Equal(t, 24, count)
 				assert.Equal(t, 24, len(returnedRuns))
@@ -1975,7 +1975,7 @@ func TestJobRunService(t *testing.T) {
 
 			projectGetter.On("Get", ctx, projName).Return(nil, errors.NewError(errors.ErrInternalError, tenant.EntityProject, "unexpected error"))
 
-			service := service.NewJobRunService(logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, projectGetter, feats, nil, nil)
+			service := service.NewJobRunService(logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, projectGetter, feats, nil, nil, nil)
 
 			actualInterval, actualError := service.GetInterval(ctx, projName, jobName, referenceTime)
 
@@ -1994,7 +1994,7 @@ func TestJobRunService(t *testing.T) {
 
 			jobRepo.On("GetJobDetails", ctx, projName, jobName).Return(nil, errors.NewError(errors.ErrInternalError, job.EntityJob, "unexpected error"))
 
-			service := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil, nil, nil, nil, nil, projectGetter, feats, nil, nil)
+			service := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil, nil, nil, nil, nil, projectGetter, feats, nil, nil, nil)
 
 			actualInterval, actualError := service.GetInterval(ctx, projName, jobName, referenceTime)
 
@@ -2029,7 +2029,7 @@ func TestJobRunService(t *testing.T) {
 			}
 
 			jobRepo.On("GetJobDetails", ctx, projName, jobName).Return(job, nil)
-			service := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil, nil, nil, nil, nil, projectGetter, feats, nil, nil)
+			service := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil, nil, nil, nil, nil, projectGetter, feats, nil, nil, nil)
 
 			actualInterval, actualError := service.GetInterval(ctx, projName, jobName, referenceTime)
 
@@ -2062,7 +2062,7 @@ func TestJobRunService(t *testing.T) {
 
 			jobRepo.On("GetJobDetails", ctx, projName, jobName).Return(job, nil)
 
-			service := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil, nil, nil, nil, nil, projectGetter, feats, nil, nil)
+			service := service.NewJobRunService(logger, jobRepo, nil, nil, nil, nil, nil, nil, nil, nil, projectGetter, feats, nil, nil, nil)
 
 			actualInterval, actualError := service.GetInterval(ctx, projName, jobName, referenceTime)
 
@@ -2089,7 +2089,7 @@ func TestJobRunService(t *testing.T) {
 			}, nil)
 			defer jobRunRepo.AssertExpectations(t)
 
-			runService := service.NewJobRunService(logger, nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+			runService := service.NewJobRunService(logger, nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 			filters := []filter.FilterOpt{
 				filter.WithTime(filter.StartDate, startDate),
@@ -2118,7 +2118,7 @@ func TestJobRunService(t *testing.T) {
 			jobRunRepo.On("GetLatestRun", ctx, projName, jobName, &runState).Return(jobRun, nil)
 			defer jobRunRepo.AssertExpectations(t)
 
-			runService := service.NewJobRunService(logger, nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+			runService := service.NewJobRunService(logger, nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 			filters := []filter.FilterOpt{
 				filter.WithString(filter.RunState, runState.String()),
@@ -2141,7 +2141,7 @@ func TestJobRunService(t *testing.T) {
 			jobRunRepo.On("GetRunsByTimeRange", ctx, projName, jobName, &runState, startDate, endDate).Return(runsByTimeRange, fmt.Errorf("some error"))
 			defer jobRunRepo.AssertExpectations(t)
 
-			runService := service.NewJobRunService(logger, nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+			runService := service.NewJobRunService(logger, nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 			filters := []filter.FilterOpt{
 				filter.WithTime(filter.StartDate, startDate),
@@ -2163,7 +2163,7 @@ func TestJobRunService(t *testing.T) {
 			jobRunRepo.On("GetLatestRun", ctx, projName, jobName, &runState).Return(jobRun, fmt.Errorf("some error"))
 			defer jobRunRepo.AssertExpectations(t)
 
-			runService := service.NewJobRunService(logger, nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+			runService := service.NewJobRunService(logger, nil, jobRunRepo, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 			filters := []filter.FilterOpt{
 				filter.WithString(filter.RunState, runState.String()),
@@ -2261,7 +2261,7 @@ func TestJobRunService(t *testing.T) {
 			// 2023-12-15 08:00 UTC
 			downstreamScheduledAt := time.Date(2023, 12, 15, 8, 0, 0, 0, time.UTC)
 
-			runService := service.NewJobRunService(logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+			runService := service.NewJobRunService(logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 			schedules, err := runService.GetExpectedRunSchedules(ctx, project,
 				sourceJobWithYesterdayConfig.Schedule.Interval, sourceJobWithYesterdayConfig.Job.WindowConfig,
 				upstreamJob.Schedule.Interval, downstreamScheduledAt)
@@ -2280,7 +2280,7 @@ func TestJobRunService(t *testing.T) {
 		t.Run("should return recent schedule if downstream schedule = upstream schedule", func(t *testing.T) {
 			downstreamScheduledAt := time.Date(2023, 12, 15, 8, 0, 0, 0, time.UTC)
 
-			runService := service.NewJobRunService(logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+			runService := service.NewJobRunService(logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 			schedules, err := runService.GetExpectedRunSchedules(ctx, project,
 				sourceJobWithYesterdayConfig.Schedule.Interval, sourceJobWithYesterdayConfig.Job.WindowConfig,
 				upstreamJobWithEqualSchedule.Schedule.Interval, downstreamScheduledAt)
@@ -2299,7 +2299,7 @@ func TestJobRunService(t *testing.T) {
 		t.Run("should return multiple expected run schedules for multi-day window config", func(t *testing.T) {
 			downstreamScheduledAt := time.Date(2023, 12, 15, 8, 0, 0, 0, time.UTC)
 
-			runService := service.NewJobRunService(logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+			runService := service.NewJobRunService(logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 			schedules, err := runService.GetExpectedRunSchedules(ctx, project,
 				sourceJobWithMultiDayConfig.Schedule.Interval, sourceJobWithMultiDayConfig.Job.WindowConfig,
 				upstreamJobWithEqualSchedule.Schedule.Interval, downstreamScheduledAt)
@@ -2334,7 +2334,7 @@ func TestJobRunService(t *testing.T) {
 
 			referenceTime := time.Date(2023, 12, 15, 8, 0, 0, 0, time.UTC)
 
-			runService := service.NewJobRunService(logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+			runService := service.NewJobRunService(logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 			schedules, err := runService.GetExpectedRunSchedules(ctx, project,
 				sourceJobWithYesterdayConfig.Schedule.Interval,
@@ -2361,7 +2361,7 @@ func TestJobRunService(t *testing.T) {
 
 			referenceTime := time.Date(2023, 12, 15, 8, 0, 0, 0, time.UTC)
 
-			runService := service.NewJobRunService(logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+			runService := service.NewJobRunService(logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 			schedules, err := runService.GetExpectedRunSchedules(ctx, project,
 				sourceJobWithYesterdayConfig.Schedule.Interval, sourceJobWithYesterdayConfig.Job.WindowConfig,
@@ -2394,7 +2394,7 @@ func TestJobRunService(t *testing.T) {
 
 			referenceTime := time.Date(2023, 12, 15, 8, 0, 0, 0, time.UTC)
 
-			runService := service.NewJobRunService(logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+			runService := service.NewJobRunService(logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 			schedules, err := runService.GetExpectedRunSchedules(ctx, project,
 				sourceJobWithYesterdayConfig.Schedule.Interval, sourceJobWithYesterdayConfig.Job.WindowConfig,
@@ -2428,7 +2428,7 @@ func TestJobRunService(t *testing.T) {
 			// upstream runs in window: 2023-12-14 18:00 and 2023-12-15 00:00
 			referenceTime := time.Date(2023, 12, 15, 8, 0, 0, 0, time.UTC)
 
-			runService := service.NewJobRunService(logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+			runService := service.NewJobRunService(logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 			schedules, err := runService.GetExpectedRunSchedules(ctx, project,
 				sourceJobWithYesterdayConfig.Schedule.Interval, sourceJobWithYesterdayConfig.Job.WindowConfig,
@@ -2459,7 +2459,7 @@ func TestJobRunService(t *testing.T) {
 
 			referenceTime := time.Date(2023, 12, 15, 8, 0, 0, 0, time.UTC)
 
-			runService := service.NewJobRunService(logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil)
+			runService := service.NewJobRunService(logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, feats, nil, nil, nil)
 
 			schedules, err := runService.GetExpectedRunSchedules(ctx, project,
 				sourceJobWithNonUTCConfig.Schedule.Interval, sourceJobWithNonUTCConfig.Job.WindowConfig,
@@ -2591,6 +2591,19 @@ func (m *mockJobRunRepository) UpdateSLA(ctx context.Context, jobName scheduler.
 func (m *mockJobRunRepository) UpdateMonitoring(ctx context.Context, jobRunID uuid.UUID, monitoring map[string]any) error {
 	args := m.Called(ctx, jobRunID, monitoring)
 	return args.Error(0)
+}
+
+// UpdateSchedulerRunID is called opportunistically, whenever an event happens to carry a dag
+// run id that differs from what is stored. Recording it is best effort in production, so tests
+// that do not care about it are not obliged to expect it; those that do can set an expectation
+// as usual and it will be honoured.
+func (m *mockJobRunRepository) UpdateSchedulerRunID(ctx context.Context, jobRunID uuid.UUID, schedulerRunID string) error {
+	for _, expected := range m.ExpectedCalls {
+		if expected.Method == "UpdateSchedulerRunID" {
+			return m.Called(ctx, jobRunID, schedulerRunID).Error(0)
+		}
+	}
+	return nil
 }
 
 func (m *mockJobRunRepository) GetRunSummaryByIdentifiers(ctx context.Context, identifiers []scheduler.JobRunIdentifier) ([]*scheduler.JobRunSummary, error) {
@@ -2783,9 +2796,16 @@ func (m *mockOperatorRunRepository) GetOperatorRun(ctx context.Context, operator
 	return args.Get(0).(*scheduler.OperatorRun), args.Error(1)
 }
 
-func (m *mockOperatorRunRepository) CreateOperatorRun(ctx context.Context, operatorName string, operator scheduler.OperatorType, jobRunID uuid.UUID, startTime time.Time) error {
+func (m *mockOperatorRunRepository) CreateOperatorRun(ctx context.Context, operatorName string, operator scheduler.OperatorType, jobRunID uuid.UUID, startTime time.Time, _ scheduler.RunAttribution, _ int) (uuid.UUID, error) {
 	args := m.Called(ctx, operatorName, operator, jobRunID, startTime)
-	return args.Error(0)
+	if args.Get(0) == nil {
+		return uuid.Nil, args.Error(0)
+	}
+	if id, ok := args.Get(0).(uuid.UUID); ok {
+		return id, args.Error(1)
+	}
+	// Existing expectations only set an error; synthesise an id so the caller can carry on.
+	return uuid.New(), args.Error(0)
 }
 
 func (m *mockOperatorRunRepository) UpdateOperatorRun(ctx context.Context, operator scheduler.OperatorType, jobRunID uuid.UUID, eventTime time.Time, state scheduler.State) error {

--- a/core/scheduler/service/job_run_service_test.go
+++ b/core/scheduler/service/job_run_service_test.go
@@ -450,6 +450,46 @@ func TestJobRunService(t *testing.T) {
 				assert.NotNil(t, err)
 				assert.EqualError(t, err, "some error in GetByScheduledAt")
 			})
+			t.Run("should never consult the attribution service for a sensor start", func(t *testing.T) {
+				// Sensors are upstream waits. Classifying one would add a replay lookup to every
+				// sensor start for an answer already recorded against the run's task and hook rows,
+				// so the attributor must not be reached at all.
+				scheduledAtTimeStamp, _ := time.Parse(scheduler.ISODateFormat, "2022-01-02T15:04:05Z")
+				eventTime := time.Unix(todayDate.Add(time.Hour).Unix(), 0)
+				jobRun := scheduler.JobRun{ID: uuid.New(), JobName: jobName, Tenant: tnnt, State: scheduler.StateWaitUpstream}
+				event := &scheduler.Event{
+					JobName:        jobName,
+					Tenant:         tnnt,
+					Type:           scheduler.SensorStartEvent,
+					JobScheduledAt: scheduledAtTimeStamp,
+					EventTime:      eventTime,
+					OperatorName:   "wait-upstream",
+					Values:         map[string]any{},
+					EventContext: &scheduler.EventContext{
+						Type:         scheduler.OperatorStartEvent,
+						OperatorType: scheduler.OperatorSensor,
+						DagRun:       scheduler.DagRun{RunID: "manual__2026-07-20T13:00:00+00:00"},
+					},
+				}
+
+				jobRunRepo := new(mockJobRunRepository)
+				jobRunRepo.On("GetByScheduledAt", ctx, tnnt, jobName, scheduledAtTimeStamp).Return(&jobRun, nil)
+				jobRunRepo.On("UpdateSchedulerRunID", ctx, jobRun.ID, "manual__2026-07-20T13:00:00+00:00").Return(nil)
+
+				operatorRunRepository := new(mockOperatorRunRepository)
+				operatorRunRepository.On("CreateOperatorRun", ctx, event.OperatorName, scheduler.OperatorSensor,
+					jobRun.ID, eventTime).Return(uuid.New(), nil)
+
+				// A run id that would otherwise classify as manual, so a sensor reaching the
+				// attributor at all would show up here.
+				attributor := new(mockRunAttributor)
+				defer attributor.AssertExpectations(t)
+
+				runService := service.NewJobRunService(logger,
+					nil, jobRunRepo, nil, operatorRunRepository, nil, nil, nil, nil, nil, nil, feats, nil, nil, attributor)
+
+				assert.NoError(t, runService.UpdateJobState(ctx, event))
+			})
 			t.Run("should return error on SensorStartEvent if GetJobDetails fails", func(t *testing.T) {
 				scheduledAtTimeStamp, _ := time.Parse(scheduler.ISODateFormat, "2022-01-02T15:04:05Z")
 				eventTime := time.Unix(todayDate.Add(time.Hour).Unix(), 0)
@@ -2811,6 +2851,21 @@ func (m *mockOperatorRunRepository) CreateOperatorRun(ctx context.Context, opera
 func (m *mockOperatorRunRepository) UpdateOperatorRun(ctx context.Context, operator scheduler.OperatorType, jobRunID uuid.UUID, eventTime time.Time, state scheduler.State) error {
 	args := m.Called(ctx, operator, jobRunID, eventTime, state)
 	return args.Error(0)
+}
+
+// mockRunAttributor has no expectations set by default, so testify fails on any call. That is
+// the point: it proves a code path never reaches attribution.
+type mockRunAttributor struct {
+	mock.Mock
+}
+
+func (m *mockRunAttributor) Classify(ctx context.Context, in service.AttributionInput) scheduler.RunAttribution {
+	args := m.Called(ctx, in)
+	return args.Get(0).(scheduler.RunAttribution)
+}
+
+func (m *mockRunAttributor) Record(ctx context.Context, in service.AttributionInput, operatorRunID uuid.UUID, attribution scheduler.RunAttribution) error {
+	return m.Called(ctx, in, operatorRunID, attribution).Error(0)
 }
 
 type mockEventHandler struct {

--- a/core/scheduler/service/run_attribution_service.go
+++ b/core/scheduler/service/run_attribution_service.go
@@ -1,0 +1,501 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/goto/salt/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/goto/optimus/config"
+	"github.com/goto/optimus/core/scheduler"
+	"github.com/goto/optimus/core/tenant"
+	"github.com/goto/optimus/internal/errors"
+	"github.com/goto/optimus/internal/utils"
+)
+
+// Airflow 2.9 audit event names. Not configurable: these are properties of the Airflow version
+// being talked to, established by reading its source, and a wrong value would silently yield
+// unattributed runs rather than an error.
+//
+// exactMatchEvents identify a specific dag run, because Airflow populates the audit row's
+// dag_id and run_id from the request's form or query parameters. heuristicEvents are what the
+// /dagrun/list/ and /taskinstance/list/ bulk actions emit; those requests carry only opaque row
+// ids, so Airflow records no dag_id or run_id and the rows can be correlated by time alone.
+var (
+	exactMatchEvents = []string{
+		"clear",        // grid page, clear a task instance
+		"dagrun_clear", // grid page, clear a whole dag run
+		"trigger",      // Trigger DAG button
+		"api.clear_dag_run",
+		"api.post_clear_task_instances",
+		"api.post_dag_run",
+		"api.update_dag_run_state",
+		"api.patch_task_instance",
+	}
+
+	heuristicEvents = []string{
+		"action_clear",
+		"action_clear_downstream",
+		"action_set_failed",
+		"action_set_success",
+		"action_set_retry",
+		"action_set_queued",
+		"action_set_running",
+	}
+)
+
+// Fallbacks for when this service is constructed with a zero config, e.g. in tests. Normal
+// operation gets these from the config loader's struct tag defaults.
+const (
+	defaultResolveTimeout = 30 * time.Second
+	defaultAuditLookback  = 30 * time.Minute
+	defaultAuditPageLimit = 100
+)
+
+var runAttributionMetric = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "jobrun_attribution_total",
+	Help: "Operator runs classified by why they ran and how that was decided",
+}, []string{"run_type", "attribution"})
+
+// AuditLogGetter reads Airflow's record of user actions. Deliberately narrow rather than
+// another method on the already broad Scheduler interface.
+type AuditLogGetter interface {
+	GetEventLogs(ctx context.Context, filter scheduler.AuditEventFilter) ([]*scheduler.AuditEvent, error)
+}
+
+// RunAttributionRepository persists why an operator run happened. UpdateTriggerSourceResolution
+// writes both the trigger source row and the operator run row, atomically — task_run and hook_run
+// are what most consumers read, so a partial write would leave them disagreeing with the trigger
+// source and nothing reconciles them afterwards.
+type RunAttributionRepository interface {
+	InsertTriggerSource(ctx context.Context, src *scheduler.TriggerSource) (uuid.UUID, error)
+	UpdateTriggerSourceResolution(ctx context.Context, triggerSourceID uuid.UUID, operatorType scheduler.OperatorType,
+		operatorRunID uuid.UUID, attribution scheduler.RunAttribution, resolveAttempts int) error
+}
+
+type ReplayAttributionGetter interface {
+	GetReplayAttributionByScheduledAt(ctx context.Context, jobTenant tenant.Tenant, jobName scheduler.JobName, scheduledAt time.Time) (uuid.UUID, string, error)
+}
+
+type BackfillAttributionGetter interface {
+	GetBackfillDetails(ctx context.Context, backfillID uuid.UUID) (*scheduler.Backfill, error)
+}
+
+// AttributionInput is everything known about an operator run at the moment it starts.
+type AttributionInput struct {
+	Tenant         tenant.Tenant
+	JobName        scheduler.JobName
+	OperatorName   string
+	OperatorType   scheduler.OperatorType
+	JobRunID       uuid.UUID
+	ScheduledAt    time.Time
+	SchedulerRunID string
+	Attempt        int
+	StartTime      time.Time
+
+	// PreviousRun is the most recent earlier attempt of this same operator, if any. Its status
+	// is the only reliable way to tell a scheduler retry from a manual clear: Airflow fires
+	// on_retry_callback for its own retries and not for a clear, so a predecessor left in
+	// 'retried' means the scheduler is responsible for this attempt.
+	PreviousRun *scheduler.OperatorRun
+}
+
+type RunAttributionService struct {
+	l    log.Logger
+	conf config.RunAttributionConfig
+
+	repo         RunAttributionRepository
+	replayRepo   ReplayAttributionGetter
+	backfillRepo BackfillAttributionGetter
+	auditGetter  AuditLogGetter
+
+	// sem caps concurrent resolutions. A full semaphore sheds the resolution rather than
+	// queueing it, so a slow Airflow cannot pile up goroutines on the event ingestion path.
+	sem   chan struct{}
+	group singleflight.Group
+
+	serviceAccounts map[string]bool
+
+	// resolved is signalled after every detached resolution finishes. Tests join on it so
+	// they never have to sleep; it is nil in production.
+	resolved *sync.WaitGroup
+}
+
+func NewRunAttributionService(l log.Logger, conf config.RunAttributionConfig, repo RunAttributionRepository,
+	replayRepo ReplayAttributionGetter, backfillRepo BackfillAttributionGetter, auditGetter AuditLogGetter,
+) *RunAttributionService {
+	serviceAccounts := map[string]bool{}
+	for _, owner := range conf.ServiceAccountOwners {
+		serviceAccounts[strings.ToLower(strings.TrimSpace(owner))] = true
+	}
+
+	maxConcurrent := conf.MaxConcurrentResolves
+	if maxConcurrent < 1 {
+		maxConcurrent = 1
+	}
+
+	return &RunAttributionService{
+		l:               l,
+		conf:            conf,
+		repo:            repo,
+		replayRepo:      replayRepo,
+		backfillRepo:    backfillRepo,
+		auditGetter:     auditGetter,
+		sem:             make(chan struct{}, maxConcurrent),
+		serviceAccounts: serviceAccounts,
+	}
+}
+
+// Classify decides why a run is executing, using only local state. It never calls Airflow, so
+// it is safe on the event ingestion path.
+//
+// Order matters. Optimus's own replay and backfill are checked first because a replay clears
+// an existing dag run in place, leaving Airflow's run id reading as an ordinary scheduled run
+// that would otherwise be mistaken for a manual clear.
+func (s *RunAttributionService) Classify(ctx context.Context, in AttributionInput) scheduler.RunAttribution {
+	// 1. Optimus custom backfill. The backfill id is embedded in the dag run id, so this is an
+	// exact match with no scan. Note we do not filter the backfill by status: BackfillService
+	// sets 'in progress' only after the Airflow dag run has been created, so a fast-starting
+	// task can legitimately observe 'created'.
+	if ok, backfillID := isRunCustomBackfillType(in.SchedulerRunID); ok {
+		if attribution, err := s.attributeToBackfill(ctx, backfillID); err == nil {
+			return attribution
+		}
+		s.l.Warn("run attribution: dag run %s names backfill %s but it could not be read", in.SchedulerRunID, backfillID)
+	}
+
+	// 2. Optimus replay. Matched on the replay's time window rather than the dag run id,
+	// because a replay of an existing run does not change that run's id.
+	if attribution, ok := s.attributeToReplay(ctx, in); ok {
+		return attribution
+	}
+
+	// 3. Somebody used Airflow's Trigger DAG button.
+	if scheduler.IsManualDagRunID(in.SchedulerRunID) {
+		return pendingManualAttribution()
+	}
+
+	// 4. An earlier attempt of this operator exists.
+	if in.PreviousRun != nil {
+		if in.PreviousRun.Status == scheduler.StateRetry {
+			// The scheduler retried it. Carry the earlier attempt's verdict forward.
+			return inheritedAttribution(in.PreviousRun)
+		}
+		// The previous attempt had already finished, so something outside the scheduler made
+		// this one happen: a task or dag run cleared in Airflow.
+		return pendingManualAttribution()
+	}
+
+	// 5. Nothing suggests otherwise; the scheduler started it on its own.
+	return scheduler.ScheduledAttribution()
+}
+
+// Record persists the cause of a run, and where the actor is still unknown, starts a detached
+// resolution against Airflow's audit log.
+//
+// operatorRunID must be the row this attribution belongs to. Scheduled runs write nothing.
+func (s *RunAttributionService) Record(ctx context.Context, in AttributionInput, operatorRunID uuid.UUID, attribution scheduler.RunAttribution) error {
+	runAttributionMetric.WithLabelValues(attribution.RunType.String(), attribution.Attribution).Inc()
+
+	if attribution.IsScheduled() {
+		return nil
+	}
+
+	src := &scheduler.TriggerSource{
+		OperatorRunID:  operatorRunID,
+		OperatorType:   in.OperatorType,
+		JobRunID:       in.JobRunID,
+		SchedulerRunID: in.SchedulerRunID,
+		Attribution:    attribution,
+	}
+	triggerSourceID, err := s.repo.InsertTriggerSource(ctx, src)
+	if err != nil {
+		return err
+	}
+
+	// With audit resolution off the row keeps its pending values, which still answers "was this a
+	// manual action" even though it cannot answer "who did it".
+	if attribution.NeedsAuditResolution() && s.conf.AuditResolutionEnabled {
+		s.resolveDetached(ctx, in, triggerSourceID, operatorRunID)
+	}
+	return nil
+}
+
+func (s *RunAttributionService) attributeToBackfill(ctx context.Context, backfillID uuid.UUID) (scheduler.RunAttribution, error) {
+	backfill, err := s.backfillRepo.GetBackfillDetails(ctx, backfillID)
+	if err != nil {
+		return scheduler.RunAttribution{}, err
+	}
+	id := backfillID
+	return scheduler.RunAttribution{
+		RunType:     scheduler.RunTypeBackfill,
+		TriggeredBy: backfill.GetUserID(),
+		SourceType:  scheduler.SourceTypeBackfill,
+		Attribution: scheduler.AttributionOptimusBackfill,
+		BackfillID:  &id,
+	}, nil
+}
+
+func (s *RunAttributionService) attributeToReplay(ctx context.Context, in AttributionInput) (scheduler.RunAttribution, bool) {
+	replayID, userID, err := s.replayRepo.GetReplayAttributionByScheduledAt(ctx, in.Tenant, in.JobName, in.ScheduledAt)
+	if err != nil {
+		if !errors.IsErrorType(err, errors.ErrNotFound) {
+			s.l.Error("run attribution: unable to look up replay for job %s at %s: %s", in.JobName, in.ScheduledAt, err)
+		}
+		return scheduler.RunAttribution{}, false
+	}
+	id := replayID
+	return scheduler.RunAttribution{
+		RunType:     scheduler.RunTypeReplay,
+		TriggeredBy: userID,
+		SourceType:  scheduler.SourceTypeReplay,
+		Attribution: scheduler.AttributionOptimusReplay,
+		ReplayID:    &id,
+	}, true
+}
+
+func inheritedAttribution(previous *scheduler.OperatorRun) scheduler.RunAttribution {
+	runType := previous.RunType
+	if runType == "" {
+		runType = scheduler.RunTypeScheduled
+	}
+	triggeredBy := previous.TriggeredBy
+	if triggeredBy == "" {
+		triggeredBy = scheduler.TriggeredByScheduler
+	}
+	if runType == scheduler.RunTypeScheduled {
+		// A retry of an ordinary scheduled run is still just a scheduled run; nothing to link.
+		return scheduler.ScheduledAttribution()
+	}
+	return scheduler.RunAttribution{
+		RunType:     runType,
+		TriggeredBy: triggeredBy,
+		SourceType:  scheduler.SourceTypeManual,
+		Attribution: scheduler.AttributionInherited,
+	}
+}
+
+// pendingManualAttribution marks a run as manual with the actor not yet established. If
+// resolution never completes the row keeps these values, which honestly says "a human did
+// this and we could not tell who".
+func pendingManualAttribution() scheduler.RunAttribution {
+	return scheduler.RunAttribution{
+		RunType:     scheduler.RunTypeManual,
+		TriggeredBy: scheduler.TriggeredByUnidentified,
+		SourceType:  scheduler.SourceTypeManual,
+		Attribution: scheduler.AttributionPending,
+	}
+}
+
+// resolveDetached runs the Airflow audit lookup outside the caller's request.
+func (s *RunAttributionService) resolveDetached(parent context.Context, in AttributionInput, triggerSourceID, operatorRunID uuid.UUID) {
+	select {
+	case s.sem <- struct{}{}:
+	default:
+		// Shed rather than block event ingestion or grow goroutines without bound. The row
+		// stays as a manual run with an unresolved actor.
+		s.l.Warn("run attribution: resolver saturated, leaving %s unresolved", operatorRunID)
+		runAttributionMetric.WithLabelValues(scheduler.RunTypeManual.String(), "shed").Inc()
+		return
+	}
+	if s.resolved != nil {
+		s.resolved.Add(1)
+	}
+
+	go func() {
+		defer func() { <-s.sem }()
+		if s.resolved != nil {
+			defer s.resolved.Done()
+		}
+		defer func() {
+			// A panic here would take down the server, and this runs once per manual task start.
+			if r := recover(); r != nil {
+				s.l.Error("run attribution: panic while resolving %s: %v", operatorRunID, r)
+			}
+		}()
+
+		// WithoutCancel keeps trace and tenant values but detaches from the request's
+		// cancellation, which fires as soon as the event handler returns.
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(parent), s.resolveTimeout())
+		defer cancel()
+
+		s.resolve(ctx, in, triggerSourceID, operatorRunID)
+	}()
+}
+
+func (s *RunAttributionService) resolve(ctx context.Context, in AttributionInput, triggerSourceID, operatorRunID uuid.UUID) {
+	attribution := pendingManualAttribution()
+	attempts := 0
+
+	// One dag run means one answer, however many of its tasks were cleared at once. singleflight
+	// collapses the concurrent lookups; every caller then updates only its own row.
+	key := in.Tenant.ProjectName().String() + "/" + in.JobName.String() + "/" + in.SchedulerRunID
+	result, err, _ := s.group.Do(key, func() (any, error) {
+		var resolved scheduler.RunAttribution
+		err := utils.Retry(s.l, s.retryMax(), int64(s.conf.ResolveRetryBackoffMs), func() error {
+			attempts++
+			var retryErr error
+			resolved, retryErr = s.resolveFromAudit(ctx, in)
+			return retryErr
+		})
+		return resolved, err
+	})
+
+	switch {
+	case err != nil:
+		s.l.Error("run attribution: giving up on %s after %d attempts: %s", operatorRunID, attempts, err)
+		attribution.Attribution = scheduler.AttributionUnidentified
+	default:
+		if resolved, ok := result.(scheduler.RunAttribution); ok {
+			attribution = resolved
+		}
+	}
+
+	if err := s.repo.UpdateTriggerSourceResolution(ctx, triggerSourceID, in.OperatorType, operatorRunID, attribution, attempts); err != nil {
+		s.l.Error("run attribution: unable to persist resolution for %s: %s", operatorRunID, err)
+		return
+	}
+	runAttributionMetric.WithLabelValues(attribution.RunType.String(), attribution.Attribution).Inc()
+}
+
+// resolveFromAudit asks Airflow who acted. It tries an exact match on the dag run first, then
+// falls back to correlating by time against the bulk actions that record no dag run at all.
+func (s *RunAttributionService) resolveFromAudit(ctx context.Context, in AttributionInput) (scheduler.RunAttribution, error) {
+	after, before := s.auditWindow(in.StartTime)
+
+	if in.SchedulerRunID != "" {
+		events, err := s.auditGetter.GetEventLogs(ctx, scheduler.AuditEventFilter{
+			Tenant:         in.Tenant,
+			DagID:          in.JobName.String(),
+			RunID:          in.SchedulerRunID,
+			After:          after,
+			Before:         before,
+			IncludedEvents: exactMatchEvents,
+			Limit:          s.auditPageLimit(),
+		})
+		if err != nil {
+			return scheduler.RunAttribution{}, err
+		}
+		if event := s.pickLatestActionable(events); event != nil {
+			return auditAttribution(event, scheduler.AttributionAuditRunID), nil
+		}
+	}
+
+	// Nothing named this dag run. The bulk clear pages log no dag_id or run_id at all, so all
+	// that is left is timing.
+	events, err := s.auditGetter.GetEventLogs(ctx, scheduler.AuditEventFilter{
+		Tenant:         in.Tenant,
+		After:          after,
+		Before:         before,
+		IncludedEvents: heuristicEvents,
+		Limit:          s.auditPageLimit(),
+	})
+	if err != nil {
+		return scheduler.RunAttribution{}, err
+	}
+	return s.correlateByTime(events), nil
+}
+
+// pickLatestActionable returns the most recent audit row that names a real actor. Events are
+// requested newest first. Airflow logs the Trigger DAG form's GET as well as its POST, so the
+// same action can appear twice; taking the newest and ignoring blank owners handles both.
+func (s *RunAttributionService) pickLatestActionable(events []*scheduler.AuditEvent) *scheduler.AuditEvent {
+	for _, event := range events {
+		if event.Owner == "" || s.isServiceAccount(event.Owner) {
+			continue
+		}
+		return event
+	}
+	return nil
+}
+
+// correlateByTime attributes a run from audit rows that carry no dag context. This is a guess,
+// and it is recorded as one: a single unambiguous actor is accepted, anything else is left
+// unidentified. The candidate rows are kept on the record either way so a human can adjudicate.
+func (s *RunAttributionService) correlateByTime(events []*scheduler.AuditEvent) scheduler.RunAttribution {
+	attribution := pendingManualAttribution()
+	attribution.Attribution = scheduler.AttributionUnidentified
+
+	owners := map[string]bool{}
+	var candidates []*scheduler.AuditEvent
+	for _, event := range events {
+		// A row that does name a dag is about some other dag; had it been about ours, the
+		// exact-match query above would have found it.
+		if event.HasDagContext() || event.Owner == "" || s.isServiceAccount(event.Owner) {
+			continue
+		}
+		owners[event.Owner] = true
+		candidates = append(candidates, event)
+	}
+
+	if extra, err := json.Marshal(candidates); err == nil && len(candidates) > 0 {
+		attribution.AuditExtra = string(extra)
+	}
+	if len(owners) != 1 {
+		return attribution
+	}
+
+	latest := candidates[0]
+	resolved := auditAttribution(latest, scheduler.AttributionAuditHeuristic)
+	resolved.AuditExtra = attribution.AuditExtra
+	return resolved
+}
+
+func auditAttribution(event *scheduler.AuditEvent, how string) scheduler.RunAttribution {
+	eventLogID := event.EventLogID
+	return scheduler.RunAttribution{
+		RunType:      scheduler.RunTypeManual,
+		TriggeredBy:  event.Owner,
+		SourceType:   scheduler.SourceTypeManual,
+		Attribution:  how,
+		AuditEvent:   event.Event,
+		AuditEventID: &eventLogID,
+		AuditExtra:   event.Extra,
+	}
+}
+
+func (s *RunAttributionService) isServiceAccount(owner string) bool {
+	return s.serviceAccounts[strings.ToLower(strings.TrimSpace(owner))]
+}
+
+// auditWindow brackets the search on when the run actually started, not on now: the gap between
+// a user's click and the task starting is a scheduler loop plus queue and pool wait. The action
+// necessarily precedes the run it caused, so the window ends at the start time.
+func (s *RunAttributionService) auditWindow(startTime time.Time) (after, before time.Time) {
+	if startTime.IsZero() {
+		startTime = time.Now()
+	}
+	lookback := time.Duration(s.conf.AuditLookbackMinutes) * time.Minute
+	if lookback <= 0 {
+		lookback = defaultAuditLookback
+	}
+	return startTime.Add(-lookback), startTime
+}
+
+func (s *RunAttributionService) resolveTimeout() time.Duration {
+	if s.conf.ResolveTimeoutSeconds > 0 {
+		return time.Duration(s.conf.ResolveTimeoutSeconds) * time.Second
+	}
+	return defaultResolveTimeout
+}
+
+func (s *RunAttributionService) retryMax() int {
+	if s.conf.ResolveRetryMax > 0 {
+		return s.conf.ResolveRetryMax
+	}
+	return 1
+}
+
+func (s *RunAttributionService) auditPageLimit() int {
+	if s.conf.AuditPageLimit > 0 {
+		return s.conf.AuditPageLimit
+	}
+	return defaultAuditPageLimit
+}

--- a/core/scheduler/service/run_attribution_service.go
+++ b/core/scheduler/service/run_attribution_service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -24,10 +25,14 @@ import (
 // being talked to, established by reading its source, and a wrong value would silently yield
 // unattributed runs rather than an error.
 //
-// exactMatchEvents identify a specific dag run, because Airflow populates the audit row's
-// dag_id and run_id from the request's form or query parameters. heuristicEvents are what the
-// /dagrun/list/ and /taskinstance/list/ bulk actions emit; those requests carry only opaque row
-// ids, so Airflow records no dag_id or run_id and the rows can be correlated by time alone.
+// exactMatchEvents always identify the DAG, because Airflow fills dag_id from the request's path or
+// form. They identify the *run* only sometimes: a plain Trigger DAG leaves the Run Id field blank,
+// and the REST clears pass it in a JSON body, both of which leave run_id NULL. So run_id is treated
+// as a bonus discriminator rather than a filter.
+//
+// heuristicEvents are what the /dagrun/list/ and /taskinstance/list/ bulk actions emit; those
+// requests carry only opaque row ids, so Airflow records no dag_id or run_id at all and the rows can
+// be correlated by time alone.
 var (
 	exactMatchEvents = []string{
 		"clear",        // grid page, clear a task instance
@@ -54,9 +59,11 @@ var (
 // Fallbacks for when this service is constructed with a zero config, e.g. in tests. Normal
 // operation gets these from the config loader's struct tag defaults.
 const (
-	defaultResolveTimeout = 30 * time.Second
-	defaultAuditLookback  = 30 * time.Minute
-	defaultAuditPageLimit = 100
+	defaultResolveTimeout   = 30 * time.Second
+	defaultAuditLookback    = 30 * time.Minute
+	defaultAuditPageLimit   = 100
+	defaultMaxPending       = 512
+	defaultIdentifyLookback = 24 * time.Hour
 )
 
 var runAttributionMetric = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -78,6 +85,7 @@ type RunAttributionRepository interface {
 	InsertTriggerSource(ctx context.Context, src *scheduler.TriggerSource) (uuid.UUID, error)
 	UpdateTriggerSourceResolution(ctx context.Context, triggerSourceID uuid.UUID, operatorType scheduler.OperatorType,
 		operatorRunID uuid.UUID, attribution scheduler.RunAttribution, resolveAttempts int) error
+	GetTriggerSourceByOperatorRunID(ctx context.Context, operatorRunID uuid.UUID) (*scheduler.TriggerSource, error)
 }
 
 type ReplayAttributionGetter interface {
@@ -116,10 +124,12 @@ type RunAttributionService struct {
 	backfillRepo BackfillAttributionGetter
 	auditGetter  AuditLogGetter
 
-	// sem caps concurrent resolutions. A full semaphore sheds the resolution rather than
-	// queueing it, so a slow Airflow cannot pile up goroutines on the event ingestion path.
-	sem   chan struct{}
-	group singleflight.Group
+	// sem caps concurrent calls into Airflow. Acquired inside the singleflight closure, so
+	// resolutions that collapse onto a shared lookup do not consume a slot.
+	sem chan struct{}
+	// inFlight counts resolver goroutines, as a memory backstop distinct from sem.
+	inFlight atomic.Int64
+	group    singleflight.Group
 
 	serviceAccounts map[string]bool
 
@@ -160,41 +170,71 @@ func NewRunAttributionService(l log.Logger, conf config.RunAttributionConfig, re
 // an existing dag run in place, leaving Airflow's run id reading as an ordinary scheduled run
 // that would otherwise be mistaken for a manual clear.
 func (s *RunAttributionService) Classify(ctx context.Context, in AttributionInput) scheduler.RunAttribution {
-	// 1. Optimus custom backfill. The backfill id is embedded in the dag run id, so this is an
+	// 1. A scheduler retry carries the previous attempt's verdict forward. Checked first because
+	// nothing about how the dag run originally came about can override the fact that Airflow
+	// itself started this attempt.
+	if in.PreviousRun != nil && in.PreviousRun.Status == scheduler.StateRetry {
+		return s.inheritedAttribution(ctx, in.PreviousRun)
+	}
+
+	// An earlier attempt of this operator already reached a terminal state, so this attempt was
+	// not started by the scheduler and not by whatever originally created the dag run. Something
+	// re-ran it. Who that was depends on the dag run's provenance, below.
+	rerun := in.PreviousRun != nil
+
+	// 2. Optimus custom backfill. The backfill id is embedded in the dag run id, so this is an
 	// exact match with no scan. Note we do not filter the backfill by status: BackfillService
 	// sets 'in progress' only after the Airflow dag run has been created, so a fast-starting
 	// task can legitimately observe 'created'.
 	if ok, backfillID := isRunCustomBackfillType(in.SchedulerRunID); ok {
 		if attribution, err := s.attributeToBackfill(ctx, backfillID); err == nil {
+			if rerun {
+				// Optimus never clears a backfill: it creates one dag run and then only watches
+				// it. So a further attempt that is not a scheduler retry was started by a person,
+				// and naming whoever requested the backfill would attribute their action to
+				// somebody else. The dag run id says nothing about who re-ran it, and it never
+				// changes, so without this the original requester would be blamed forever.
+				return manualRerunOf(attribution)
+			}
 			return attribution
 		}
 		s.l.Warn("run attribution: dag run %s names backfill %s but it could not be read", in.SchedulerRunID, backfillID)
 	}
 
-	// 2. Optimus replay. Matched on the replay's time window rather than the dag run id,
-	// because a replay of an existing run does not change that run's id.
+	// 3. Optimus replay. Matched on the replay's time window rather than the dag run id, because
+	// a replay of an existing run clears it in place and does not change its id.
+	//
+	// This deliberately wins over the rerun check: replaying an existing run *is* a clear issued
+	// by Optimus, so a terminal previous attempt is the expected state here rather than evidence
+	// of a person. Only replays that are still in flight match, so a human clearing a run whose
+	// replay has already finished falls through to the manual path below and is named correctly.
+	// The residual case — a human clearing a run while its replay is still running — is
+	// attributed to the replay; see the note in the solution doc.
 	if attribution, ok := s.attributeToReplay(ctx, in); ok {
 		return attribution
 	}
 
-	// 3. Somebody used Airflow's Trigger DAG button.
-	if scheduler.IsManualDagRunID(in.SchedulerRunID) {
-		return pendingManualAttribution()
-	}
-
-	// 4. An earlier attempt of this operator exists.
-	if in.PreviousRun != nil {
-		if in.PreviousRun.Status == scheduler.StateRetry {
-			// The scheduler retried it. Carry the earlier attempt's verdict forward.
-			return inheritedAttribution(in.PreviousRun)
-		}
-		// The previous attempt had already finished, so something outside the scheduler made
-		// this one happen: a task or dag run cleared in Airflow.
+	// 4. Either somebody used Airflow's Trigger DAG button, or somebody cleared an earlier
+	// attempt. Both are manual actions whose actor only Airflow's audit log knows.
+	if rerun || scheduler.IsManualDagRunID(in.SchedulerRunID) {
 		return pendingManualAttribution()
 	}
 
 	// 5. Nothing suggests otherwise; the scheduler started it on its own.
 	return scheduler.ScheduledAttribution()
+}
+
+// manualRerunOf marks an attempt that a person started on a dag run Optimus originally created.
+//
+// The link to the originating replay or backfill is kept, because it still explains why the run
+// exists at all, but the actor is deliberately not inherited: whoever re-ran it need not be
+// whoever requested it. The audit log supplies the real actor; failing that the run is recorded
+// as manual with an unidentified actor, which is honest, rather than naming the wrong person.
+func manualRerunOf(provenance scheduler.RunAttribution) scheduler.RunAttribution {
+	attribution := pendingManualAttribution()
+	attribution.ReplayID = provenance.ReplayID
+	attribution.BackfillID = provenance.BackfillID
+	return attribution
 }
 
 // Record persists the cause of a run, and where the actor is still unknown, starts a detached
@@ -261,25 +301,40 @@ func (s *RunAttributionService) attributeToReplay(ctx context.Context, in Attrib
 	}, true
 }
 
-func inheritedAttribution(previous *scheduler.OperatorRun) scheduler.RunAttribution {
-	runType := previous.RunType
-	if runType == "" {
-		runType = scheduler.RunTypeScheduled
-	}
-	triggeredBy := previous.TriggeredBy
-	if triggeredBy == "" {
-		triggeredBy = scheduler.TriggeredByScheduler
-	}
-	if runType == scheduler.RunTypeScheduled {
+// inheritedAttribution carries the previous attempt's verdict onto a scheduler retry.
+//
+// task_run and hook_run hold only the run type and actor, so the link to the originating replay
+// or backfill has to be read back from the previous attempt's trigger source row. Without that
+// the retry would record e.g. run_type=replay with a null replay_id, losing exactly the link the
+// trigger source table exists to preserve.
+func (s *RunAttributionService) inheritedAttribution(ctx context.Context, previous *scheduler.OperatorRun) scheduler.RunAttribution {
+	if previous.RunType == "" || previous.RunType == scheduler.RunTypeScheduled {
 		// A retry of an ordinary scheduled run is still just a scheduled run; nothing to link.
 		return scheduler.ScheduledAttribution()
 	}
-	return scheduler.RunAttribution{
-		RunType:     runType,
+
+	triggeredBy := previous.TriggeredBy
+	if triggeredBy == "" {
+		triggeredBy = scheduler.TriggeredByUnidentified
+	}
+	attribution := scheduler.RunAttribution{
+		RunType:     previous.RunType,
 		TriggeredBy: triggeredBy,
 		SourceType:  scheduler.SourceTypeManual,
 		Attribution: scheduler.AttributionInherited,
 	}
+
+	previousSource, err := s.repo.GetTriggerSourceByOperatorRunID(ctx, previous.ID)
+	if err != nil {
+		if !errors.IsErrorType(err, errors.ErrNotFound) {
+			s.l.Error("run attribution: unable to read trigger source of previous attempt %s: %s", previous.ID, err)
+		}
+		return attribution
+	}
+	attribution.SourceType = previousSource.Attribution.SourceType
+	attribution.ReplayID = previousSource.Attribution.ReplayID
+	attribution.BackfillID = previousSource.Attribution.BackfillID
+	return attribution
 }
 
 // pendingManualAttribution marks a run as manual with the actor not yet established. If
@@ -295,13 +350,17 @@ func pendingManualAttribution() scheduler.RunAttribution {
 }
 
 // resolveDetached runs the Airflow audit lookup outside the caller's request.
+//
+// The bound here is on goroutines, not on work. Concurrency against Airflow is limited separately,
+// inside the singleflight closure in resolve, so that the waiters collapsed onto a shared lookup do
+// not consume Airflow slots. Bounding both here would mean one cleared dag run burned a slot per
+// task and shed the rest — which is precisely the case singleflight exists to make cheap.
 func (s *RunAttributionService) resolveDetached(parent context.Context, in AttributionInput, triggerSourceID, operatorRunID uuid.UUID) {
-	select {
-	case s.sem <- struct{}{}:
-	default:
-		// Shed rather than block event ingestion or grow goroutines without bound. The row
+	if inFlight := s.inFlight.Add(1); inFlight > int64(s.maxPending()) {
+		s.inFlight.Add(-1)
+		// Shed rather than grow memory without bound during a prolonged Airflow outage. The row
 		// stays as a manual run with an unresolved actor.
-		s.l.Warn("run attribution: resolver saturated, leaving %s unresolved", operatorRunID)
+		s.l.Warn("run attribution: %d resolutions already in flight, leaving %s unresolved", inFlight-1, operatorRunID)
 		runAttributionMetric.WithLabelValues(scheduler.RunTypeManual.String(), "shed").Inc()
 		return
 	}
@@ -310,7 +369,7 @@ func (s *RunAttributionService) resolveDetached(parent context.Context, in Attri
 	}
 
 	go func() {
-		defer func() { <-s.sem }()
+		defer s.inFlight.Add(-1)
 		if s.resolved != nil {
 			defer s.resolved.Done()
 		}
@@ -338,6 +397,16 @@ func (s *RunAttributionService) resolve(ctx context.Context, in AttributionInput
 	// collapses the concurrent lookups; every caller then updates only its own row.
 	key := in.Tenant.ProjectName().String() + "/" + in.JobName.String() + "/" + in.SchedulerRunID
 	result, err, _ := s.group.Do(key, func() (any, error) {
+		// Only the one goroutine that actually reaches Airflow takes a slot; everybody collapsed
+		// onto this call is waiting on singleflight and holds nothing. So one cleared dag run costs
+		// one slot however many tasks it has.
+		select {
+		case s.sem <- struct{}{}:
+		case <-ctx.Done():
+			return scheduler.RunAttribution{}, ctx.Err()
+		}
+		defer func() { <-s.sem }()
+
 		var resolved scheduler.RunAttribution
 		err := utils.Retry(s.l, s.retryMax(), int64(s.conf.ResolveRetryBackoffMs), func() error {
 			attempts++
@@ -365,32 +434,53 @@ func (s *RunAttributionService) resolve(ctx context.Context, in AttributionInput
 	runAttributionMetric.WithLabelValues(attribution.RunType.String(), attribution.Attribution).Inc()
 }
 
-// resolveFromAudit asks Airflow who acted. It tries an exact match on the dag run first, then
-// falls back to correlating by time against the bulk actions that record no dag run at all.
+// resolveFromAudit asks Airflow who acted. It tries an exact match on the dag run first, and only
+// where a bulk action could plausibly be responsible does it fall back to correlating by time.
 func (s *RunAttributionService) resolveFromAudit(ctx context.Context, in AttributionInput) (scheduler.RunAttribution, error) {
 	after, before := s.auditWindow(in.StartTime)
 
-	if in.SchedulerRunID != "" {
-		events, err := s.auditGetter.GetEventLogs(ctx, scheduler.AuditEventFilter{
-			Tenant:         in.Tenant,
-			DagID:          in.JobName.String(),
-			RunID:          in.SchedulerRunID,
-			After:          after,
-			Before:         before,
-			IncludedEvents: exactMatchEvents,
-			Limit:          s.auditPageLimit(),
-		})
-		if err != nil {
-			return scheduler.RunAttribution{}, err
-		}
-		if event := s.pickLatestActionable(events); event != nil {
-			return auditAttribution(event, scheduler.AttributionAuditRunID), nil
-		}
+	// One dag-scoped query answers both the run-exact and the run-agnostic case, because a query
+	// filtered only by dag_id returns a superset of what adding run_id would. Filtering on run_id
+	// server-side would be actively harmful: Airflow leaves run_id NULL for a plain Trigger DAG
+	// (the Run Id form field is optional) and for REST clears that pass it in a JSON body, so those
+	// rows — the common ones — would be dropped before we ever saw them. It would not even be
+	// faster: the log table is indexed on dag_id, dttm and event, but not on run_id.
+	//
+	// The window here is deliberately generous, since its job is to keep the query indexed rather
+	// than to decide which run an event belongs to. That decision is made below, per candidate.
+	events, err := s.auditGetter.GetEventLogs(ctx, scheduler.AuditEventFilter{
+		Tenant:         in.Tenant,
+		DagID:          in.JobName.String(),
+		After:          in.StartTime.Add(-s.identifyLookback()),
+		Before:         before,
+		IncludedEvents: exactMatchEvents,
+		Limit:          s.auditPageLimit(),
+	})
+	if err != nil {
+		return scheduler.RunAttribution{}, err
 	}
 
-	// Nothing named this dag run. The bulk clear pages log no dag_id or run_id at all, so all
-	// that is left is timing.
-	events, err := s.auditGetter.GetEventLogs(ctx, scheduler.AuditEventFilter{
+	// A row naming this exact dag run is conclusive however old it is.
+	if event := s.pickLatestActionable(namingRun(events, in.SchedulerRunID)); event != nil {
+		return auditAttribution(event, scheduler.AttributionAuditRunID), nil
+	}
+
+	// A row naming the DAG but no run could be about any run of it, so here the tight correlation
+	// window is what ties it to this attempt.
+	if event := s.pickLatestActionable(runAgnosticSince(events, after)); event != nil {
+		return auditAttribution(event, scheduler.AttributionAuditDagID), nil
+	}
+
+	// Only a re-run of an earlier attempt can have come from one of Airflow's bulk list-page
+	// actions, which are the only ones that record no dag_id at all. Anything that touched this DAG
+	// would have appeared above, so falling through for a first attempt would let an unrelated bulk
+	// clear of some other DAG, by somebody with no connection to this run, supply the actor.
+	if in.PreviousRun == nil {
+		return unidentifiedManual(), nil
+	}
+
+	// The bulk clear pages log no dag_id or run_id at all, so all that is left is timing.
+	events, err = s.auditGetter.GetEventLogs(ctx, scheduler.AuditEventFilter{
 		Tenant:         in.Tenant,
 		After:          after,
 		Before:         before,
@@ -401,6 +491,43 @@ func (s *RunAttributionService) resolveFromAudit(ctx context.Context, in Attribu
 		return scheduler.RunAttribution{}, err
 	}
 	return s.correlateByTime(events), nil
+}
+
+// unidentifiedManual records a run as manual with the actor established as unknown, which is a
+// terminal answer rather than the provisional pending state.
+func unidentifiedManual() scheduler.RunAttribution {
+	attribution := pendingManualAttribution()
+	attribution.Attribution = scheduler.AttributionUnidentified
+	return attribution
+}
+
+// namingRun keeps only rows that explicitly name this dag run. Such a row is conclusive: nothing
+// else could have produced it.
+func namingRun(events []*scheduler.AuditEvent, schedulerRunID string) []*scheduler.AuditEvent {
+	if schedulerRunID == "" {
+		return nil
+	}
+	var matched []*scheduler.AuditEvent
+	for _, event := range events {
+		if event.RunID == schedulerRunID {
+			matched = append(matched, event)
+		}
+	}
+	return matched
+}
+
+// runAgnosticSince keeps rows that name the DAG but no run, and are recent enough to plausibly be
+// about this attempt. A row naming some *other* run is discarded outright — it has already told us
+// it is about something else.
+func runAgnosticSince(events []*scheduler.AuditEvent, after time.Time) []*scheduler.AuditEvent {
+	var matched []*scheduler.AuditEvent
+	for _, event := range events {
+		if event.RunID != "" || event.When.Before(after) {
+			continue
+		}
+		matched = append(matched, event)
+	}
+	return matched
 }
 
 // pickLatestActionable returns the most recent audit row that names a real actor. Events are
@@ -420,8 +547,7 @@ func (s *RunAttributionService) pickLatestActionable(events []*scheduler.AuditEv
 // and it is recorded as one: a single unambiguous actor is accepted, anything else is left
 // unidentified. The candidate rows are kept on the record either way so a human can adjudicate.
 func (s *RunAttributionService) correlateByTime(events []*scheduler.AuditEvent) scheduler.RunAttribution {
-	attribution := pendingManualAttribution()
-	attribution.Attribution = scheduler.AttributionUnidentified
+	attribution := unidentifiedManual()
 
 	owners := map[string]bool{}
 	var candidates []*scheduler.AuditEvent
@@ -491,6 +617,25 @@ func (s *RunAttributionService) retryMax() int {
 		return s.conf.ResolveRetryMax
 	}
 	return 1
+}
+
+// identifyLookback bounds the dag-scoped query so it stays indexed on dttm. It is generous on
+// purpose: its job is query efficiency, not deciding which run an event belongs to. Narrowing it to
+// the correlation window would hide the row that explains the attempt — a Trigger DAG action can
+// precede its tasks by a long queue wait — and a hidden row means a weaker guess wins instead.
+func (s *RunAttributionService) identifyLookback() time.Duration {
+	if s.conf.IdentifyLookbackHours > 0 {
+		return time.Duration(s.conf.IdentifyLookbackHours) * time.Hour
+	}
+	return defaultIdentifyLookback
+}
+
+// maxPending bounds resolver goroutines. Separate from sem, which bounds Airflow calls.
+func (s *RunAttributionService) maxPending() int {
+	if s.conf.MaxPendingResolves > 0 {
+		return s.conf.MaxPendingResolves
+	}
+	return defaultMaxPending
 }
 
 func (s *RunAttributionService) auditPageLimit() int {

--- a/core/scheduler/service/run_attribution_service_test.go
+++ b/core/scheduler/service/run_attribution_service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/goto/salt/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/goto/optimus/config"
 	"github.com/goto/optimus/core/scheduler"
@@ -70,6 +71,86 @@ func TestRunAttributionService(t *testing.T) {
 			assert.Equal(t, "alice", got.TriggeredBy)
 			assert.Equal(t, scheduler.AttributionOptimusBackfill, got.Attribution)
 			assert.Equal(t, backfillID, *got.BackfillID)
+		})
+
+		t.Run("does not blame the backfill requester when somebody re-runs their backfill", func(t *testing.T) {
+			// The dag run id keeps naming the backfill forever, but Optimus never clears a backfill
+			// run, so a further attempt that is not a scheduler retry was started by a person. The
+			// link to the backfill is kept; the requester's name is not reused as the actor.
+			backfillID := uuid.New()
+			backfillRepo := new(mockBackfillAttributionGetter)
+			backfillRepo.On("GetBackfillDetails", ctx, backfillID).Return(backfillWithUser("alice"), nil)
+
+			svc := service.NewRunAttributionService(logger, conf, new(mockRunAttributionRepository),
+				noReplayMatch(), backfillRepo, new(mockAuditLogGetter))
+
+			in := baseInput()
+			in.SchedulerRunID = fmt.Sprintf("custom-backfill_%s__2026-07-20T13:00:00+00:00", backfillID)
+			in.Attempt = 2
+			in.PreviousRun = &scheduler.OperatorRun{
+				Status:      scheduler.StateSuccess,
+				RunType:     scheduler.RunTypeBackfill,
+				TriggeredBy: "alice",
+			}
+
+			got := svc.Classify(ctx, in)
+			assert.Equal(t, scheduler.RunTypeManual, got.RunType)
+			assert.NotEqual(t, "alice", got.TriggeredBy, "the backfill requester must not be blamed for someone else's clear")
+			assert.Equal(t, scheduler.TriggeredByUnidentified, got.TriggeredBy)
+			assert.True(t, got.NeedsAuditResolution(), "the real actor has to come from the audit log")
+			// Linkage survives: the run still exists because of that backfill.
+			require.NotNil(t, got.BackfillID)
+			assert.Equal(t, backfillID, *got.BackfillID)
+		})
+
+		t.Run("still attributes a scheduler retry of a backfill run to the requester", func(t *testing.T) {
+			// The counterpart to the above: a retry really is a continuation of the backfill.
+			backfillID := uuid.New()
+			repo := new(mockRunAttributionRepository)
+			repo.On("GetTriggerSourceByOperatorRunID", ctx, mock.Anything).Return(&scheduler.TriggerSource{
+				Attribution: scheduler.RunAttribution{
+					SourceType: scheduler.SourceTypeBackfill,
+					BackfillID: &backfillID,
+				},
+			}, nil)
+
+			svc := service.NewRunAttributionService(logger, conf, repo, noReplayMatch(),
+				new(mockBackfillAttributionGetter), new(mockAuditLogGetter))
+
+			in := baseInput()
+			in.SchedulerRunID = fmt.Sprintf("custom-backfill_%s__2026-07-20T13:00:00+00:00", backfillID)
+			in.PreviousRun = &scheduler.OperatorRun{
+				ID: uuid.New(), Status: scheduler.StateRetry,
+				RunType: scheduler.RunTypeBackfill, TriggeredBy: "alice",
+			}
+
+			got := svc.Classify(ctx, in)
+			assert.Equal(t, scheduler.RunTypeBackfill, got.RunType)
+			assert.Equal(t, "alice", got.TriggeredBy)
+			assert.Equal(t, scheduler.AttributionInherited, got.Attribution)
+			// Inheritance must carry the link across, not just the run type and actor.
+			require.NotNil(t, got.BackfillID)
+			assert.Equal(t, backfillID, *got.BackfillID)
+			assert.Equal(t, scheduler.SourceTypeBackfill, got.SourceType)
+		})
+
+		t.Run("does not blame the replay requester once their replay has finished", func(t *testing.T) {
+			// The replay lookup only matches non-terminal replays, so a later manual clear of a run
+			// the replay produced falls through to the audit log rather than reusing their name.
+			svc := newClassifyOnlyService(logger, conf) // no in-flight replay matches
+
+			in := baseInput()
+			in.SchedulerRunID = "scheduled__2026-07-20T12:00:00+00:00"
+			in.PreviousRun = &scheduler.OperatorRun{
+				Status:      scheduler.StateSuccess,
+				RunType:     scheduler.RunTypeReplay,
+				TriggeredBy: "bob",
+			}
+
+			got := svc.Classify(ctx, in)
+			assert.Equal(t, scheduler.RunTypeManual, got.RunType)
+			assert.NotEqual(t, "bob", got.TriggeredBy)
+			assert.True(t, got.NeedsAuditResolution())
 		})
 
 		t.Run("attributes a replay even when the dag run id looks scheduled", func(t *testing.T) {
@@ -257,7 +338,8 @@ func TestRunAttributionService(t *testing.T) {
 
 			auditGetter := new(mockAuditLogGetter)
 			auditGetter.On("GetEventLogs", mock.Anything, mock.MatchedBy(func(f scheduler.AuditEventFilter) bool {
-				return f.RunID == "manual__2026-07-20T13:00:00+00:00" && f.DagID == jobName.String()
+				// One dag-scoped query; run_id is a discriminator applied in code, not a filter.
+				return f.DagID == jobName.String() && f.RunID == ""
 			})).Return([]*scheduler.AuditEvent{{
 				EventLogID: 42, Event: "dagrun_clear", Owner: "dave",
 				DagID: jobName.String(), RunID: "manual__2026-07-20T13:00:00+00:00",
@@ -323,11 +405,12 @@ func TestRunAttributionService(t *testing.T) {
 			const taskCount = 8
 			var auditCalls atomic.Int32
 
+			var resolvedRows atomic.Int32
 			repo := new(mockRunAttributionRepository)
 			repo.On("InsertTriggerSource", mock.Anything, mock.Anything).Return(uuid.New(), nil)
 			repo.On("UpdateTriggerSourceResolution", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.MatchedBy(func(a scheduler.RunAttribution) bool {
 				return a.TriggeredBy == "frank"
-			}), mock.Anything).Return(nil)
+			}), mock.Anything).Run(func(mock.Arguments) { resolvedRows.Add(1) }).Return(nil)
 
 			gate := make(chan struct{})
 			auditGetter := new(mockAuditLogGetter)
@@ -342,8 +425,11 @@ func TestRunAttributionService(t *testing.T) {
 					DagID: jobName.String(), RunID: "manual__2026-07-20T13:00:00+00:00",
 				}}, nil)
 
+			// Deliberately one Airflow slot for eight tasks: with the semaphore acquired inside the
+			// singleflight closure, the seven waiters hold nothing and all eight rows still resolve.
+			// This previously required MaxConcurrentResolves == taskCount, which was the symptom.
 			conf := conf
-			conf.MaxConcurrentResolves = taskCount
+			conf.MaxConcurrentResolves = 1
 			svc := service.NewRunAttributionService(logger, conf, repo, noReplayMatch(),
 				new(mockBackfillAttributionGetter), auditGetter)
 			done := svc.WaitGroupForTest()
@@ -361,6 +447,8 @@ func TestRunAttributionService(t *testing.T) {
 			done.Wait()
 
 			assert.Equal(t, int32(1), auditCalls.Load(), "one dag run should mean one audit query")
+			assert.Equal(t, int32(taskCount), resolvedRows.Load(),
+				"every task of the cleared dag run must be resolved, not just as many as there are Airflow slots")
 		})
 
 		t.Run("correlates by time when the audit rows carry no dag context", func(t *testing.T) {
@@ -377,11 +465,11 @@ func TestRunAttributionService(t *testing.T) {
 			auditGetter := new(mockAuditLogGetter)
 			// Exact match on the dag run finds nothing.
 			auditGetter.On("GetEventLogs", mock.Anything, mock.MatchedBy(func(f scheduler.AuditEventFilter) bool {
-				return f.RunID != ""
+				return f.DagID != ""
 			})).Return([]*scheduler.AuditEvent{}, nil)
 			// The time-correlated query finds one bulk clear, plus noise that must be ignored.
 			auditGetter.On("GetEventLogs", mock.Anything, mock.MatchedBy(func(f scheduler.AuditEventFilter) bool {
-				return f.RunID == ""
+				return f.DagID == ""
 			})).Return([]*scheduler.AuditEvent{
 				{EventLogID: 11, Event: "action_clear", Owner: "grace", When: startTime.Add(-2 * time.Minute)},
 				{EventLogID: 10, Event: "action_clear", Owner: "optimus", When: startTime.Add(-3 * time.Minute)},
@@ -392,8 +480,11 @@ func TestRunAttributionService(t *testing.T) {
 				new(mockBackfillAttributionGetter), auditGetter)
 			done := svc.WaitGroupForTest()
 
+			// A bulk clear re-runs an attempt that already finished, which is the only situation
+			// time correlation is allowed to explain.
 			in := baseInput()
-			in.SchedulerRunID = "manual__2026-07-20T13:00:00+00:00"
+			in.SchedulerRunID = "scheduled__2026-07-20T12:00:00+00:00"
+			in.PreviousRun = &scheduler.OperatorRun{Status: scheduler.StateSuccess}
 			assert.NoError(t, svc.Record(ctx, in, operatorRunID, svc.Classify(ctx, in)))
 
 			done.Wait()
@@ -415,13 +506,98 @@ func TestRunAttributionService(t *testing.T) {
 
 			auditGetter := new(mockAuditLogGetter)
 			auditGetter.On("GetEventLogs", mock.Anything, mock.MatchedBy(func(f scheduler.AuditEventFilter) bool {
-				return f.RunID != ""
+				return f.DagID != ""
 			})).Return([]*scheduler.AuditEvent{}, nil)
 			auditGetter.On("GetEventLogs", mock.Anything, mock.MatchedBy(func(f scheduler.AuditEventFilter) bool {
-				return f.RunID == ""
+				return f.DagID == ""
 			})).Return([]*scheduler.AuditEvent{
 				{EventLogID: 21, Event: "action_clear", Owner: "ivan", When: startTime.Add(-time.Minute)},
 				{EventLogID: 20, Event: "action_clear", Owner: "judy", When: startTime.Add(-2 * time.Minute)},
+			}, nil)
+
+			svc := service.NewRunAttributionService(logger, conf, repo, noReplayMatch(),
+				new(mockBackfillAttributionGetter), auditGetter)
+			done := svc.WaitGroupForTest()
+
+			in := baseInput()
+			in.SchedulerRunID = "scheduled__2026-07-20T12:00:00+00:00"
+			in.PreviousRun = &scheduler.OperatorRun{Status: scheduler.StateSuccess}
+			assert.NoError(t, svc.Record(ctx, in, operatorRunID, svc.Classify(ctx, in)))
+
+			done.Wait()
+			repo.AssertExpectations(t)
+		})
+
+		t.Run("never blames a bulk clear for a manual trigger it cannot explain", func(t *testing.T) {
+			// A manual__ dag run came from the Trigger DAG view, which always records dag_id. So if
+			// the exact query misses — audit lag, log retention, a trigger older than the window —
+			// time correlation cannot legitimately explain it, and must not name whoever happened to
+			// bulk-clear an unrelated DAG in the same window.
+			operatorRunID := uuid.New()
+			triggerSourceID := uuid.New()
+
+			repo := new(mockRunAttributionRepository)
+			repo.On("InsertTriggerSource", mock.Anything, mock.Anything).Return(triggerSourceID, nil)
+			repo.On("UpdateTriggerSourceResolution", mock.Anything, triggerSourceID, mock.Anything, mock.Anything,
+				mock.MatchedBy(func(a scheduler.RunAttribution) bool {
+					return a.TriggeredBy == scheduler.TriggeredByUnidentified &&
+						a.Attribution == scheduler.AttributionUnidentified
+				}), mock.Anything).Return(nil)
+
+			auditGetter := new(mockAuditLogGetter)
+			// The exact query finds nothing for this dag run...
+			auditGetter.On("GetEventLogs", mock.Anything, mock.MatchedBy(func(f scheduler.AuditEventFilter) bool {
+				return f.DagID != ""
+			})).Return([]*scheduler.AuditEvent{}, nil)
+			// ...and the time-correlated query must never be issued at all. An expectation is set so
+			// that if it is, the returned actor would be "mallory" and the assertion above fails.
+			auditGetter.On("GetEventLogs", mock.Anything, mock.MatchedBy(func(f scheduler.AuditEventFilter) bool {
+				return f.DagID == ""
+			})).Return([]*scheduler.AuditEvent{
+				{EventLogID: 99, Event: "action_clear", Owner: "mallory", When: startTime.Add(-time.Minute)},
+			}, nil).Maybe()
+
+			svc := service.NewRunAttributionService(logger, conf, repo, noReplayMatch(),
+				new(mockBackfillAttributionGetter), auditGetter)
+			done := svc.WaitGroupForTest()
+
+			in := baseInput()
+			in.SchedulerRunID = "manual__2026-07-20T13:00:00+00:00" // first attempt, no PreviousRun
+			assert.NoError(t, svc.Record(ctx, in, operatorRunID, svc.Classify(ctx, in)))
+
+			done.Wait()
+			repo.AssertExpectations(t)
+			auditGetter.AssertNotCalled(t, "GetEventLogs", mock.Anything, mock.MatchedBy(func(f scheduler.AuditEventFilter) bool {
+				return f.DagID == ""
+			}))
+		})
+
+		t.Run("attributes a plain trigger whose audit row carries no run id", func(t *testing.T) {
+			// The Trigger DAG form's Run Id field is optional, so the common case logs dag_id with
+			// run_id NULL. Filtering the query on run_id dropped exactly these rows, which left the
+			// most frequent manual action unattributed.
+			operatorRunID := uuid.New()
+			triggerSourceID := uuid.New()
+
+			repo := new(mockRunAttributionRepository)
+			repo.On("InsertTriggerSource", mock.Anything, mock.Anything).Return(triggerSourceID, nil)
+			repo.On("UpdateTriggerSourceResolution", mock.Anything, triggerSourceID, mock.Anything, mock.Anything,
+				mock.MatchedBy(func(a scheduler.RunAttribution) bool {
+					return a.TriggeredBy == "nina" && a.Attribution == scheduler.AttributionAuditDagID
+				}), mock.Anything).Return(nil)
+
+			auditGetter := new(mockAuditLogGetter)
+			auditGetter.On("GetEventLogs", mock.Anything, mock.Anything).Return([]*scheduler.AuditEvent{
+				// Names the DAG, no run id — and a row about a different run of the same DAG that
+				// must be discarded rather than picked as the newest.
+				{
+					EventLogID: 31, Event: "trigger", Owner: "nina", DagID: jobName.String(),
+					When: startTime.Add(-2 * time.Minute),
+				},
+				{
+					EventLogID: 30, Event: "dagrun_clear", Owner: "otto", DagID: jobName.String(),
+					RunID: "scheduled__2020-01-01T00:00:00+00:00", When: startTime.Add(-time.Minute),
+				},
 			}, nil)
 
 			svc := service.NewRunAttributionService(logger, conf, repo, noReplayMatch(),
@@ -433,6 +609,85 @@ func TestRunAttributionService(t *testing.T) {
 			assert.NoError(t, svc.Record(ctx, in, operatorRunID, svc.Classify(ctx, in)))
 
 			done.Wait()
+			repo.AssertExpectations(t)
+		})
+
+		t.Run("ignores a run-agnostic row that is older than the correlation window", func(t *testing.T) {
+			// A row naming the DAG but not the run is only tied to this attempt by timing, so an old
+			// one must not be accepted the way an exact run_id match is.
+			operatorRunID := uuid.New()
+			triggerSourceID := uuid.New()
+
+			repo := new(mockRunAttributionRepository)
+			repo.On("InsertTriggerSource", mock.Anything, mock.Anything).Return(triggerSourceID, nil)
+			repo.On("UpdateTriggerSourceResolution", mock.Anything, triggerSourceID, mock.Anything, mock.Anything,
+				mock.MatchedBy(func(a scheduler.RunAttribution) bool {
+					return a.Attribution == scheduler.AttributionUnidentified
+				}), mock.Anything).Return(nil)
+
+			auditGetter := new(mockAuditLogGetter)
+			auditGetter.On("GetEventLogs", mock.Anything, mock.Anything).Return([]*scheduler.AuditEvent{
+				// Inside identify_lookback_hours (24h) so the query returns it, but well outside
+				// audit_lookback_minutes (30m) so it cannot be tied to this attempt.
+				{
+					EventLogID: 41, Event: "trigger", Owner: "pete", DagID: jobName.String(),
+					When: startTime.Add(-6 * time.Hour),
+				},
+			}, nil)
+
+			svc := service.NewRunAttributionService(logger, conf, repo, noReplayMatch(),
+				new(mockBackfillAttributionGetter), auditGetter)
+			done := svc.WaitGroupForTest()
+
+			in := baseInput()
+			in.SchedulerRunID = "manual__2026-07-20T13:00:00+00:00"
+			assert.NoError(t, svc.Record(ctx, in, operatorRunID, svc.Classify(ctx, in)))
+
+			done.Wait()
+			repo.AssertExpectations(t)
+		})
+
+		t.Run("still matches a trigger far older than the correlation window", func(t *testing.T) {
+			// A Trigger DAG action can precede its tasks by a long queue wait. The dag-scoped query
+			// is windowed generously so the row is still returned, and a row naming this exact dag
+			// run is then accepted regardless of age. Narrowing to the correlation window would hide
+			// it and let a weaker guess win instead.
+			operatorRunID := uuid.New()
+			triggerSourceID := uuid.New()
+
+			repo := new(mockRunAttributionRepository)
+			repo.On("InsertTriggerSource", mock.Anything, mock.Anything).Return(triggerSourceID, nil)
+			repo.On("UpdateTriggerSourceResolution", mock.Anything, triggerSourceID, mock.Anything, mock.Anything,
+				mock.MatchedBy(func(a scheduler.RunAttribution) bool {
+					return a.TriggeredBy == "dave" && a.Attribution == scheduler.AttributionAuditRunID
+				}), mock.Anything).Return(nil)
+
+			var exactFilter scheduler.AuditEventFilter
+			auditGetter := new(mockAuditLogGetter)
+			auditGetter.On("GetEventLogs", mock.Anything, mock.Anything).
+				Run(func(args mock.Arguments) { exactFilter, _ = args.Get(1).(scheduler.AuditEventFilter) }).
+				Return([]*scheduler.AuditEvent{{
+					EventLogID: 7, Event: "trigger", Owner: "dave",
+					DagID: jobName.String(), RunID: "manual__2026-07-20T13:00:00+00:00",
+					// Far older than audit_lookback_minutes (30m), inside identify_lookback_hours (24h).
+					When: startTime.Add(-6 * time.Hour),
+				}}, nil)
+
+			svc := service.NewRunAttributionService(logger, conf, repo, noReplayMatch(),
+				new(mockBackfillAttributionGetter), auditGetter)
+			done := svc.WaitGroupForTest()
+
+			in := baseInput()
+			in.SchedulerRunID = "manual__2026-07-20T13:00:00+00:00"
+			assert.NoError(t, svc.Record(ctx, in, operatorRunID, svc.Classify(ctx, in)))
+
+			done.Wait()
+			// Bounded, so the query stays indexed on the log table's timestamp, but far wider than
+			// the correlation window that decides which run a run-agnostic row belongs to.
+			assert.Equal(t, startTime.Add(-24*time.Hour), exactFilter.After)
+			assert.Equal(t, startTime, exactFilter.Before)
+			assert.Equal(t, jobName.String(), exactFilter.DagID, "dag_id is always supplied when we have one")
+			assert.Empty(t, exactFilter.RunID, "run_id is a discriminator applied in code, not a filter")
 			repo.AssertExpectations(t)
 		})
 
@@ -472,35 +727,28 @@ func TestRunAttributionService(t *testing.T) {
 			const shedRunID = "manual__2026-07-20T14:00:00+00:00"
 
 			var (
-				mu         sync.Mutex
-				queriedFor []string
-				block      = make(chan struct{})
+				mu        sync.Mutex
+				callCount int
+				block     = make(chan struct{})
 			)
 			auditGetter := new(mockAuditLogGetter)
 			auditGetter.On("GetEventLogs", mock.Anything, mock.Anything).
-				Run(func(args mock.Arguments) {
-					filter, _ := args.Get(1).(scheduler.AuditEventFilter)
+				Run(func(mock.Arguments) {
 					mu.Lock()
-					queriedFor = append(queriedFor, filter.RunID)
+					callCount++
 					mu.Unlock()
 					<-block
 				}).
 				Return([]*scheduler.AuditEvent{}, nil)
-			// A single resolution issues two queries, an exact one on the dag run then a
-			// time-correlated one, so count dag runs asked about rather than calls made.
-			askedAbout := func(runID string) bool {
+			calls := func() int {
 				mu.Lock()
 				defer mu.Unlock()
-				for _, seen := range queriedFor {
-					if seen == runID {
-						return true
-					}
-				}
-				return false
+				return callCount
 			}
 
+			// One resolver goroutine allowed, so the second Record must shed rather than wait.
 			conf := conf
-			conf.MaxConcurrentResolves = 1
+			conf.MaxPendingResolves = 1
 			svc := service.NewRunAttributionService(logger, conf, repo, noReplayMatch(),
 				new(mockBackfillAttributionGetter), auditGetter)
 			done := svc.WaitGroupForTest()
@@ -509,7 +757,7 @@ func TestRunAttributionService(t *testing.T) {
 			first := baseInput()
 			first.SchedulerRunID = occupyingRunID
 			assert.NoError(t, svc.Record(ctx, first, uuid.New(), svc.Classify(ctx, first)))
-			assert.Eventually(t, func() bool { return askedAbout(occupyingRunID) }, 2*time.Second, 10*time.Millisecond)
+			assert.Eventually(t, func() bool { return calls() == 1 }, 2*time.Second, 10*time.Millisecond)
 
 			// This one must return immediately rather than waiting for the slot.
 			returned := make(chan struct{})
@@ -528,7 +776,9 @@ func TestRunAttributionService(t *testing.T) {
 
 			close(block)
 			done.Wait()
-			assert.False(t, askedAbout(shedRunID), "the shed resolution should not have queried airflow")
+			// The two Records use different dag run ids, so singleflight would not merge them: a
+			// second query would mean the second resolution ran instead of being shed.
+			assert.Equal(t, 1, calls(), "the shed resolution should not have queried airflow")
 		})
 
 		t.Run("survives a panic in the resolver", func(t *testing.T) {
@@ -584,6 +834,21 @@ func (m *mockRunAttributionRepository) InsertTriggerSource(ctx context.Context, 
 		return uuid.Nil, args.Error(1)
 	}
 	return args.Get(0).(uuid.UUID), args.Error(1)
+}
+
+// GetTriggerSourceByOperatorRunID is only consulted on the scheduler-retry path, so tests that
+// do not exercise inheritance are not obliged to expect it.
+func (m *mockRunAttributionRepository) GetTriggerSourceByOperatorRunID(ctx context.Context, operatorRunID uuid.UUID) (*scheduler.TriggerSource, error) {
+	for _, expected := range m.ExpectedCalls {
+		if expected.Method == "GetTriggerSourceByOperatorRunID" {
+			args := m.Called(ctx, operatorRunID)
+			if args.Get(0) == nil {
+				return nil, args.Error(1)
+			}
+			return args.Get(0).(*scheduler.TriggerSource), args.Error(1)
+		}
+	}
+	return nil, errors.NotFound(scheduler.EntityRunAttribution, "no trigger source")
 }
 
 func (m *mockRunAttributionRepository) UpdateTriggerSourceResolution(ctx context.Context, triggerSourceID uuid.UUID,

--- a/core/scheduler/service/run_attribution_service_test.go
+++ b/core/scheduler/service/run_attribution_service_test.go
@@ -1,0 +1,626 @@
+package service_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/goto/salt/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/goto/optimus/config"
+	"github.com/goto/optimus/core/scheduler"
+	"github.com/goto/optimus/core/scheduler/service"
+	"github.com/goto/optimus/core/tenant"
+	"github.com/goto/optimus/internal/errors"
+)
+
+func TestRunAttributionService(t *testing.T) {
+	logger := log.NewNoop()
+	ctx := context.Background()
+	tnnt, _ := tenant.NewTenant("test-proj", "test-ns")
+	jobName := scheduler.JobName("a-job")
+	jobRunID := uuid.New()
+	scheduledAt := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	startTime := time.Date(2026, 7, 20, 13, 0, 0, 0, time.UTC)
+
+	baseInput := func() service.AttributionInput {
+		return service.AttributionInput{
+			Tenant:       tnnt,
+			JobName:      jobName,
+			OperatorName: "a-job",
+			OperatorType: scheduler.OperatorTask,
+			JobRunID:     jobRunID,
+			ScheduledAt:  scheduledAt,
+			Attempt:      1,
+			StartTime:    startTime,
+		}
+	}
+
+	// Retry count of 1 so a failing test fails fast rather than backing off three times.
+	conf := config.RunAttributionConfig{
+		AuditResolutionEnabled: true,
+		MaxConcurrentResolves:  4,
+		ResolveRetryMax:        1,
+		ResolveTimeoutSeconds:  5,
+		AuditLookbackMinutes:   30,
+		ServiceAccountOwners:   []string{"optimus"},
+	}
+
+	t.Run("Classify", func(t *testing.T) {
+		t.Run("attributes an optimus custom backfill from the dag run id", func(t *testing.T) {
+			backfillID := uuid.New()
+			backfillRepo := new(mockBackfillAttributionGetter)
+			backfillRepo.On("GetBackfillDetails", ctx, backfillID).Return(backfillWithUser("alice"), nil)
+			defer backfillRepo.AssertExpectations(t)
+
+			svc := service.NewRunAttributionService(logger, conf, new(mockRunAttributionRepository),
+				noReplayMatch(), backfillRepo, new(mockAuditLogGetter))
+
+			in := baseInput()
+			in.SchedulerRunID = fmt.Sprintf("custom-backfill_%s__2026-07-20T13:00:00+00:00", backfillID)
+
+			got := svc.Classify(ctx, in)
+			assert.Equal(t, scheduler.RunTypeBackfill, got.RunType)
+			assert.Equal(t, "alice", got.TriggeredBy)
+			assert.Equal(t, scheduler.AttributionOptimusBackfill, got.Attribution)
+			assert.Equal(t, backfillID, *got.BackfillID)
+		})
+
+		t.Run("attributes a replay even when the dag run id looks scheduled", func(t *testing.T) {
+			// A replay of an existing run clears it in place, so Airflow's run id keeps its
+			// scheduled prefix. This is the case that must not be mistaken for a manual clear.
+			replayID := uuid.New()
+			replayRepo := new(mockReplayAttributionGetter)
+			replayRepo.On("GetReplayAttributionByScheduledAt", ctx, tnnt, jobName, scheduledAt).
+				Return(replayID, "bob", nil)
+			defer replayRepo.AssertExpectations(t)
+
+			svc := service.NewRunAttributionService(logger, conf, new(mockRunAttributionRepository),
+				replayRepo, new(mockBackfillAttributionGetter), new(mockAuditLogGetter))
+
+			in := baseInput()
+			in.SchedulerRunID = "scheduled__2026-07-20T12:00:00+00:00"
+			// A finished previous attempt would otherwise read as a manual clear.
+			in.PreviousRun = &scheduler.OperatorRun{Status: scheduler.StateFailed}
+
+			got := svc.Classify(ctx, in)
+			assert.Equal(t, scheduler.RunTypeReplay, got.RunType)
+			assert.Equal(t, "bob", got.TriggeredBy)
+			assert.Equal(t, scheduler.AttributionOptimusReplay, got.Attribution)
+			assert.Equal(t, replayID, *got.ReplayID)
+		})
+
+		t.Run("marks an airflow manual trigger for audit resolution", func(t *testing.T) {
+			svc := newClassifyOnlyService(logger, conf)
+
+			in := baseInput()
+			in.SchedulerRunID = "manual__2026-07-20T13:00:00+00:00"
+
+			got := svc.Classify(ctx, in)
+			assert.Equal(t, scheduler.RunTypeManual, got.RunType)
+			assert.Equal(t, scheduler.TriggeredByUnidentified, got.TriggeredBy)
+			assert.True(t, got.NeedsAuditResolution())
+		})
+
+		t.Run("does not treat a single underscore manual prefix as a manual run", func(t *testing.T) {
+			// Airflow generates manual__<iso>; a single underscore is not a run it produces.
+			svc := newClassifyOnlyService(logger, conf)
+
+			in := baseInput()
+			in.SchedulerRunID = "manual_2026-07-20T13:00:00+00:00"
+
+			assert.Equal(t, scheduler.RunTypeScheduled, svc.Classify(ctx, in).RunType)
+		})
+
+		t.Run("inherits from the previous attempt when the scheduler retried it", func(t *testing.T) {
+			svc := newClassifyOnlyService(logger, conf)
+
+			in := baseInput()
+			in.SchedulerRunID = "scheduled__2026-07-20T12:00:00+00:00"
+			in.Attempt = 3
+			in.PreviousRun = &scheduler.OperatorRun{
+				Status:      scheduler.StateRetry,
+				RunType:     scheduler.RunTypeManual,
+				TriggeredBy: "carol",
+			}
+
+			got := svc.Classify(ctx, in)
+			assert.Equal(t, scheduler.RunTypeManual, got.RunType)
+			assert.Equal(t, "carol", got.TriggeredBy)
+			assert.Equal(t, scheduler.AttributionInherited, got.Attribution)
+			assert.False(t, got.NeedsAuditResolution())
+		})
+
+		t.Run("keeps a retry of a scheduled run scheduled", func(t *testing.T) {
+			svc := newClassifyOnlyService(logger, conf)
+
+			in := baseInput()
+			in.SchedulerRunID = "scheduled__2026-07-20T12:00:00+00:00"
+			in.PreviousRun = &scheduler.OperatorRun{
+				Status:      scheduler.StateRetry,
+				RunType:     scheduler.RunTypeScheduled,
+				TriggeredBy: scheduler.TriggeredByScheduler,
+			}
+
+			got := svc.Classify(ctx, in)
+			assert.Equal(t, scheduler.RunTypeScheduled, got.RunType)
+			assert.True(t, got.IsScheduled())
+		})
+
+		t.Run("treats a finished previous attempt as a manual clear", func(t *testing.T) {
+			for _, previousState := range []scheduler.State{scheduler.StateSuccess, scheduler.StateFailed, scheduler.StateRunning} {
+				svc := newClassifyOnlyService(logger, conf)
+
+				in := baseInput()
+				in.SchedulerRunID = "scheduled__2026-07-20T12:00:00+00:00"
+				in.PreviousRun = &scheduler.OperatorRun{Status: previousState}
+
+				got := svc.Classify(ctx, in)
+				assert.Equal(t, scheduler.RunTypeManual, got.RunType, "previous state %s", previousState)
+				assert.True(t, got.NeedsAuditResolution(), "previous state %s", previousState)
+			}
+		})
+
+		t.Run("defaults to scheduled when nothing suggests otherwise", func(t *testing.T) {
+			svc := newClassifyOnlyService(logger, conf)
+
+			in := baseInput()
+			in.SchedulerRunID = "scheduled__2026-07-20T12:00:00+00:00"
+
+			got := svc.Classify(ctx, in)
+			assert.Equal(t, scheduler.RunTypeScheduled, got.RunType)
+			assert.Equal(t, scheduler.TriggeredByScheduler, got.TriggeredBy)
+			assert.True(t, got.IsScheduled())
+		})
+	})
+
+	t.Run("Record", func(t *testing.T) {
+		t.Run("records a manual run but never calls airflow when audit resolution is off", func(t *testing.T) {
+			// The kill switch: attribution to Optimus's own replay and backfill keeps working, and a
+			// manual run is still recorded as manual, but its actor is left unidentified rather than
+			// Optimus reaching out to Airflow.
+			operatorRunID := uuid.New()
+
+			repo := new(mockRunAttributionRepository)
+			repo.On("InsertTriggerSource", ctx, mock.MatchedBy(func(src *scheduler.TriggerSource) bool {
+				return src.Attribution.RunType == scheduler.RunTypeManual &&
+					src.Attribution.TriggeredBy == scheduler.TriggeredByUnidentified &&
+					src.Attribution.Attribution == scheduler.AttributionPending
+			})).Return(uuid.New(), nil)
+
+			auditGetter := new(mockAuditLogGetter)
+			defer auditGetter.AssertExpectations(t) // asserts GetEventLogs was never called
+
+			offConf := conf
+			offConf.AuditResolutionEnabled = false
+			svc := service.NewRunAttributionService(logger, offConf, repo, noReplayMatch(),
+				new(mockBackfillAttributionGetter), auditGetter)
+			done := svc.WaitGroupForTest()
+
+			in := baseInput()
+			in.SchedulerRunID = "manual__2026-07-20T13:00:00+00:00"
+			assert.NoError(t, svc.Record(ctx, in, operatorRunID, svc.Classify(ctx, in)))
+
+			done.Wait()
+			repo.AssertExpectations(t)
+		})
+
+		t.Run("still attributes an optimus backfill when audit resolution is off", func(t *testing.T) {
+			backfillID := uuid.New()
+			backfillRepo := new(mockBackfillAttributionGetter)
+			backfillRepo.On("GetBackfillDetails", ctx, backfillID).Return(backfillWithUser("alice"), nil)
+
+			offConf := conf
+			offConf.AuditResolutionEnabled = false
+			svc := service.NewRunAttributionService(logger, offConf, new(mockRunAttributionRepository),
+				noReplayMatch(), backfillRepo, new(mockAuditLogGetter))
+
+			in := baseInput()
+			in.SchedulerRunID = fmt.Sprintf("custom-backfill_%s__2026-07-20T13:00:00+00:00", backfillID)
+
+			got := svc.Classify(ctx, in)
+			assert.Equal(t, scheduler.RunTypeBackfill, got.RunType)
+			assert.Equal(t, "alice", got.TriggeredBy)
+			assert.False(t, got.NeedsAuditResolution())
+		})
+
+		t.Run("writes nothing for a scheduled run", func(t *testing.T) {
+			repo := new(mockRunAttributionRepository)
+			defer repo.AssertExpectations(t)
+
+			svc := service.NewRunAttributionService(logger, conf, repo, noReplayMatch(),
+				new(mockBackfillAttributionGetter), new(mockAuditLogGetter))
+
+			assert.NoError(t, svc.Record(ctx, baseInput(), uuid.New(), scheduler.ScheduledAttribution()))
+		})
+	})
+
+	t.Run("audit resolution", func(t *testing.T) {
+		t.Run("resolves the actor from an audit row naming the dag run", func(t *testing.T) {
+			operatorRunID := uuid.New()
+			triggerSourceID := uuid.New()
+
+			repo := new(mockRunAttributionRepository)
+			repo.On("InsertTriggerSource", mock.Anything, mock.Anything).Return(triggerSourceID, nil)
+			// The operator type and run id are asserted here because stamping the resolution onto
+			// task_run now happens inside this one transactional call, not a separate write.
+			repo.On("UpdateTriggerSourceResolution", mock.Anything, triggerSourceID, scheduler.OperatorTask, operatorRunID,
+				mock.MatchedBy(func(a scheduler.RunAttribution) bool {
+					return a.TriggeredBy == "dave" && a.Attribution == scheduler.AttributionAuditRunID && a.AuditEvent == "dagrun_clear"
+				}), mock.Anything).Return(nil)
+
+			auditGetter := new(mockAuditLogGetter)
+			auditGetter.On("GetEventLogs", mock.Anything, mock.MatchedBy(func(f scheduler.AuditEventFilter) bool {
+				return f.RunID == "manual__2026-07-20T13:00:00+00:00" && f.DagID == jobName.String()
+			})).Return([]*scheduler.AuditEvent{{
+				EventLogID: 42, Event: "dagrun_clear", Owner: "dave",
+				DagID: jobName.String(), RunID: "manual__2026-07-20T13:00:00+00:00",
+				When: startTime.Add(-time.Minute),
+			}}, nil)
+
+			svc := service.NewRunAttributionService(logger, conf, repo, noReplayMatch(),
+				new(mockBackfillAttributionGetter), auditGetter)
+			done := svc.WaitGroupForTest()
+
+			in := baseInput()
+			in.SchedulerRunID = "manual__2026-07-20T13:00:00+00:00"
+			assert.NoError(t, svc.Record(ctx, in, operatorRunID, svc.Classify(ctx, in)))
+
+			done.Wait()
+			repo.AssertExpectations(t)
+		})
+
+		t.Run("finishes after the caller's context is cancelled", func(t *testing.T) {
+			// The resolver is detached from the request that started it. If it inherited that
+			// request's cancellation it would abort the moment the event handler returned, which
+			// is the single most likely way for this feature to silently stop working.
+			operatorRunID := uuid.New()
+			triggerSourceID := uuid.New()
+
+			var resolved atomic.Bool
+			repo := new(mockRunAttributionRepository)
+			repo.On("InsertTriggerSource", mock.Anything, mock.Anything).Return(triggerSourceID, nil)
+			repo.On("UpdateTriggerSourceResolution", mock.Anything, triggerSourceID, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				Run(func(args mock.Arguments) {
+					// Prove the context handed to the repository is still alive.
+					callCtx, _ := args.Get(0).(context.Context)
+					assert.NoError(t, callCtx.Err())
+					resolved.Store(true)
+				}).Return(nil)
+
+			release := make(chan struct{})
+			auditGetter := new(mockAuditLogGetter)
+			auditGetter.On("GetEventLogs", mock.Anything, mock.Anything).
+				Run(func(mock.Arguments) { <-release }).
+				Return([]*scheduler.AuditEvent{{EventLogID: 7, Event: "clear", Owner: "erin", DagID: jobName.String(), RunID: "manual__x"}}, nil)
+
+			svc := service.NewRunAttributionService(logger, conf, repo, noReplayMatch(),
+				new(mockBackfillAttributionGetter), auditGetter)
+			done := svc.WaitGroupForTest()
+
+			callerCtx, cancel := context.WithCancel(ctx)
+			in := baseInput()
+			in.SchedulerRunID = "manual__2026-07-20T13:00:00+00:00"
+			assert.NoError(t, svc.Record(callerCtx, in, operatorRunID, svc.Classify(callerCtx, in)))
+
+			// Cancel as the request handler would, then let the audit call proceed.
+			cancel()
+			close(release)
+			done.Wait()
+
+			assert.True(t, resolved.Load(), "resolution should complete after the caller's context is cancelled")
+		})
+
+		t.Run("collapses concurrent resolutions for one dag run into a single airflow call", func(t *testing.T) {
+			// Clearing a dag run restarts every task in it. Without collapsing, a wide DAG would
+			// fire one audit query per task and could reach inconsistent answers.
+			const taskCount = 8
+			var auditCalls atomic.Int32
+
+			repo := new(mockRunAttributionRepository)
+			repo.On("InsertTriggerSource", mock.Anything, mock.Anything).Return(uuid.New(), nil)
+			repo.On("UpdateTriggerSourceResolution", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.MatchedBy(func(a scheduler.RunAttribution) bool {
+				return a.TriggeredBy == "frank"
+			}), mock.Anything).Return(nil)
+
+			gate := make(chan struct{})
+			auditGetter := new(mockAuditLogGetter)
+			auditGetter.On("GetEventLogs", mock.Anything, mock.Anything).
+				Run(func(mock.Arguments) {
+					auditCalls.Add(1)
+					// Hold the in-flight call open so the siblings arrive while it is running.
+					<-gate
+				}).
+				Return([]*scheduler.AuditEvent{{
+					EventLogID: 9, Event: "dagrun_clear", Owner: "frank",
+					DagID: jobName.String(), RunID: "manual__2026-07-20T13:00:00+00:00",
+				}}, nil)
+
+			conf := conf
+			conf.MaxConcurrentResolves = taskCount
+			svc := service.NewRunAttributionService(logger, conf, repo, noReplayMatch(),
+				new(mockBackfillAttributionGetter), auditGetter)
+			done := svc.WaitGroupForTest()
+
+			for i := range taskCount {
+				in := baseInput()
+				in.OperatorName = fmt.Sprintf("task-%d", i)
+				in.SchedulerRunID = "manual__2026-07-20T13:00:00+00:00"
+				assert.NoError(t, svc.Record(ctx, in, uuid.New(), svc.Classify(ctx, in)))
+			}
+
+			// Give the goroutines time to reach singleflight before releasing the gate.
+			assert.Eventually(t, func() bool { return auditCalls.Load() == 1 }, 2*time.Second, 10*time.Millisecond)
+			close(gate)
+			done.Wait()
+
+			assert.Equal(t, int32(1), auditCalls.Load(), "one dag run should mean one audit query")
+		})
+
+		t.Run("correlates by time when the audit rows carry no dag context", func(t *testing.T) {
+			// This is the /taskinstance/list/ bulk clear: Airflow records no dag_id or run_id.
+			operatorRunID := uuid.New()
+			triggerSourceID := uuid.New()
+
+			repo := new(mockRunAttributionRepository)
+			repo.On("InsertTriggerSource", mock.Anything, mock.Anything).Return(triggerSourceID, nil)
+			repo.On("UpdateTriggerSourceResolution", mock.Anything, triggerSourceID, mock.Anything, mock.Anything, mock.MatchedBy(func(a scheduler.RunAttribution) bool {
+				return a.TriggeredBy == "grace" && a.Attribution == scheduler.AttributionAuditHeuristic
+			}), mock.Anything).Return(nil)
+
+			auditGetter := new(mockAuditLogGetter)
+			// Exact match on the dag run finds nothing.
+			auditGetter.On("GetEventLogs", mock.Anything, mock.MatchedBy(func(f scheduler.AuditEventFilter) bool {
+				return f.RunID != ""
+			})).Return([]*scheduler.AuditEvent{}, nil)
+			// The time-correlated query finds one bulk clear, plus noise that must be ignored.
+			auditGetter.On("GetEventLogs", mock.Anything, mock.MatchedBy(func(f scheduler.AuditEventFilter) bool {
+				return f.RunID == ""
+			})).Return([]*scheduler.AuditEvent{
+				{EventLogID: 11, Event: "action_clear", Owner: "grace", When: startTime.Add(-2 * time.Minute)},
+				{EventLogID: 10, Event: "action_clear", Owner: "optimus", When: startTime.Add(-3 * time.Minute)},
+				{EventLogID: 9, Event: "clear", Owner: "heidi", DagID: "some-other-job", RunID: "manual__z"},
+			}, nil)
+
+			svc := service.NewRunAttributionService(logger, conf, repo, noReplayMatch(),
+				new(mockBackfillAttributionGetter), auditGetter)
+			done := svc.WaitGroupForTest()
+
+			in := baseInput()
+			in.SchedulerRunID = "manual__2026-07-20T13:00:00+00:00"
+			assert.NoError(t, svc.Record(ctx, in, operatorRunID, svc.Classify(ctx, in)))
+
+			done.Wait()
+			repo.AssertExpectations(t)
+		})
+
+		t.Run("leaves the actor unidentified when several could be responsible", func(t *testing.T) {
+			operatorRunID := uuid.New()
+			triggerSourceID := uuid.New()
+
+			repo := new(mockRunAttributionRepository)
+			repo.On("InsertTriggerSource", mock.Anything, mock.Anything).Return(triggerSourceID, nil)
+			repo.On("UpdateTriggerSourceResolution", mock.Anything, triggerSourceID, mock.Anything, mock.Anything, mock.MatchedBy(func(a scheduler.RunAttribution) bool {
+				// The candidate rows are still recorded so a human can adjudicate.
+				return a.TriggeredBy == scheduler.TriggeredByUnidentified &&
+					a.Attribution == scheduler.AttributionUnidentified &&
+					a.AuditExtra != ""
+			}), mock.Anything).Return(nil)
+
+			auditGetter := new(mockAuditLogGetter)
+			auditGetter.On("GetEventLogs", mock.Anything, mock.MatchedBy(func(f scheduler.AuditEventFilter) bool {
+				return f.RunID != ""
+			})).Return([]*scheduler.AuditEvent{}, nil)
+			auditGetter.On("GetEventLogs", mock.Anything, mock.MatchedBy(func(f scheduler.AuditEventFilter) bool {
+				return f.RunID == ""
+			})).Return([]*scheduler.AuditEvent{
+				{EventLogID: 21, Event: "action_clear", Owner: "ivan", When: startTime.Add(-time.Minute)},
+				{EventLogID: 20, Event: "action_clear", Owner: "judy", When: startTime.Add(-2 * time.Minute)},
+			}, nil)
+
+			svc := service.NewRunAttributionService(logger, conf, repo, noReplayMatch(),
+				new(mockBackfillAttributionGetter), auditGetter)
+			done := svc.WaitGroupForTest()
+
+			in := baseInput()
+			in.SchedulerRunID = "manual__2026-07-20T13:00:00+00:00"
+			assert.NoError(t, svc.Record(ctx, in, operatorRunID, svc.Classify(ctx, in)))
+
+			done.Wait()
+			repo.AssertExpectations(t)
+		})
+
+		t.Run("records unidentified when airflow cannot be reached", func(t *testing.T) {
+			operatorRunID := uuid.New()
+			triggerSourceID := uuid.New()
+
+			repo := new(mockRunAttributionRepository)
+			repo.On("InsertTriggerSource", mock.Anything, mock.Anything).Return(triggerSourceID, nil)
+			repo.On("UpdateTriggerSourceResolution", mock.Anything, triggerSourceID, mock.Anything, mock.Anything, mock.MatchedBy(func(a scheduler.RunAttribution) bool {
+				return a.Attribution == scheduler.AttributionUnidentified && a.RunType == scheduler.RunTypeManual
+			}), mock.Anything).Return(nil)
+
+			auditGetter := new(mockAuditLogGetter)
+			auditGetter.On("GetEventLogs", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("airflow is down"))
+
+			svc := service.NewRunAttributionService(logger, conf, repo, noReplayMatch(),
+				new(mockBackfillAttributionGetter), auditGetter)
+			done := svc.WaitGroupForTest()
+
+			in := baseInput()
+			in.SchedulerRunID = "manual__2026-07-20T13:00:00+00:00"
+			assert.NoError(t, svc.Record(ctx, in, operatorRunID, svc.Classify(ctx, in)))
+
+			done.Wait()
+			repo.AssertExpectations(t)
+		})
+
+		t.Run("sheds resolution without blocking the caller when saturated", func(t *testing.T) {
+			// Event ingestion must never wait on Airflow. When the resolver is full the run stays
+			// recorded as manual with an unresolved actor.
+			repo := new(mockRunAttributionRepository)
+			repo.On("InsertTriggerSource", mock.Anything, mock.Anything).Return(uuid.New(), nil)
+			repo.On("UpdateTriggerSourceResolution", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+			const occupyingRunID = "manual__2026-07-20T13:00:00+00:00"
+			const shedRunID = "manual__2026-07-20T14:00:00+00:00"
+
+			var (
+				mu         sync.Mutex
+				queriedFor []string
+				block      = make(chan struct{})
+			)
+			auditGetter := new(mockAuditLogGetter)
+			auditGetter.On("GetEventLogs", mock.Anything, mock.Anything).
+				Run(func(args mock.Arguments) {
+					filter, _ := args.Get(1).(scheduler.AuditEventFilter)
+					mu.Lock()
+					queriedFor = append(queriedFor, filter.RunID)
+					mu.Unlock()
+					<-block
+				}).
+				Return([]*scheduler.AuditEvent{}, nil)
+			// A single resolution issues two queries, an exact one on the dag run then a
+			// time-correlated one, so count dag runs asked about rather than calls made.
+			askedAbout := func(runID string) bool {
+				mu.Lock()
+				defer mu.Unlock()
+				for _, seen := range queriedFor {
+					if seen == runID {
+						return true
+					}
+				}
+				return false
+			}
+
+			conf := conf
+			conf.MaxConcurrentResolves = 1
+			svc := service.NewRunAttributionService(logger, conf, repo, noReplayMatch(),
+				new(mockBackfillAttributionGetter), auditGetter)
+			done := svc.WaitGroupForTest()
+
+			// Occupy the single slot. A distinct dag run keeps singleflight from merging the two.
+			first := baseInput()
+			first.SchedulerRunID = occupyingRunID
+			assert.NoError(t, svc.Record(ctx, first, uuid.New(), svc.Classify(ctx, first)))
+			assert.Eventually(t, func() bool { return askedAbout(occupyingRunID) }, 2*time.Second, 10*time.Millisecond)
+
+			// This one must return immediately rather than waiting for the slot.
+			returned := make(chan struct{})
+			go func() {
+				second := baseInput()
+				second.SchedulerRunID = shedRunID
+				assert.NoError(t, svc.Record(ctx, second, uuid.New(), svc.Classify(ctx, second)))
+				close(returned)
+			}()
+
+			select {
+			case <-returned:
+			case <-time.After(2 * time.Second):
+				t.Fatal("Record blocked while the resolver was saturated")
+			}
+
+			close(block)
+			done.Wait()
+			assert.False(t, askedAbout(shedRunID), "the shed resolution should not have queried airflow")
+		})
+
+		t.Run("survives a panic in the resolver", func(t *testing.T) {
+			// This runs once per manual task start; an unrecovered panic would take the server down.
+			repo := new(mockRunAttributionRepository)
+			repo.On("InsertTriggerSource", mock.Anything, mock.Anything).Return(uuid.New(), nil)
+
+			auditGetter := new(mockAuditLogGetter)
+			auditGetter.On("GetEventLogs", mock.Anything, mock.Anything).
+				Run(func(mock.Arguments) { panic("boom") }).
+				Return(nil, nil)
+
+			svc := service.NewRunAttributionService(logger, conf, repo, noReplayMatch(),
+				new(mockBackfillAttributionGetter), auditGetter)
+			done := svc.WaitGroupForTest()
+
+			in := baseInput()
+			in.SchedulerRunID = "manual__2026-07-20T13:00:00+00:00"
+			assert.NoError(t, svc.Record(ctx, in, uuid.New(), svc.Classify(ctx, in)))
+
+			done.Wait()
+		})
+	})
+}
+
+func newClassifyOnlyService(logger log.Logger, conf config.RunAttributionConfig) *service.RunAttributionService {
+	// No replay or backfill matches, so Classify falls through to the run id and previous run.
+	return service.NewRunAttributionService(logger, conf, new(mockRunAttributionRepository), noReplayMatch(),
+		new(mockBackfillAttributionGetter), new(mockAuditLogGetter))
+}
+
+// noReplayMatch is the common case: the run's scheduled time falls inside no recent replay
+// window, so Classify moves on to the dag run id and the previous attempt.
+func noReplayMatch() *mockReplayAttributionGetter {
+	repo := new(mockReplayAttributionGetter)
+	repo.On("GetReplayAttributionByScheduledAt", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(uuid.Nil, "", errors.NotFound(scheduler.EntityReplay, "no replay")).Maybe()
+	return repo
+}
+
+func backfillWithUser(userID string) *scheduler.Backfill {
+	cfg := scheduler.NewBackfillConfig(time.Now(), time.Now(), nil, nil, "desc", "BACKFILL", "approval", userID)
+	return scheduler.NewBackfillRequest("a-job", tenant.Tenant{}, cfg, scheduler.BackfillStateCreated, "")
+}
+
+type mockRunAttributionRepository struct {
+	mock.Mock
+}
+
+func (m *mockRunAttributionRepository) InsertTriggerSource(ctx context.Context, src *scheduler.TriggerSource) (uuid.UUID, error) {
+	args := m.Called(ctx, src)
+	if args.Get(0) == nil {
+		return uuid.Nil, args.Error(1)
+	}
+	return args.Get(0).(uuid.UUID), args.Error(1)
+}
+
+func (m *mockRunAttributionRepository) UpdateTriggerSourceResolution(ctx context.Context, triggerSourceID uuid.UUID,
+	operatorType scheduler.OperatorType, operatorRunID uuid.UUID, attribution scheduler.RunAttribution, resolveAttempts int,
+) error {
+	return m.Called(ctx, triggerSourceID, operatorType, operatorRunID, attribution, resolveAttempts).Error(0)
+}
+
+type mockReplayAttributionGetter struct {
+	mock.Mock
+}
+
+func (m *mockReplayAttributionGetter) GetReplayAttributionByScheduledAt(ctx context.Context, jobTenant tenant.Tenant, jobName scheduler.JobName, scheduledAt time.Time) (uuid.UUID, string, error) {
+	args := m.Called(ctx, jobTenant, jobName, scheduledAt)
+	return args.Get(0).(uuid.UUID), args.String(1), args.Error(2)
+}
+
+type mockBackfillAttributionGetter struct {
+	mock.Mock
+}
+
+func (m *mockBackfillAttributionGetter) GetBackfillDetails(ctx context.Context, backfillID uuid.UUID) (*scheduler.Backfill, error) {
+	args := m.Called(ctx, backfillID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*scheduler.Backfill), args.Error(1)
+}
+
+type mockAuditLogGetter struct {
+	mock.Mock
+}
+
+func (m *mockAuditLogGetter) GetEventLogs(ctx context.Context, filter scheduler.AuditEventFilter) ([]*scheduler.AuditEvent, error) {
+	args := m.Called(ctx, filter)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*scheduler.AuditEvent), args.Error(1)
+}

--- a/ext/scheduler/airflow/airflow.go
+++ b/ext/scheduler/airflow/airflow.go
@@ -43,6 +43,7 @@ const (
 	dagRunCreateURL    = "api/v1/dags/%s/dagRuns"
 	getTaskInstanceURL = "api/v1/dags/%s/dagRuns/%s/taskInstances/%s"
 	dagRunIDURL        = "api/v1/dags/%s/dagRuns/%s"
+	eventLogsURL       = "api/v1/eventLogs"
 	airflowDateFormat  = "2006-01-02T15:04:05+00:00"
 
 	schedulerHostKey = "SCHEDULER_HOST"
@@ -820,6 +821,73 @@ func (s *Scheduler) GetOperatorInstance(ctx context.Context, tnnt tenant.Tenant,
 	}
 
 	return taskInstance.toSchedulerOperatorRunInstance()
+}
+
+// GetEventLogs reads Airflow's audit log, which is how Optimus finds out who cleared or
+// triggered a run from outside Optimus. Requires the scheduler credential to hold `can_read`
+// on `Audit Logs`; without it Airflow answers 403 and Invoke surfaces that as an error.
+//
+// The filter's included/excluded event names rely on Airflow 2.9.0 or later.
+func (s *Scheduler) GetEventLogs(ctx context.Context, filter scheduler.AuditEventFilter) ([]*scheduler.AuditEvent, error) {
+	spanCtx, span := startChildSpan(ctx, "GetEventLogs")
+	defer span.End()
+
+	req := airflowRequest{
+		// The query is kept out of path on purpose: Invoke uses path as a Prometheus label,
+		// so folding per-request values into it would make the metric unbounded.
+		path:   eventLogsURL,
+		method: http.MethodGet,
+		query:  buildEventLogQuery(filter),
+	}
+	schdAuth, err := s.getSchedulerAuth(ctx, filter.Tenant.ProjectName())
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.client.Invoke(spanCtx, req, schdAuth)
+	if err != nil {
+		return nil, errors.Wrap(EntityAirflow, "failure while getting airflow event logs", err)
+	}
+	eventLogs, err := unmarshalAs[EventLogListResponse](resp)
+	if err != nil {
+		return nil, errors.Wrap(EntityAirflow, "failure while unmarshalling airflow event logs", err)
+	}
+
+	auditEvents := make([]*scheduler.AuditEvent, 0, len(eventLogs.EventLogs))
+	for _, eventLog := range eventLogs.EventLogs {
+		auditEvents = append(auditEvents, eventLog.toAuditEvent())
+	}
+	return auditEvents, nil
+}
+
+func buildEventLogQuery(filter scheduler.AuditEventFilter) string {
+	query := url.Values{}
+	// Newest first, so callers can stop at the first row at or before the run's start time.
+	query.Set("order_by", "-when")
+	if filter.Limit > 0 {
+		query.Set("limit", strconv.Itoa(filter.Limit))
+	}
+	if filter.DagID != "" {
+		query.Set("dag_id", filter.DagID)
+	}
+	if filter.RunID != "" {
+		query.Set("run_id", filter.RunID)
+	}
+	if filter.TaskID != "" {
+		query.Set("task_id", filter.TaskID)
+	}
+	if !filter.After.IsZero() {
+		query.Set("after", filter.After.UTC().Format(time.RFC3339))
+	}
+	if !filter.Before.IsZero() {
+		query.Set("before", filter.Before.UTC().Format(time.RFC3339))
+	}
+	if len(filter.IncludedEvents) > 0 {
+		query.Set("included_events", strings.Join(filter.IncludedEvents, ","))
+	}
+	if len(filter.ExcludedEvents) > 0 {
+		query.Set("excluded_events", strings.Join(filter.ExcludedEvents, ","))
+	}
+	return query.Encode()
 }
 
 func NewScheduler(l log.Logger, bucketFac BucketFactory, client Client, compiler DagCompiler, projectGetter ProjectGetter, secretGetter SecretGetter) *Scheduler {

--- a/ext/scheduler/airflow/client.go
+++ b/ext/scheduler/airflow/client.go
@@ -23,6 +23,10 @@ import (
 
 const (
 	pageLimit = 99999
+
+	// requestTimeout bounds a single Airflow API call. Without it the shared http.Client has
+	// no timeout at all, so an unresponsive webserver holds the calling goroutine forever.
+	requestTimeout = 30 * time.Second
 )
 
 type airflowRequest struct {
@@ -52,6 +56,53 @@ type DagRun struct {
 	RunType                string    `json:"run_type"`
 }
 
+// EventLogListResponse and EventLog mirror Airflow's /eventLogs collection, which is its
+// record of user actions taken through the UI or the REST API.
+//
+// DagID, TaskID and RunID are nullable: Airflow fills them from the originating request's
+// query and form parameters only, so bulk actions taken from the /dagrun/list/ and
+// /taskinstance/list/ pages, and REST calls that pass arguments in a JSON body, leave them
+// unset. Extra holds whatever other request parameters were logged.
+type EventLogListResponse struct {
+	EventLogs    []EventLog `json:"event_logs"`
+	TotalEntries int        `json:"total_entries"`
+}
+
+type EventLog struct {
+	EventLogID    int64      `json:"event_log_id"`
+	When          time.Time  `json:"when"`
+	Event         string     `json:"event"`
+	Owner         string     `json:"owner"`
+	DagID         *string    `json:"dag_id"`
+	TaskID        *string    `json:"task_id"`
+	RunID         *string    `json:"run_id"`
+	ExecutionDate *time.Time `json:"execution_date"`
+	Extra         *string    `json:"extra"`
+}
+
+func (e EventLog) toAuditEvent() *scheduler.AuditEvent {
+	event := &scheduler.AuditEvent{
+		EventLogID:    e.EventLogID,
+		When:          e.When,
+		Event:         e.Event,
+		Owner:         e.Owner,
+		ExecutionDate: e.ExecutionDate,
+	}
+	if e.DagID != nil {
+		event.DagID = *e.DagID
+	}
+	if e.TaskID != nil {
+		event.TaskID = *e.TaskID
+	}
+	if e.RunID != nil {
+		event.RunID = *e.RunID
+	}
+	if e.Extra != nil {
+		event.Extra = *e.Extra
+	}
+	return event
+}
+
 type DagRunRequest struct {
 	OrderBy          string   `json:"order_by"`
 	PageOffset       int      `json:"page_offset"`
@@ -75,7 +126,7 @@ var airflowAPIMetrics = promauto.NewCounterVec(prometheus.CounterOpts{
 }, []string{"api_name", "status", "error"})
 
 func NewAirflowClient() *ClientAirflow {
-	return &ClientAirflow{client: &http.Client{}}
+	return &ClientAirflow{client: &http.Client{Timeout: requestTimeout}}
 }
 
 func (ac ClientAirflow) Invoke(ctx context.Context, r airflowRequest, auth SchedulerAuth) ([]byte, error) {

--- a/ext/scheduler/airflow/client_test.go
+++ b/ext/scheduler/airflow/client_test.go
@@ -1,0 +1,194 @@
+// This test lives in package airflow rather than airflow_test because the Client seam takes an
+// unexported airflowRequest, so a stub client cannot be written from outside the package.
+//
+//nolint:testpackage // must be in-package to implement Client, whose argument is unexported
+package airflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/goto/salt/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/goto/optimus/core/scheduler"
+	"github.com/goto/optimus/core/tenant"
+)
+
+func TestBuildEventLogQuery(t *testing.T) {
+	tnnt, _ := tenant.NewTenant("proj", "ns")
+	after := time.Date(2026, 7, 20, 12, 30, 0, 0, time.UTC)
+	before := time.Date(2026, 7, 20, 13, 0, 0, 0, time.UTC)
+
+	t.Run("sets every populated filter and omits the rest", func(t *testing.T) {
+		query := buildEventLogQuery(scheduler.AuditEventFilter{
+			Tenant:         tnnt,
+			DagID:          "a-job",
+			RunID:          "manual__2026-07-20T13:00:00+00:00",
+			TaskID:         "a-task",
+			After:          after,
+			Before:         before,
+			IncludedEvents: []string{"clear", "dagrun_clear"},
+			ExcludedEvents: []string{"trigger"},
+			Limit:          50,
+		})
+
+		values, err := url.ParseQuery(query)
+		require.NoError(t, err)
+		assert.Equal(t, "a-job", values.Get("dag_id"))
+		assert.Equal(t, "manual__2026-07-20T13:00:00+00:00", values.Get("run_id"))
+		assert.Equal(t, "a-task", values.Get("task_id"))
+		assert.Equal(t, "2026-07-20T12:30:00Z", values.Get("after"))
+		assert.Equal(t, "2026-07-20T13:00:00Z", values.Get("before"))
+		// Airflow expects one comma separated value, not repeated parameters.
+		assert.Equal(t, "clear,dagrun_clear", values.Get("included_events"))
+		assert.Equal(t, "trigger", values.Get("excluded_events"))
+		assert.Equal(t, "50", values.Get("limit"))
+		// Newest first, so a caller can stop at the first row at or before the run's start.
+		assert.Equal(t, "-when", values.Get("order_by"))
+	})
+
+	t.Run("omits empty and zero filters entirely", func(t *testing.T) {
+		query := buildEventLogQuery(scheduler.AuditEventFilter{Tenant: tnnt})
+
+		values, err := url.ParseQuery(query)
+		require.NoError(t, err)
+		for _, absent := range []string{"dag_id", "run_id", "task_id", "after", "before", "included_events", "excluded_events", "limit"} {
+			_, present := values[absent]
+			assert.False(t, present, "%s should be omitted when unset", absent)
+		}
+		assert.Equal(t, "-when", values.Get("order_by"))
+	})
+}
+
+func TestGetEventLogs(t *testing.T) {
+	logger := log.NewNoop()
+	tnnt, _ := tenant.NewTenant("proj", "ns")
+
+	t.Run("maps a bulk clear row that carries no dag context", func(t *testing.T) {
+		// This is what /taskinstance/list/ and /dagrun/list/ produce: dag_id, task_id and run_id
+		// are all null, and the only extra detail is an opaque row id.
+		body := `{"event_logs":[{"event_log_id":11,"when":"2026-07-20T12:58:00+00:00","event":"action_clear",` +
+			`"owner":"grace","dag_id":null,"task_id":null,"run_id":null,"execution_date":null,` +
+			`"extra":"{\"rowid\": \"1234\"}"}],"total_entries":1}`
+
+		sch := schedulerWithClient(logger, &stubClient{response: []byte(body)})
+
+		events, err := sch.GetEventLogs(context.Background(), scheduler.AuditEventFilter{Tenant: tnnt})
+		require.NoError(t, err)
+		require.Len(t, events, 1)
+
+		assert.Equal(t, int64(11), events[0].EventLogID)
+		assert.Equal(t, "action_clear", events[0].Event)
+		assert.Equal(t, "grace", events[0].Owner)
+		assert.Empty(t, events[0].DagID)
+		assert.Empty(t, events[0].RunID)
+		assert.Nil(t, events[0].ExecutionDate)
+		assert.Equal(t, `{"rowid": "1234"}`, events[0].Extra)
+		assert.False(t, events[0].HasDagContext(), "a row with no dag_id cannot be matched exactly")
+	})
+
+	t.Run("maps a grid page clear that names the dag run", func(t *testing.T) {
+		body := `{"event_logs":[{"event_log_id":42,"when":"2026-07-20T12:59:00+00:00","event":"dagrun_clear",` +
+			`"owner":"dave","dag_id":"a-job","task_id":null,"run_id":"manual__2026-07-20T13:00:00+00:00",` +
+			`"execution_date":"2026-07-20T12:00:00+00:00","extra":"{}"}],"total_entries":1}`
+
+		client := &stubClient{response: []byte(body)}
+		sch := schedulerWithClient(logger, client)
+
+		events, err := sch.GetEventLogs(context.Background(), scheduler.AuditEventFilter{
+			Tenant: tnnt, DagID: "a-job", RunID: "manual__2026-07-20T13:00:00+00:00",
+		})
+		require.NoError(t, err)
+		require.Len(t, events, 1)
+
+		assert.Equal(t, "a-job", events[0].DagID)
+		assert.Equal(t, "manual__2026-07-20T13:00:00+00:00", events[0].RunID)
+		require.NotNil(t, events[0].ExecutionDate)
+		assert.True(t, events[0].HasDagContext())
+
+		// The path must stay free of per-request values: Invoke uses it as a Prometheus label.
+		assert.Equal(t, eventLogsURL, client.request.path)
+		assert.NotContains(t, client.request.path, "a-job")
+		assert.Contains(t, client.request.query, "dag_id=a-job")
+	})
+
+	t.Run("returns an empty slice rather than nil when airflow has nothing", func(t *testing.T) {
+		sch := schedulerWithClient(logger, &stubClient{response: []byte(`{"event_logs":[],"total_entries":0}`)})
+
+		events, err := sch.GetEventLogs(context.Background(), scheduler.AuditEventFilter{Tenant: tnnt})
+		require.NoError(t, err)
+		assert.NotNil(t, events)
+		assert.Empty(t, events)
+	})
+
+	t.Run("surfaces an airflow failure", func(t *testing.T) {
+		// A missing `can_read on Audit Logs` permission shows up here as a non-200 from Invoke.
+		sch := schedulerWithClient(logger, &stubClient{err: fmt.Errorf("status code received 403")})
+
+		_, err := sch.GetEventLogs(context.Background(), scheduler.AuditEventFilter{Tenant: tnnt})
+		assert.ErrorContains(t, err, "failure while getting airflow event logs")
+	})
+
+	t.Run("surfaces a malformed airflow response", func(t *testing.T) {
+		sch := schedulerWithClient(logger, &stubClient{response: []byte(`not json`)})
+
+		_, err := sch.GetEventLogs(context.Background(), scheduler.AuditEventFilter{Tenant: tnnt})
+		assert.ErrorContains(t, err, "failure while unmarshalling airflow event logs")
+	})
+}
+
+func schedulerWithClient(logger log.Logger, client Client) *Scheduler {
+	project, _ := tenant.NewProject("proj", map[string]string{
+		tenant.ProjectSchedulerHost:  "http://airflow.example.com",
+		tenant.ProjectStoragePathKey: "file://path",
+	}, map[string]string{})
+	secret, _ := tenant.NewPlainTextSecret(tenant.SecretSchedulerAuth, "user:pass")
+	return NewScheduler(logger, nil, client, nil, &stubProjectGetter{project: project}, &stubSecretGetter{secret: secret})
+}
+
+type stubClient struct {
+	response []byte
+	err      error
+	request  airflowRequest
+}
+
+func (c *stubClient) Invoke(_ context.Context, r airflowRequest, _ SchedulerAuth) ([]byte, error) {
+	c.request = r
+	return c.response, c.err
+}
+
+type stubProjectGetter struct {
+	project *tenant.Project
+}
+
+func (g *stubProjectGetter) Get(context.Context, tenant.ProjectName) (*tenant.Project, error) {
+	return g.project, nil
+}
+
+type stubSecretGetter struct {
+	secret *tenant.PlainTextSecret
+}
+
+func (g *stubSecretGetter) Get(context.Context, tenant.ProjectName, string, string) (*tenant.PlainTextSecret, error) {
+	return g.secret, nil
+}
+
+// Guard against a silent contract drift: the audit event shape Optimus unmarshals must keep
+// accepting nulls in every identifier column, since Airflow leaves them unset for bulk actions.
+func TestEventLogNullableFields(t *testing.T) {
+	var eventLog EventLog
+	require.NoError(t, json.Unmarshal([]byte(`{"event_log_id":1,"event":"action_clear","owner":"x"}`), &eventLog))
+
+	event := eventLog.toAuditEvent()
+	assert.Empty(t, event.DagID)
+	assert.Empty(t, event.TaskID)
+	assert.Empty(t, event.RunID)
+	assert.Empty(t, event.Extra)
+	assert.Nil(t, event.ExecutionDate)
+}

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	gocloud.dev v0.26.0
 	golang.org/x/net v0.20.0
 	golang.org/x/oauth2 v0.6.0
+	golang.org/x/sync v0.1.0
 	google.golang.org/api v0.103.0
 	google.golang.org/genproto v0.0.0-20221117204609-8f9c96812029
 	google.golang.org/grpc v1.50.1
@@ -158,7 +159,6 @@ require (
 	go.uber.org/ratelimit v0.2.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.18.0 // indirect
-	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/term v0.16.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/internal/store/postgres/migrations/000086_add_run_trigger_attribution.down.sql
+++ b/internal/store/postgres/migrations/000086_add_run_trigger_attribution.down.sql
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS operator_run_trigger_source;
+
+DROP INDEX IF EXISTS sensor_run_job_run_id_name_attempt_idx;
+ALTER TABLE sensor_run DROP COLUMN IF EXISTS attempt;
+ALTER TABLE sensor_run DROP COLUMN IF EXISTS triggered_by;
+ALTER TABLE sensor_run DROP COLUMN IF EXISTS run_type;
+
+DROP INDEX IF EXISTS hook_run_job_run_id_name_attempt_idx;
+ALTER TABLE hook_run DROP COLUMN IF EXISTS attempt;
+ALTER TABLE hook_run DROP COLUMN IF EXISTS triggered_by;
+ALTER TABLE hook_run DROP COLUMN IF EXISTS run_type;
+
+DROP INDEX IF EXISTS task_run_job_run_id_name_attempt_idx;
+ALTER TABLE task_run DROP COLUMN IF EXISTS attempt;
+ALTER TABLE task_run DROP COLUMN IF EXISTS triggered_by;
+ALTER TABLE task_run DROP COLUMN IF EXISTS run_type;
+
+DROP INDEX IF EXISTS job_run_scheduler_run_id_idx;
+ALTER TABLE job_run DROP COLUMN IF EXISTS scheduler_run_id;

--- a/internal/store/postgres/migrations/000086_add_run_trigger_attribution.up.sql
+++ b/internal/store/postgres/migrations/000086_add_run_trigger_attribution.up.sql
@@ -1,0 +1,69 @@
+-- Capture the Airflow dag run id on job_run so a run row can be joined back to a specific
+-- Airflow dag run. Value comes from the existing event payload field
+-- event_context.dag_run.run_id, which is already parsed but was never persisted.
+ALTER TABLE job_run ADD COLUMN IF NOT EXISTS scheduler_run_id VARCHAR(255);
+CREATE INDEX IF NOT EXISTS job_run_scheduler_run_id_idx ON job_run (scheduler_run_id);
+
+-- run_type      : scheduled | replay | backfill | manual
+-- triggered_by  : 'scheduler' | '<username>' | 'unidentified_user'
+-- attempt       : Airflow task instance try_number, from event_context.task_instance.attempt
+--
+-- Defaults keep every pre-existing and newly ingested row reading as a plain scheduled
+-- run, so behaviour is unchanged until attribution is enabled.
+ALTER TABLE task_run ADD COLUMN IF NOT EXISTS run_type VARCHAR(20) NOT NULL DEFAULT 'scheduled';
+ALTER TABLE task_run ADD COLUMN IF NOT EXISTS triggered_by VARCHAR(255) NOT NULL DEFAULT 'scheduler';
+ALTER TABLE task_run ADD COLUMN IF NOT EXISTS attempt INTEGER NOT NULL DEFAULT 1;
+CREATE INDEX IF NOT EXISTS task_run_job_run_id_name_attempt_idx ON task_run (job_run_id, name, attempt);
+
+ALTER TABLE hook_run ADD COLUMN IF NOT EXISTS run_type VARCHAR(20) NOT NULL DEFAULT 'scheduled';
+ALTER TABLE hook_run ADD COLUMN IF NOT EXISTS triggered_by VARCHAR(255) NOT NULL DEFAULT 'scheduler';
+ALTER TABLE hook_run ADD COLUMN IF NOT EXISTS attempt INTEGER NOT NULL DEFAULT 1;
+CREATE INDEX IF NOT EXISTS hook_run_job_run_id_name_attempt_idx ON hook_run (job_run_id, name, attempt);
+
+-- sensor_run is included even though the requirement names only task/hook: all three tables
+-- share a single Go struct and a single set of SQL strings switched by operatorTypeToTableName,
+-- so a divergent schema would force per-table branching in the query builder.
+ALTER TABLE sensor_run ADD COLUMN IF NOT EXISTS run_type VARCHAR(20) NOT NULL DEFAULT 'scheduled';
+ALTER TABLE sensor_run ADD COLUMN IF NOT EXISTS triggered_by VARCHAR(255) NOT NULL DEFAULT 'scheduler';
+ALTER TABLE sensor_run ADD COLUMN IF NOT EXISTS attempt INTEGER NOT NULL DEFAULT 1;
+CREATE INDEX IF NOT EXISTS sensor_run_job_run_id_name_attempt_idx ON sensor_run (job_run_id, name, attempt);
+
+-- Links a task_run / hook_run / sensor_run back to the cause of the run: an Optimus
+-- replay_request, an Optimus backfill, or a manual action taken directly in Airflow.
+--
+-- Rows are written only for non-scheduled runs, so this table stays small relative to task_run.
+-- operator_run_id is polymorphic across the three *_run tables, hence no foreign key on it.
+CREATE TABLE IF NOT EXISTS operator_run_trigger_source (
+    id               UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+
+    operator_run_id  UUID         NOT NULL,
+    operator_type    VARCHAR(10)  NOT NULL,
+    job_run_id       UUID         NOT NULL,
+    scheduler_run_id VARCHAR(255),
+
+    source_type      VARCHAR(20)  NOT NULL,
+    replay_id        UUID         REFERENCES replay_request (id) ON DELETE SET NULL,
+    backfill_id      UUID         REFERENCES backfill (id) ON DELETE SET NULL,
+    triggered_by     VARCHAR(255) NOT NULL,
+
+    -- How the attribution was decided, so a consumer can tell an exact match from a guess:
+    -- optimus_replay | optimus_backfill | airflow_audit_run_id | inherited  -- exact
+    -- airflow_audit_heuristic                                              -- correlated by time only
+    -- unidentified | pending                                               -- actor not established
+    attribution      VARCHAR(30)  NOT NULL,
+    resolve_attempts INTEGER      NOT NULL DEFAULT 0,
+
+    audit_event      VARCHAR(100),
+    audit_event_id   BIGINT,
+    audit_extra      JSONB,
+
+    created_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS operator_run_trigger_source_run_idx ON operator_run_trigger_source (operator_run_id);
+CREATE INDEX IF NOT EXISTS operator_run_trigger_source_job_run_idx ON operator_run_trigger_source (job_run_id);
+CREATE INDEX IF NOT EXISTS operator_run_trigger_source_replay_idx ON operator_run_trigger_source (replay_id);
+CREATE INDEX IF NOT EXISTS operator_run_trigger_source_backfill_idx ON operator_run_trigger_source (backfill_id);
+CREATE INDEX IF NOT EXISTS operator_run_trigger_source_pending_idx ON operator_run_trigger_source (updated_at)
+    WHERE attribution = 'pending';

--- a/internal/store/postgres/scheduler/job_operator_repository.go
+++ b/internal/store/postgres/scheduler/job_operator_repository.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
@@ -18,8 +19,12 @@ const (
 	taskRunTableName   = "task_run"
 	hookRunTableName   = "hook_run"
 
-	jobOperatorColumnsToStore = `name, job_run_id, status, start_time, end_time`
+	jobOperatorColumnsToStore = `name, job_run_id, status, start_time, end_time, run_type, triggered_by, attempt`
 	jobOperatorColumns        = `id, ` + jobOperatorColumnsToStore
+
+	triggerSourceColumnsToStore = `operator_run_id, operator_type, job_run_id, scheduler_run_id, source_type, ` +
+		`replay_id, backfill_id, triggered_by, attribution, resolve_attempts, audit_event, audit_event_id, audit_extra`
+	triggerSourceColumns = `id, ` + triggerSourceColumnsToStore
 )
 
 type OperatorRunRepository struct {
@@ -36,6 +41,10 @@ type operatorRun struct {
 
 	StartTime time.Time
 	EndTime   *time.Time
+
+	RunType     string
+	TriggeredBy string
+	Attempt     int
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
@@ -69,6 +78,9 @@ func (o *operatorRun) toOperatorRun() (*scheduler.OperatorRun, error) {
 		Status:       status,
 		StartTime:    o.StartTime,
 		EndTime:      o.EndTime,
+		RunType:      scheduler.RunType(o.RunType),
+		TriggeredBy:  o.TriggeredBy,
+		Attempt:      o.Attempt,
 	}, nil
 }
 
@@ -80,7 +92,8 @@ func (o *OperatorRunRepository) GetOperatorRun(ctx context.Context, name string,
 	}
 	getJobRunByID := "SELECT " + jobOperatorColumns + " FROM " + operatorTableName + " j where job_run_id = $1 and name = $2 order by created_at desc limit 1"
 	err = o.db.QueryRow(ctx, getJobRunByID, jobRunID, name).
-		Scan(&opRun.ID, &opRun.Name, &opRun.JobRunID, &opRun.Status, &opRun.StartTime, &opRun.EndTime)
+		Scan(&opRun.ID, &opRun.Name, &opRun.JobRunID, &opRun.Status, &opRun.StartTime, &opRun.EndTime,
+			&opRun.RunType, &opRun.TriggeredBy, &opRun.Attempt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, errors.NotFound(scheduler.EntityJobRun, "no record for "+operatorType.String()+"/"+name+" for job_run ID: "+jobRunID.String())
@@ -90,17 +103,30 @@ func (o *OperatorRunRepository) GetOperatorRun(ctx context.Context, name string,
 	return opRun.toOperatorRun()
 }
 
-func (o *OperatorRunRepository) CreateOperatorRun(ctx context.Context, name string, operatorType scheduler.OperatorType, jobRunID uuid.UUID, startTime time.Time) error {
+// CreateOperatorRun inserts a new attempt row and returns its id, which the caller needs in
+// order to link the run back to whatever caused it.
+func (o *OperatorRunRepository) CreateOperatorRun(ctx context.Context, name string, operatorType scheduler.OperatorType, jobRunID uuid.UUID, startTime time.Time, attribution scheduler.RunAttribution, attempt int) (uuid.UUID, error) {
 	operatorTableName, err := operatorTypeToTableName(operatorType)
 	if err != nil {
-		return err
+		return uuid.Nil, err
 	}
-	insertOperatorRun := "INSERT INTO " + operatorTableName + " ( " + jobOperatorColumnsToStore + ", created_at, updated_at) values ( $1, $2, $3, $4, null, NOW(), NOW())"
-	_, err = o.db.Exec(ctx, insertOperatorRun, name, jobRunID, scheduler.StateRunning, startTime)
+	if attribution.RunType == "" {
+		attribution = scheduler.ScheduledAttribution()
+	}
+	if attempt < 1 {
+		// Airflow's try_number is 1-based; treat a missing value as the first attempt rather
+		// than storing a 0 that no Airflow payload would produce.
+		attempt = 1
+	}
+	insertOperatorRun := "INSERT INTO " + operatorTableName + " ( " + jobOperatorColumnsToStore +
+		", created_at, updated_at) values ( $1, $2, $3, $4, null, $5, $6, $7, NOW(), NOW()) RETURNING id"
+	var operatorRunID uuid.UUID
+	err = o.db.QueryRow(ctx, insertOperatorRun, name, jobRunID, scheduler.StateRunning, startTime,
+		attribution.RunType.String(), attribution.TriggeredBy, attempt).Scan(&operatorRunID)
 	if err != nil {
-		return errors.WrapIfErr(scheduler.EntityJobRun, "error while inserting the run", err)
+		return uuid.Nil, errors.Wrap(scheduler.EntityJobRun, "error while inserting the run", err)
 	}
-	return nil
+	return operatorRunID, nil
 }
 
 func (o *OperatorRunRepository) UpdateOperatorRun(ctx context.Context, operatorType scheduler.OperatorType, operatorRunID uuid.UUID, eventTime time.Time, state scheduler.State) error {
@@ -111,6 +137,195 @@ func (o *OperatorRunRepository) UpdateOperatorRun(ctx context.Context, operatorT
 	updateJobRun := "UPDATE " + operatorTableName + " SET status = $1, end_time = $2, updated_at = NOW() where id = $3"
 	_, err = o.db.Exec(ctx, updateJobRun, state, eventTime, operatorRunID)
 	return errors.WrapIfErr(scheduler.EntityJobRun, "error while updating the run", err)
+}
+
+// -- operator_run_trigger_source -------------------------------------------------------------
+//
+// A trigger source records why an operator run happened: an Optimus replay_request, an Optimus
+// backfill, or a manual action taken directly in Airflow. It lives on this repository rather
+// than its own because it is 1:1 with an operator run, and because resolving one has to update
+// both tables together (see UpdateTriggerSourceResolution).
+
+type triggerSource struct {
+	ID uuid.UUID
+
+	OperatorRunID  uuid.UUID
+	OperatorType   string
+	JobRunID       uuid.UUID
+	SchedulerRunID *string
+
+	SourceType  string
+	ReplayID    *uuid.UUID
+	BackfillID  *uuid.UUID
+	TriggeredBy string
+
+	Attribution     string
+	ResolveAttempts int
+
+	AuditEvent   *string
+	AuditEventID *int64
+	// AuditExtra is a jsonb column, so it has to be scanned as raw bytes rather than a string.
+	AuditExtra []byte
+}
+
+func (t *triggerSource) toTriggerSource() *scheduler.TriggerSource {
+	src := &scheduler.TriggerSource{
+		ID:              t.ID,
+		OperatorRunID:   t.OperatorRunID,
+		OperatorType:    scheduler.OperatorType(t.OperatorType),
+		JobRunID:        t.JobRunID,
+		ResolveAttempts: t.ResolveAttempts,
+		Attribution: scheduler.RunAttribution{
+			SourceType:   t.SourceType,
+			ReplayID:     t.ReplayID,
+			BackfillID:   t.BackfillID,
+			TriggeredBy:  t.TriggeredBy,
+			Attribution:  t.Attribution,
+			AuditEventID: t.AuditEventID,
+		},
+	}
+	if t.SchedulerRunID != nil {
+		src.SchedulerRunID = *t.SchedulerRunID
+	}
+	if t.AuditEvent != nil {
+		src.Attribution.AuditEvent = *t.AuditEvent
+	}
+	if len(t.AuditExtra) > 0 {
+		src.Attribution.AuditExtra = string(t.AuditExtra)
+	}
+	return src
+}
+
+// nullIfEmpty keeps genuinely absent values out of the table as NULL rather than as empty
+// strings, so that "we have no audit event" is distinguishable from "the event name was blank".
+func nullIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// toJSONB prepares a value for the audit_extra jsonb column.
+//
+// Airflow's own `extra` field is only conventionally JSON: it is whatever json.dumps produced
+// for that request, and nothing guarantees it parses. Rather than let a malformed value fail the
+// insert and lose the whole trigger source row, anything unparseable is wrapped so it is still
+// preserved and still queryable.
+func toJSONB(s string) []byte {
+	if s == "" {
+		return nil
+	}
+	if json.Valid([]byte(s)) {
+		return []byte(s)
+	}
+	wrapped, err := json.Marshal(map[string]string{"raw": s})
+	if err != nil {
+		return nil
+	}
+	return wrapped
+}
+
+// InsertTriggerSource records the cause of an operator run. Scheduled runs are not written here;
+// only replay, backfill and manual runs get a row.
+//
+// The unique index on operator_run_id makes this idempotent: a duplicated start event that
+// somehow reaches the same operator run updates the existing row instead of adding a second.
+func (o *OperatorRunRepository) InsertTriggerSource(ctx context.Context, src *scheduler.TriggerSource) (uuid.UUID, error) {
+	insert := `INSERT INTO operator_run_trigger_source (` + triggerSourceColumnsToStore + `, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW(), NOW())
+		ON CONFLICT (operator_run_id) DO UPDATE SET
+			source_type = EXCLUDED.source_type,
+			replay_id = EXCLUDED.replay_id,
+			backfill_id = EXCLUDED.backfill_id,
+			triggered_by = EXCLUDED.triggered_by,
+			attribution = EXCLUDED.attribution,
+			audit_event = EXCLUDED.audit_event,
+			audit_event_id = EXCLUDED.audit_event_id,
+			audit_extra = EXCLUDED.audit_extra,
+			updated_at = NOW()
+		RETURNING id`
+
+	a := src.Attribution
+	var id uuid.UUID
+	err := o.db.QueryRow(ctx, insert,
+		src.OperatorRunID, src.OperatorType.String(), src.JobRunID, nullIfEmpty(src.SchedulerRunID),
+		a.SourceType, a.ReplayID, a.BackfillID, a.TriggeredBy, a.Attribution, src.ResolveAttempts,
+		nullIfEmpty(a.AuditEvent), a.AuditEventID, toJSONB(a.AuditExtra),
+	).Scan(&id)
+	if err != nil {
+		return uuid.Nil, errors.Wrap(scheduler.EntityRunAttribution, "error while inserting run trigger source", err)
+	}
+	return id, nil
+}
+
+// UpdateTriggerSourceResolution writes the outcome of an audit lookup to both the trigger source
+// row and the operator run it belongs to, in one transaction.
+//
+// The two writes must be atomic: task_run and hook_run are what most consumers read, so a
+// partial write would leave them claiming the actor is unidentified while the trigger source
+// names somebody. Nothing reconciles the two afterwards, so it has to be all or nothing.
+func (o *OperatorRunRepository) UpdateTriggerSourceResolution(ctx context.Context, triggerSourceID uuid.UUID,
+	operatorType scheduler.OperatorType, operatorRunID uuid.UUID, a scheduler.RunAttribution, resolveAttempts int,
+) error {
+	operatorTableName, err := operatorTypeToTableName(operatorType)
+	if err != nil {
+		return err
+	}
+
+	tx, err := o.db.Begin(ctx)
+	if err != nil {
+		return errors.Wrap(scheduler.EntityRunAttribution, "error while starting resolution transaction", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // no-op once Commit has succeeded
+
+	updateTriggerSource := `UPDATE operator_run_trigger_source SET
+			source_type = $1, triggered_by = $2, attribution = $3, resolve_attempts = $4,
+			audit_event = $5, audit_event_id = $6, audit_extra = $7, updated_at = NOW()
+		WHERE id = $8`
+	if _, err := tx.Exec(ctx, updateTriggerSource,
+		a.SourceType, a.TriggeredBy, a.Attribution, resolveAttempts,
+		nullIfEmpty(a.AuditEvent), a.AuditEventID, toJSONB(a.AuditExtra), triggerSourceID); err != nil {
+		return errors.Wrap(scheduler.EntityRunAttribution, "error while updating run trigger source", err)
+	}
+
+	updateOperatorRun := "UPDATE " + operatorTableName + " SET run_type = $1, triggered_by = $2, updated_at = NOW() where id = $3"
+	if _, err := tx.Exec(ctx, updateOperatorRun, a.RunType.String(), a.TriggeredBy, operatorRunID); err != nil {
+		return errors.Wrap(scheduler.EntityRunAttribution, "error while updating run attribution", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return errors.Wrap(scheduler.EntityRunAttribution, "error while committing resolution", err)
+	}
+	return nil
+}
+
+// GetTriggerSourceByOperatorRunID returns the recorded cause of a single operator run.
+func (o *OperatorRunRepository) GetTriggerSourceByOperatorRunID(ctx context.Context, operatorRunID uuid.UUID) (*scheduler.TriggerSource, error) {
+	query := `SELECT ` + triggerSourceColumns + ` FROM operator_run_trigger_source WHERE operator_run_id = $1`
+	var ts triggerSource
+	err := o.db.QueryRow(ctx, query, operatorRunID).Scan(
+		&ts.ID, &ts.OperatorRunID, &ts.OperatorType, &ts.JobRunID, &ts.SchedulerRunID,
+		&ts.SourceType, &ts.ReplayID, &ts.BackfillID, &ts.TriggeredBy, &ts.Attribution,
+		&ts.ResolveAttempts, &ts.AuditEvent, &ts.AuditEventID, &ts.AuditExtra)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, errors.NotFound(scheduler.EntityRunAttribution, "no trigger source for operator run "+operatorRunID.String())
+		}
+		return nil, errors.Wrap(scheduler.EntityRunAttribution, "error while getting run trigger source", err)
+	}
+	return ts.toTriggerSource(), nil
+}
+
+// CountPendingTriggerSourcesSince reports how many rows never reached a resolved attribution.
+// Exposed for monitoring: because nothing rescans pending rows, a rising count is the signal
+// that resolution is failing or being shed under load.
+func (o *OperatorRunRepository) CountPendingTriggerSourcesSince(ctx context.Context, since time.Time) (int, error) {
+	var count int
+	query := `SELECT COUNT(1) FROM operator_run_trigger_source WHERE attribution = $1 AND created_at > $2`
+	if err := o.db.QueryRow(ctx, query, scheduler.AttributionPending, since).Scan(&count); err != nil {
+		return 0, errors.Wrap(scheduler.EntityRunAttribution, "error while counting pending attributions", err)
+	}
+	return count, nil
 }
 
 func NewOperatorRunRepository(pool *pgxpool.Pool) *OperatorRunRepository {

--- a/internal/store/postgres/scheduler/job_operator_repository_test.go
+++ b/internal/store/postgres/scheduler/job_operator_repository_test.go
@@ -40,7 +40,7 @@ func TestPostgresJobOperatorRepository(t *testing.T) {
 			assert.Nil(t, err)
 
 			operatorRunRepo := postgres.NewOperatorRunRepository(db)
-			err = operatorRunRepo.CreateOperatorRun(ctx, "some-operator-name", scheduler.OperatorSensor, jobRun.ID, operatorStartTime)
+			_, err = operatorRunRepo.CreateOperatorRun(ctx, "some-operator-name", scheduler.OperatorSensor, jobRun.ID, operatorStartTime, scheduler.ScheduledAttribution(), 1)
 			assert.Nil(t, err)
 
 			operatorRun, err := operatorRunRepo.GetOperatorRun(ctx, "some-operator-name", scheduler.OperatorSensor, jobRun.ID)
@@ -93,7 +93,7 @@ func TestPostgresJobOperatorRepository(t *testing.T) {
 			assert.Nil(t, err)
 
 			operatorRunRepo := postgres.NewOperatorRunRepository(db)
-			err = operatorRunRepo.CreateOperatorRun(ctx, "some-operator-name", scheduler.OperatorTask, jobRun.ID, operatorStartTime)
+			_, err = operatorRunRepo.CreateOperatorRun(ctx, "some-operator-name", scheduler.OperatorTask, jobRun.ID, operatorStartTime, scheduler.ScheduledAttribution(), 1)
 			assert.Nil(t, err)
 
 			operatorRun, err := operatorRunRepo.GetOperatorRun(ctx, "some-operator-name", scheduler.OperatorTask, jobRun.ID)

--- a/internal/store/postgres/scheduler/job_operator_trigger_source_test.go
+++ b/internal/store/postgres/scheduler/job_operator_trigger_source_test.go
@@ -1,0 +1,353 @@
+//go:build !unit_test
+
+package scheduler_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/goto/optimus/core/scheduler"
+	"github.com/goto/optimus/core/tenant"
+	"github.com/goto/optimus/internal/errors"
+	"github.com/goto/optimus/internal/lib/interval"
+	postgres "github.com/goto/optimus/internal/store/postgres/scheduler"
+)
+
+func TestPostgresOperatorRunTriggerSource(t *testing.T) {
+	ctx := context.Background()
+	tnnt, _ := tenant.NewTenant("test-proj", "test-ns")
+	currentTime := time.Now().UTC()
+	scheduledAt := currentTime.Add(-time.Hour)
+	slaDefinitionInSec := int64(3600)
+	start := currentTime.Truncate(time.Hour * 24)
+	intr := interval.NewInterval(start, start.Add(time.Hour*24))
+
+	// newTaskRun creates a job run plus one task run and returns both ids, since a trigger source
+	// row is only meaningful against a real operator run.
+	newTaskRun := func(t *testing.T, db *pgxpool.Pool) (jobRunID, taskRunID uuid.UUID) {
+		t.Helper()
+		jobRunRepo := postgres.NewJobRunRepository(db, nil)
+		require.NoError(t, jobRunRepo.Create(ctx, tnnt, jobAName, scheduledAt, intr, slaDefinitionInSec))
+
+		jobRun, err := jobRunRepo.GetByScheduledAt(ctx, tnnt, jobAName, scheduledAt)
+		require.NoError(t, err)
+
+		operatorRunRepo := postgres.NewOperatorRunRepository(db)
+		taskRunID, err = operatorRunRepo.CreateOperatorRun(ctx, "a-task", scheduler.OperatorTask, jobRun.ID,
+			currentTime, scheduler.ScheduledAttribution(), 1)
+		require.NoError(t, err)
+		return jobRun.ID, taskRunID
+	}
+
+	t.Run("InsertTriggerSource", func(t *testing.T) {
+		t.Run("records a manual run awaiting resolution and reads it back", func(t *testing.T) {
+			db := dbSetup()
+			_ = addJobs(ctx, t, db)
+			jobRunID, taskRunID := newTaskRun(t, db)
+
+			repo := postgres.NewOperatorRunRepository(db)
+			id, err := repo.InsertTriggerSource(ctx, &scheduler.TriggerSource{
+				OperatorRunID:  taskRunID,
+				OperatorType:   scheduler.OperatorTask,
+				JobRunID:       jobRunID,
+				SchedulerRunID: "manual__2026-07-20T13:00:00+00:00",
+				Attribution: scheduler.RunAttribution{
+					RunType:     scheduler.RunTypeManual,
+					TriggeredBy: scheduler.TriggeredByUnidentified,
+					SourceType:  scheduler.SourceTypeManual,
+					Attribution: scheduler.AttributionPending,
+				},
+			})
+			require.NoError(t, err)
+			assert.NotEqual(t, uuid.Nil, id)
+
+			stored, err := repo.GetTriggerSourceByOperatorRunID(ctx, taskRunID)
+			require.NoError(t, err)
+			assert.Equal(t, taskRunID, stored.OperatorRunID)
+			assert.Equal(t, scheduler.OperatorTask, stored.OperatorType)
+			assert.Equal(t, jobRunID, stored.JobRunID)
+			assert.Equal(t, "manual__2026-07-20T13:00:00+00:00", stored.SchedulerRunID)
+			assert.Equal(t, scheduler.AttributionPending, stored.Attribution.Attribution)
+			assert.Nil(t, stored.Attribution.ReplayID)
+			assert.Nil(t, stored.Attribution.BackfillID)
+			// Absent audit detail must round trip as empty, not as an empty JSON string.
+			assert.Empty(t, stored.Attribution.AuditEvent)
+			assert.Nil(t, stored.Attribution.AuditEventID)
+		})
+
+		t.Run("is idempotent for the same operator run", func(t *testing.T) {
+			// A duplicated start event must update the existing row rather than add a second,
+			// which is what the unique index on operator_run_id enforces.
+			db := dbSetup()
+			_ = addJobs(ctx, t, db)
+			jobRunID, taskRunID := newTaskRun(t, db)
+
+			repo := postgres.NewOperatorRunRepository(db)
+			src := &scheduler.TriggerSource{
+				OperatorRunID: taskRunID,
+				OperatorType:  scheduler.OperatorTask,
+				JobRunID:      jobRunID,
+				Attribution: scheduler.RunAttribution{
+					RunType:     scheduler.RunTypeManual,
+					TriggeredBy: scheduler.TriggeredByUnidentified,
+					SourceType:  scheduler.SourceTypeManual,
+					Attribution: scheduler.AttributionPending,
+				},
+			}
+			first, err := repo.InsertTriggerSource(ctx, src)
+			require.NoError(t, err)
+
+			src.Attribution.TriggeredBy = "dave"
+			src.Attribution.Attribution = scheduler.AttributionAuditRunID
+			second, err := repo.InsertTriggerSource(ctx, src)
+			require.NoError(t, err)
+
+			assert.Equal(t, first, second, "the same operator run must keep one trigger source row")
+			stored, err := repo.GetTriggerSourceByOperatorRunID(ctx, taskRunID)
+			require.NoError(t, err)
+			assert.Equal(t, "dave", stored.Attribution.TriggeredBy)
+		})
+
+		t.Run("links a replay request", func(t *testing.T) {
+			db := dbSetup()
+			_ = addJobs(ctx, t, db)
+			jobRunID, taskRunID := newTaskRun(t, db)
+
+			replayRepo := postgres.NewReplayRepository(db)
+			replayConfig := scheduler.NewReplayConfig(scheduledAt.Add(-time.Hour), scheduledAt.Add(time.Hour),
+				true, map[string]string{}, "attribution test", "", "approval_id", "user_id")
+			replayID, err := replayRepo.RegisterReplay(ctx,
+				scheduler.NewReplayRequest(jobAName, tnnt, replayConfig, scheduler.ReplayStateCreated),
+				[]*scheduler.JobRunStatus{{ScheduledAt: scheduledAt, State: scheduler.StatePending}})
+			require.NoError(t, err)
+
+			repo := postgres.NewOperatorRunRepository(db)
+			_, err = repo.InsertTriggerSource(ctx, &scheduler.TriggerSource{
+				OperatorRunID: taskRunID,
+				OperatorType:  scheduler.OperatorTask,
+				JobRunID:      jobRunID,
+				Attribution: scheduler.RunAttribution{
+					RunType:     scheduler.RunTypeReplay,
+					TriggeredBy: "user_id",
+					SourceType:  scheduler.SourceTypeReplay,
+					Attribution: scheduler.AttributionOptimusReplay,
+					ReplayID:    &replayID,
+				},
+			})
+			require.NoError(t, err)
+
+			stored, err := repo.GetTriggerSourceByOperatorRunID(ctx, taskRunID)
+			require.NoError(t, err)
+			require.NotNil(t, stored.Attribution.ReplayID)
+			assert.Equal(t, replayID, *stored.Attribution.ReplayID)
+		})
+	})
+
+	t.Run("UpdateTriggerSourceResolution", func(t *testing.T) {
+		t.Run("replaces a pending row with the resolved actor", func(t *testing.T) {
+			db := dbSetup()
+			_ = addJobs(ctx, t, db)
+			jobRunID, taskRunID := newTaskRun(t, db)
+
+			repo := postgres.NewOperatorRunRepository(db)
+			id, err := repo.InsertTriggerSource(ctx, &scheduler.TriggerSource{
+				OperatorRunID: taskRunID,
+				OperatorType:  scheduler.OperatorTask,
+				JobRunID:      jobRunID,
+				Attribution: scheduler.RunAttribution{
+					RunType:     scheduler.RunTypeManual,
+					TriggeredBy: scheduler.TriggeredByUnidentified,
+					SourceType:  scheduler.SourceTypeManual,
+					Attribution: scheduler.AttributionPending,
+				},
+			})
+			require.NoError(t, err)
+
+			eventLogID := int64(42)
+			require.NoError(t, repo.UpdateTriggerSourceResolution(ctx, id, scheduler.OperatorTask, taskRunID,
+				scheduler.RunAttribution{
+					RunType:      scheduler.RunTypeManual,
+					TriggeredBy:  "dave",
+					SourceType:   scheduler.SourceTypeManual,
+					Attribution:  scheduler.AttributionAuditRunID,
+					AuditEvent:   "dagrun_clear",
+					AuditEventID: &eventLogID,
+					AuditExtra:   `{"rowid": "1234"}`,
+				}, 2))
+
+			stored, err := repo.GetTriggerSourceByOperatorRunID(ctx, taskRunID)
+			require.NoError(t, err)
+			assert.Equal(t, "dave", stored.Attribution.TriggeredBy)
+			assert.Equal(t, scheduler.AttributionAuditRunID, stored.Attribution.Attribution)
+			assert.Equal(t, "dagrun_clear", stored.Attribution.AuditEvent)
+			require.NotNil(t, stored.Attribution.AuditEventID)
+			assert.Equal(t, eventLogID, *stored.Attribution.AuditEventID)
+			assert.JSONEq(t, `{"rowid": "1234"}`, stored.Attribution.AuditExtra)
+			assert.Equal(t, 2, stored.ResolveAttempts)
+
+			// The whole point of merging this into the operator repository: task_run must carry the
+			// same verdict, written in the same transaction, since that is what consumers read.
+			operatorRun, err := repo.GetOperatorRun(ctx, "a-task", scheduler.OperatorTask, jobRunID)
+			require.NoError(t, err)
+			assert.Equal(t, scheduler.RunTypeManual, operatorRun.RunType)
+			assert.Equal(t, "dave", operatorRun.TriggeredBy)
+		})
+
+		t.Run("leaves both tables untouched when the operator type is invalid", func(t *testing.T) {
+			// Proves the two writes are atomic rather than sequential: a failure must not leave the
+			// trigger source naming an actor while task_run still says unidentified.
+			db := dbSetup()
+			_ = addJobs(ctx, t, db)
+			jobRunID, taskRunID := newTaskRun(t, db)
+
+			repo := postgres.NewOperatorRunRepository(db)
+			id, err := repo.InsertTriggerSource(ctx, &scheduler.TriggerSource{
+				OperatorRunID: taskRunID,
+				OperatorType:  scheduler.OperatorTask,
+				JobRunID:      jobRunID,
+				Attribution: scheduler.RunAttribution{
+					RunType:     scheduler.RunTypeManual,
+					TriggeredBy: scheduler.TriggeredByUnidentified,
+					SourceType:  scheduler.SourceTypeManual,
+					Attribution: scheduler.AttributionPending,
+				},
+			})
+			require.NoError(t, err)
+
+			err = repo.UpdateTriggerSourceResolution(ctx, id, scheduler.OperatorType("bogus"), taskRunID,
+				scheduler.RunAttribution{
+					RunType:     scheduler.RunTypeManual,
+					TriggeredBy: "dave",
+					SourceType:  scheduler.SourceTypeManual,
+					Attribution: scheduler.AttributionAuditRunID,
+				}, 1)
+			assert.Error(t, err)
+
+			stored, err := repo.GetTriggerSourceByOperatorRunID(ctx, taskRunID)
+			require.NoError(t, err)
+			assert.Equal(t, scheduler.TriggeredByUnidentified, stored.Attribution.TriggeredBy)
+			assert.Equal(t, scheduler.AttributionPending, stored.Attribution.Attribution)
+		})
+	})
+
+	t.Run("GetTriggerSourceByOperatorRunID", func(t *testing.T) {
+		t.Run("reports not found for a scheduled run", func(t *testing.T) {
+			// Scheduled runs deliberately have no trigger source row.
+			db := dbSetup()
+			_ = addJobs(ctx, t, db)
+			_, taskRunID := newTaskRun(t, db)
+
+			repo := postgres.NewOperatorRunRepository(db)
+			_, err := repo.GetTriggerSourceByOperatorRunID(ctx, taskRunID)
+			assert.True(t, errors.IsErrorType(err, errors.ErrNotFound))
+		})
+	})
+
+	t.Run("CountPendingTriggerSourcesSince", func(t *testing.T) {
+		t.Run("counts only rows that never resolved", func(t *testing.T) {
+			db := dbSetup()
+			_ = addJobs(ctx, t, db)
+			jobRunID, taskRunID := newTaskRun(t, db)
+
+			repo := postgres.NewOperatorRunRepository(db)
+			id, err := repo.InsertTriggerSource(ctx, &scheduler.TriggerSource{
+				OperatorRunID: taskRunID,
+				OperatorType:  scheduler.OperatorTask,
+				JobRunID:      jobRunID,
+				Attribution: scheduler.RunAttribution{
+					RunType:     scheduler.RunTypeManual,
+					TriggeredBy: scheduler.TriggeredByUnidentified,
+					SourceType:  scheduler.SourceTypeManual,
+					Attribution: scheduler.AttributionPending,
+				},
+			})
+			require.NoError(t, err)
+
+			since := currentTime.Add(-time.Hour)
+			count, err := repo.CountPendingTriggerSourcesSince(ctx, since)
+			require.NoError(t, err)
+			assert.Equal(t, 1, count)
+
+			require.NoError(t, repo.UpdateTriggerSourceResolution(ctx, id, scheduler.OperatorTask, taskRunID,
+				scheduler.RunAttribution{
+					RunType:     scheduler.RunTypeManual,
+					TriggeredBy: "dave",
+					SourceType:  scheduler.SourceTypeManual,
+					Attribution: scheduler.AttributionAuditRunID,
+				}, 1))
+
+			count, err = repo.CountPendingTriggerSourcesSince(ctx, since)
+			require.NoError(t, err)
+			assert.Zero(t, count)
+		})
+	})
+
+	t.Run("GetReplayAttributionByScheduledAt", func(t *testing.T) {
+		registerReplay := func(t *testing.T, db *pgxpool.Pool, state scheduler.ReplayState, userID string) uuid.UUID {
+			t.Helper()
+			replayRepo := postgres.NewReplayRepository(db)
+			replayConfig := scheduler.NewReplayConfig(scheduledAt.Add(-time.Hour), scheduledAt.Add(time.Hour),
+				true, map[string]string{}, "attribution test", "", "approval_"+userID, userID)
+			replayID, err := replayRepo.RegisterReplay(ctx,
+				scheduler.NewReplayRequest(jobAName, tnnt, replayConfig, state),
+				[]*scheduler.JobRunStatus{{ScheduledAt: scheduledAt, State: scheduler.StatePending}})
+			require.NoError(t, err)
+			return replayID
+		}
+
+		t.Run("finds an in-flight replay covering the scheduled time", func(t *testing.T) {
+			db := dbSetup()
+			_ = addJobs(ctx, t, db)
+			replayID := registerReplay(t, db, scheduler.ReplayStateInProgress, "alice")
+
+			replayRepo := postgres.NewReplayRepository(db)
+			gotID, gotUser, err := replayRepo.GetReplayAttributionByScheduledAt(ctx, tnnt, jobAName, scheduledAt)
+			require.NoError(t, err)
+			assert.Equal(t, replayID, gotID)
+			assert.Equal(t, "alice", gotUser)
+		})
+
+		t.Run("finds a replay that has been created but not yet started", func(t *testing.T) {
+			// ReplayWorker only moves the request to 'in progress' on its first loop iteration,
+			// so a run must still be attributable while the request is merely 'created'.
+			db := dbSetup()
+			_ = addJobs(ctx, t, db)
+			replayID := registerReplay(t, db, scheduler.ReplayStateCreated, "bob")
+
+			replayRepo := postgres.NewReplayRepository(db)
+			gotID, gotUser, err := replayRepo.GetReplayAttributionByScheduledAt(ctx, tnnt, jobAName, scheduledAt)
+			require.NoError(t, err)
+			assert.Equal(t, replayID, gotID)
+			assert.Equal(t, "bob", gotUser)
+		})
+
+		t.Run("ignores a finished replay so a later scheduled run is not blamed on it", func(t *testing.T) {
+			db := dbSetup()
+			_ = addJobs(ctx, t, db)
+			replayID := registerReplay(t, db, scheduler.ReplayStateCreated, "carol")
+
+			replayRepo := postgres.NewReplayRepository(db)
+			require.NoError(t, replayRepo.UpdateReplayStatus(ctx, replayID, scheduler.ReplayStateSuccess, "done"))
+
+			_, _, err := replayRepo.GetReplayAttributionByScheduledAt(ctx, tnnt, jobAName, scheduledAt)
+			assert.True(t, errors.IsErrorType(err, errors.ErrNotFound))
+		})
+
+		t.Run("ignores a replay whose window excludes the scheduled time", func(t *testing.T) {
+			db := dbSetup()
+			_ = addJobs(ctx, t, db)
+			_ = registerReplay(t, db, scheduler.ReplayStateInProgress, "dave")
+
+			replayRepo := postgres.NewReplayRepository(db)
+			outside := scheduledAt.Add(48 * time.Hour)
+			_, _, err := replayRepo.GetReplayAttributionByScheduledAt(ctx, tnnt, jobAName, outside)
+			assert.True(t, errors.IsErrorType(err, errors.ErrNotFound))
+		})
+	})
+}

--- a/internal/store/postgres/scheduler/job_run_repository.go
+++ b/internal/store/postgres/scheduler/job_run_repository.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	columnsToStore = `job_name, namespace_name, project_name, scheduled_at, start_time, end_time, window_start, window_end, status, sla_definition, sla_alert`
-	jobRunColumns  = `id, ` + columnsToStore + `, monitoring`
+	jobRunColumns  = `id, ` + columnsToStore + `, monitoring, scheduler_run_id`
 	dbTimeFormat   = "2006-01-02 15:04:05.000000+00"
 )
 
@@ -50,6 +50,9 @@ type jobRun struct {
 	UpdatedAt time.Time
 
 	Monitoring json.RawMessage
+	// SchedulerRunID is nullable: rows written before this column existed, and rows created
+	// from events whose payload carried no dag run id, leave it unset.
+	SchedulerRunID *string
 }
 
 func (j *jobRun) toJobRun() (*scheduler.JobRun, error) {
@@ -79,19 +82,25 @@ func (j *jobRun) toJobRun() (*scheduler.JobRun, error) {
 		windowEnd = &t2
 	}
 
+	var schedulerRunID string
+	if j.SchedulerRunID != nil {
+		schedulerRunID = *j.SchedulerRunID
+	}
+
 	return &scheduler.JobRun{
-		ID:            j.ID,
-		JobName:       scheduler.JobName(j.JobName),
-		Tenant:        t,
-		State:         state,
-		ScheduledAt:   j.ScheduledAt,
-		SLAAlert:      j.SLAAlert,
-		StartTime:     j.StartTime,
-		EndTime:       j.EndTime,
-		WindowStart:   windowStart,
-		WindowEnd:     windowEnd,
-		SLADefinition: j.SLADefinition,
-		Monitoring:    monitoring,
+		ID:             j.ID,
+		JobName:        scheduler.JobName(j.JobName),
+		Tenant:         t,
+		State:          state,
+		ScheduledAt:    j.ScheduledAt,
+		SLAAlert:       j.SLAAlert,
+		StartTime:      j.StartTime,
+		EndTime:        j.EndTime,
+		WindowStart:    windowStart,
+		WindowEnd:      windowEnd,
+		SLADefinition:  j.SLADefinition,
+		SchedulerRunID: schedulerRunID,
+		Monitoring:     monitoring,
 	}, nil
 }
 
@@ -100,7 +109,7 @@ func (j *JobRunRepository) GetByID(ctx context.Context, id scheduler.JobRunID) (
 	getJobRunByID := `SELECT ` + jobRunColumns + ` FROM job_run where id = $1`
 	err := j.db.QueryRow(ctx, getJobRunByID, id.UUID()).
 		Scan(&jr.ID, &jr.JobName, &jr.NamespaceName, &jr.ProjectName, &jr.ScheduledAt, &jr.StartTime, &jr.EndTime,
-			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring)
+			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.SchedulerRunID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, errors.NotFound(scheduler.EntityJobRun, "no record for job run id "+id.UUID().String())
@@ -119,7 +128,7 @@ func (j *JobRunRepository) GetLatestRun(ctx context.Context, project tenant.Proj
 	getLatestRun := fmt.Sprintf("SELECT %s, created_at FROM job_run j where project_name = $1 and job_name = $2 %s order by scheduled_at desc limit 1", jobRunColumns, stateClause)
 	err := j.db.QueryRow(ctx, getLatestRun, project, jobName).
 		Scan(&jr.ID, &jr.JobName, &jr.NamespaceName, &jr.ProjectName, &jr.ScheduledAt, &jr.StartTime, &jr.EndTime,
-			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.CreatedAt)
+			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.SchedulerRunID, &jr.CreatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, errors.NotFound(scheduler.EntityJobRun, "no record for job:"+jobName.String()+stateClause)
@@ -140,7 +149,7 @@ func (j *JobRunRepository) GetRunsByInterval(ctx context.Context, project tenant
 	for rows.Next() {
 		var jr jobRun
 		err := rows.Scan(&jr.ID, &jr.JobName, &jr.NamespaceName, &jr.ProjectName, &jr.ScheduledAt, &jr.StartTime, &jr.EndTime,
-			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring)
+			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.SchedulerRunID)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return []*scheduler.JobRun{}, nil
@@ -170,7 +179,7 @@ func (j *JobRunRepository) GetRunsByTimeRange(ctx context.Context, project tenan
 	for rows.Next() {
 		var jr jobRun
 		err := rows.Scan(&jr.ID, &jr.JobName, &jr.NamespaceName, &jr.ProjectName, &jr.ScheduledAt, &jr.StartTime, &jr.EndTime,
-			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.CreatedAt)
+			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.SchedulerRunID, &jr.CreatedAt)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return []*scheduler.JobRun{}, nil
@@ -192,7 +201,7 @@ func (j *JobRunRepository) GetByScheduledAt(ctx context.Context, t tenant.Tenant
 	getJobRunByScheduledAt := `SELECT ` + jobRunColumns + `, created_at FROM job_run j where project_name = $1 and namespace_name = $2 and job_name = $3 and scheduled_at = $4 order by created_at desc limit 1`
 	err := j.db.QueryRow(ctx, getJobRunByScheduledAt, t.ProjectName(), t.NamespaceName(), jobName, scheduledAt).
 		Scan(&jr.ID, &jr.JobName, &jr.NamespaceName, &jr.ProjectName, &jr.ScheduledAt, &jr.StartTime, &jr.EndTime,
-			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.CreatedAt)
+			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.SchedulerRunID, &jr.CreatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, errors.NotFound(scheduler.EntityJobRun, "no record for job:"+jobName.String()+" scheduled at: "+scheduledAt.String())
@@ -217,7 +226,7 @@ func (j *JobRunRepository) GetByScheduledTimes(ctx context.Context, t tenant.Ten
 	for rows.Next() {
 		var jr jobRun
 		err := rows.Scan(&jr.ID, &jr.JobName, &jr.NamespaceName, &jr.ProjectName, &jr.ScheduledAt, &jr.StartTime, &jr.EndTime,
-			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.CreatedAt)
+			&jr.WindowStart, &jr.WindowEnd, &jr.Status, &jr.SLADefinition, &jr.SLAAlert, &jr.Monitoring, &jr.SchedulerRunID, &jr.CreatedAt)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return nil, errors.NotFound(scheduler.EntityJobRun, "no record of job run :"+jobName.String()+" for schedule Times : "+strings.Join(scheduledTimesString, ", "))
@@ -456,6 +465,16 @@ func (j *JobRunRepository) Update(ctx context.Context, jobRunID uuid.UUID, endTi
 	updateJobRun := "update job_run set status = $1, end_time = $2, updated_at = NOW() where id = $3"
 	_, err := j.db.Exec(ctx, updateJobRun, status, endTime, jobRunID)
 	return errors.WrapIfErr(scheduler.EntityJobRun, "unable to update job run", err)
+}
+
+// UpdateSchedulerRunID records Airflow's dag run id against a job run. It is written after
+// the fact rather than at Create time because job_run rows are created lazily and keyed on
+// (project, job, scheduled_at), which means the same row can outlive a dag run that is
+// deleted and recreated. Callers only invoke this when the value actually differs.
+func (j *JobRunRepository) UpdateSchedulerRunID(ctx context.Context, jobRunID uuid.UUID, schedulerRunID string) error {
+	updateJobRun := "update job_run set scheduler_run_id = $1, updated_at = NOW() where id = $2"
+	_, err := j.db.Exec(ctx, updateJobRun, schedulerRunID, jobRunID)
+	return errors.WrapIfErr(scheduler.EntityJobRun, "unable to update job run scheduler run id", err)
 }
 
 func (j *JobRunRepository) UpdateSLA(ctx context.Context, jobName scheduler.JobName, projectName tenant.ProjectName, scheduleTimes []time.Time) error {

--- a/internal/store/postgres/scheduler/replay_repository.go
+++ b/internal/store/postgres/scheduler/replay_repository.go
@@ -266,6 +266,45 @@ func (r ReplayRepository) GetReplayJobConfig(ctx context.Context, jobTenant tena
 	return configs, nil
 }
 
+// GetReplayAttributionByScheduledAt finds the in-flight replay request, if any, responsible for
+// a run at the given scheduled time, and returns its id and the user who asked for it.
+//
+// Matching is on the replay's time window rather than on replay_run rows because a replay of an
+// already existing run clears it in place, leaving Airflow's dag run id untouched, so the run
+// id carries no evidence of the replay.
+//
+// Only non-terminal replays are considered, which is what stops an ordinary scheduled run from
+// being blamed on a long-finished replay whose window happens to contain its scheduled time.
+// This is safe against both ends of the replay lifecycle: ReplayWorker marks the request
+// 'in progress' at the top of its execution loop, before it issues any Airflow clear, and it
+// only marks the request terminal once every run has reached a terminal state. A scheduler
+// retry arriving after the replay has finished is still attributed correctly, by inheriting
+// from the previous attempt.
+func (r ReplayRepository) GetReplayAttributionByScheduledAt(ctx context.Context, jobTenant tenant.Tenant, jobName scheduler.JobName, scheduledAt time.Time) (uuid.UUID, string, error) {
+	getReplay := `SELECT id, user_id FROM replay_request
+		WHERE job_name=$1 AND namespace_name=$2 AND project_name=$3
+			AND start_time<=$4 AND $4<=end_time
+			AND status = ANY($5)
+		ORDER BY created_at DESC LIMIT 1`
+	var (
+		replayID uuid.UUID
+		userID   string
+	)
+	nonTerminal := make([]string, 0, len(scheduler.ReplayNonTerminalStates))
+	for _, state := range scheduler.ReplayNonTerminalStates {
+		nonTerminal = append(nonTerminal, state.String())
+	}
+	err := r.db.QueryRow(ctx, getReplay, jobName, jobTenant.NamespaceName(), jobTenant.ProjectName(), scheduledAt, nonTerminal).
+		Scan(&replayID, &userID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return uuid.Nil, "", errors.NotFound(scheduler.EntityReplay, "no in-flight replay covering scheduled time "+scheduledAt.String()+" for job "+jobName.String())
+		}
+		return uuid.Nil, "", errors.Wrap(scheduler.EntityReplay, "unable to get replay attribution", err)
+	}
+	return replayID, userID, nil
+}
+
 func (r ReplayRepository) GetReplayRunByScheduledAt(ctx context.Context, projectName tenant.ProjectName, jobName scheduler.JobName, scheduledAt time.Time) (*scheduler.ReplayWithRun, error) {
 	getReplayRunRequest := `
 	select rq.id, rq.job_name, rq.namespace_name, rq.project_name, rq.start_time,

--- a/server/optimus.go
+++ b/server/optimus.go
@@ -376,10 +376,18 @@ func (s *OptimusServer) setupHandlers() error {
 	s.cleanupFn = append(s.cleanupFn, closeBackfillScan)
 	go backfillWorker.ScanBackfillRequest(backfillScanContext)
 
+	// Decides why a task or hook run is executing and who is answerable for it. Attribution to
+	// Optimus's own replay and backfill requests is always active; the part that reads Airflow's
+	// audit log to attribute manual clears and triggers is gated by run_attribution.enabled.
+	runAttributionService := schedulerService.NewRunAttributionService(
+		s.logger, s.conf.RunAttribution, operatorRunRepository, replayRepository,
+		backfillRepo, newScheduler,
+	)
+
 	newJobRunService := schedulerService.NewJobRunService(
 		s.logger, jobProviderRepo, jobRunRepo, replayRepository, operatorRunRepository, slaRepository,
 		newScheduler, newPriorityResolver, jobInputCompiler, s.eventHandler, tProjectService,
-		s.conf.Features, autoSLADurationEstimatorService, backfillRepo,
+		s.conf.Features, autoSLADurationEstimatorService, backfillRepo, runAttributionService,
 	)
 
 	newSchedulerService := schedulerService.NewSchedulerService(newScheduler)

--- a/tests/bench/scheduler/operator_run_repo_test.go
+++ b/tests/bench/scheduler/operator_run_repo_test.go
@@ -90,7 +90,7 @@ func BenchmarkOperatorRunRepository(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			name := fmt.Sprintf("operator_for_test_%d", i)
-			actualError := schedulerOperatorRunRepo.CreateOperatorRun(ctx, name, serviceScheduler.OperatorTask, storedJobRun.ID, time.Now())
+			_, actualError := schedulerOperatorRunRepo.CreateOperatorRun(ctx, name, serviceScheduler.OperatorTask, storedJobRun.ID, time.Now(), serviceScheduler.ScheduledAttribution(), 1)
 			assert.NoError(b, actualError)
 		}
 	})
@@ -121,7 +121,7 @@ func BenchmarkOperatorRunRepository(b *testing.B) {
 		operatorRunNames := make([]string, maxNumberOfOperatorRuns)
 		for i := 0; i < maxNumberOfOperatorRuns; i++ {
 			name := fmt.Sprintf("operator_for_test_%d", i)
-			err = schedulerOperatorRunRepo.CreateOperatorRun(ctx, name, serviceScheduler.OperatorTask, storedJobRun.ID, time.Now())
+			_, err = schedulerOperatorRunRepo.CreateOperatorRun(ctx, name, serviceScheduler.OperatorTask, storedJobRun.ID, time.Now(), serviceScheduler.ScheduledAttribution(), 1)
 			assert.NoError(b, err)
 
 			operatorRunNames[i] = name
@@ -166,7 +166,7 @@ func BenchmarkOperatorRunRepository(b *testing.B) {
 		operatorStartTime := time.Now()
 		for i := 0; i < maxNumberOfOperatorRuns; i++ {
 			name := fmt.Sprintf("operator_for_test_%d", i)
-			err = schedulerOperatorRunRepo.CreateOperatorRun(ctx, name, serviceScheduler.OperatorTask, storedJobRun.ID, operatorStartTime)
+			_, err = schedulerOperatorRunRepo.CreateOperatorRun(ctx, name, serviceScheduler.OperatorTask, storedJobRun.ID, operatorStartTime, serviceScheduler.ScheduledAttribution(), 1)
 			assert.NoError(b, err)
 
 			operatorRunNames[i] = name


### PR DESCRIPTION
# Identify and attribute backfill-type job runs

## Why

A task run could happen for four different reasons and Optimus recorded all four identically. There was no
column saying which applied, and no link back to the request that caused it — so neither question the
requirement poses was answerable:

1. is this run happening because of a backfill-type trigger?
2. who triggered it?

Optimus-triggered replays and backfills are Guardian-approved and carry a real `user_id`. Runs started by
clearing or triggering a DAG in the Airflow UI were entirely unaudited.

## What this does

Classifies every task/hook run at start time and records the cause, plus a link back to the originating
`replay_request` or `backfill`.

**Migration `000086`**

```
job_run.scheduler_run_id                                -- Airflow dag run id
task_run / hook_run / sensor_run
  run_type      scheduled | replay | backfill | manual    DEFAULT 'scheduled'
  triggered_by  'scheduler' | '<username>' | 'unidentified_user'  DEFAULT 'scheduler'
  attempt       Airflow try_number                        DEFAULT 1
operator_run_trigger_source                              -- run → replay_id / backfill_id / actor
```

**Decision tree** — inline on the event path, local state only, first match wins:

```
1. previous attempt status == 'retried'       → scheduler retry: inherit previous verdict + links
   ── else `rerun` = a previous attempt exists ──
2. run id names a custom backfill
     and not rerun                            → backfill,  actor = backfill.user_id
     and rerun                                → manual,    actor from audit; backfill link kept,
                                                  requester NOT reused as the actor
3. scheduled_at ∈ a NON-TERMINAL replay window→ replay,    actor = replay_request.user_id
4. rerun, or run id starts with "manual__"    → manual,    actor from audit
5. otherwise                                  → scheduled
```

Two pieces of ordering carry weight:

- **Rule 3 outranks rule 4** because a replay *is* Optimus clearing an existing run, so a terminal previous
  attempt is the expected state there rather than evidence of a person.
- **Rule 2 splits on `rerun`** because Optimus never clears a backfill — it creates one dag run and only
  watches it. A further non-retry attempt therefore means a person acted, and the dag run id (which names
  the backfill forever) must not be used to name them.

**Actor resolution** for the manual cases reads Airflow's `GET /api/v1/eventLogs`, in a goroutine detached
from the event request — never inline, since `RegisterJobEvent` fires for every task instance of every DAG.

One dag-scoped query, then selection in code, strongest evidence first: a row naming our `run_id` (exact), a
row naming the DAG but no run (tied by the correlation window), then dag-less bulk actions (heuristic, re-runs
only). `run_id` is **not** a query filter — Airflow leaves it NULL for a plain Trigger DAG and for REST
clears, and `log` has no index on it anyway, so filtering dropped the commonest rows for no gain. The
`attribution` column always records which stage answered, so an exact fact is never confused with a guess.

Time correlation is reached **only for a re-run of an existing attempt**, since that is the only thing a bulk
clear can produce. A `manual__` run always has an audit row carrying `dag_id`, so it is either matched exactly
or left `unidentified` — never blamed on an unrelated clear.

## Notable design points

- **No new DAG deploy.** `dag_run.run_id` and `task_instance.attempt` were already in the event payload and
  already parsed — just never persisted. Entirely server-side.
- **Replay matched on non-terminal status, not a time lookback.** The worker sets `in progress` before
  issuing any Airflow clear and only goes terminal once all runs are terminal, so no lookback is needed and
  a finished replay can never be blamed for an unrelated scheduled run.
- **`singleflight`** collapses a cleared DAG's tasks into one audit lookup. The Airflow concurrency
  semaphore is acquired *inside* that closure, so collapsed waiters hold no slot — a separate
  `max_pending_resolves` bound guards goroutine count. Covered by a mutation-verified test: 8 tasks against
  1 Airflow slot must all resolve (under the wrong placement only 1 does).
- **Sensors are never classified.** A sensor start costs exactly what it did before this change — no
  previous-attempt read, no replay lookup, no trigger source row. Their columns exist only for schema
  symmetry across the three operator tables.
- **Deliberately not** reading Airflow's audit log from `__lib.py`. It would be simpler and would make bulk
  clears exact, but Airflow 3 removes metadata-DB access from task code and points at the REST API instead,
  so it would be rework at upgrade time.
- **One transaction** for the trigger source and the operator run row — `task_run` is what consumers read,
  so a partial write would leave the two disagreeing with nothing to reconcile them.

- **Re-running someone else's backfill no longer names them.** The dag run id keeps identifying the
  backfill forever, so a clear by a different person was being attributed to the original requester.
- **Retry inheritance now carries the `replay_id` / `backfill_id` link**, read back from the previous
  attempt's trigger source, instead of writing e.g. `run_type=replay` with a null `replay_id`.
- `ext/scheduler/airflow` shared `http.Client` had **no timeout** at all.
- `audit_extra` JSONB round-trip, and Airflow's `extra` is only conventionally JSON — unparseable values are
  wrapped rather than failing the insert.

## Rollout

`run_attribution.audit_resolution_enabled` — **default `false`**, gating the Airflow dependency only.
Replay/backfill attribution is a local DB lookup and is always active.

| | off (default) | on |
|---|---|---|
| replay / backfill attributed | ✅ | ✅ |
| manual run detected as manual | ✅ | ✅ |
| manual run's **actor** identified | ✗ `unidentified_user` | ✅ |
| calls Airflow | never | on manual clears/triggers |

Column defaults mean existing rows and ordinary runs read exactly as before.
