### PR TITLE
fix: retry failed Airflow→Optimus callbacks, guard against duplicate operator runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ coverage: ## print code coverage
 	go test -race -coverprofile coverage.txt -covermode=atomic ./... -tags=unit_test && go tool cover -html=coverage.txt
 
 lint:
-	golangci-lint run --fix
+	golangci-lint run --fix --config=".golangci.yml" --new-from-rev=HEAD~1 --max-same-issues=0 --max-issues-per-linter=0
 
 install: ## install required dependencies
 	@echo "> installing dependencies"

--- a/core/scheduler/service/job_run_service.go
+++ b/core/scheduler/service/job_run_service.go
@@ -1123,7 +1123,7 @@ func (s *JobRunService) createOperatorRunIfAbsent(ctx context.Context, event *sc
 	}
 
 	isRetry := existingOperatorRun != nil && existingOperatorRun.Status == scheduler.StateRetry
-	if err = s.createOperatorRun(ctx, event, operatorType); err != nil {
+	if err := s.createOperatorRun(ctx, event, operatorType); err != nil {
 		return isRetry, err
 	}
 	return isRetry, nil

--- a/core/scheduler/service/job_run_service.go
+++ b/core/scheduler/service/job_run_service.go
@@ -1109,6 +1109,19 @@ func (s *JobRunService) createOperatorRun(ctx context.Context, event *scheduler.
 	return err
 }
 
+// createOperatorRunIfAbsent skips a duplicate create on a redelivered start event -- same
+// reasoning as the TaskStartEvent/HookStartEvent case in UpdateJobState.
+func (s *JobRunService) createOperatorRunIfAbsent(ctx context.Context, event *scheduler.Event, operatorType scheduler.OperatorType) error {
+	existingOperatorRun, err := s.getExistingOperatorRun(ctx, event)
+	if err != nil {
+		return err
+	}
+	if existingOperatorRun != nil && existingOperatorRun.Status != scheduler.StateRetry {
+		return nil
+	}
+	return s.createOperatorRun(ctx, event, operatorType)
+}
+
 func (s *JobRunService) getOperatorRun(ctx context.Context, event *scheduler.Event, operatorType scheduler.OperatorType, jobRunID uuid.UUID) (*scheduler.OperatorRun, error) {
 	var operatorRun *scheduler.OperatorRun
 	operatorRun, err := s.operatorRunRepo.GetOperatorRun(ctx, event.OperatorName, operatorType, jobRunID)
@@ -1204,7 +1217,7 @@ func (s *JobRunService) UpdateJobState(ctx context.Context, event *scheduler.Eve
 	case scheduler.JobSuccessEvent, scheduler.JobFailureEvent:
 		return s.updateJobRun(ctx, event)
 	case scheduler.SensorStartEvent:
-		return s.createOperatorRun(ctx, event, scheduler.OperatorSensor)
+		return s.createOperatorRunIfAbsent(ctx, event, scheduler.OperatorSensor)
 	case scheduler.SensorSuccessEvent, scheduler.SensorRetryEvent, scheduler.SensorFailEvent:
 		return s.updateOperatorRun(ctx, event, scheduler.OperatorSensor)
 	case scheduler.TaskStartEvent, scheduler.HookStartEvent:
@@ -1213,9 +1226,13 @@ func (s *JobRunService) UpdateJobState(ctx context.Context, event *scheduler.Eve
 		if err != nil {
 			return err
 		}
-		err = s.createOperatorRun(ctx, event, event.EventContext.OperatorType)
-		if err != nil {
-			return err
+		// No row, or a retry-transitioned row, means a genuinely new try_number; anything else
+		// non-nil is a redelivered start event and must not create a duplicate row.
+		isNewAttempt := existingOperatorRun == nil || existingOperatorRun.Status == scheduler.StateRetry
+		if isNewAttempt {
+			if err := s.createOperatorRun(ctx, event, event.EventContext.OperatorType); err != nil {
+				return err
+			}
 		}
 		if existingOperatorRun != nil && existingOperatorRun.Status == scheduler.StateRetry {
 			return nil

--- a/core/scheduler/service/job_run_service.go
+++ b/core/scheduler/service/job_run_service.go
@@ -1111,15 +1111,22 @@ func (s *JobRunService) createOperatorRun(ctx context.Context, event *scheduler.
 
 // createOperatorRunIfAbsent skips a duplicate create on a redelivered start event -- same
 // reasoning as the TaskStartEvent/HookStartEvent case in UpdateJobState.
-func (s *JobRunService) createOperatorRunIfAbsent(ctx context.Context, event *scheduler.Event, operatorType scheduler.OperatorType) error {
+// Return isRetry (bool) and error
+func (s *JobRunService) createOperatorRunIfAbsent(ctx context.Context, event *scheduler.Event, operatorType scheduler.OperatorType) (bool, error) {
 	existingOperatorRun, err := s.getExistingOperatorRun(ctx, event)
 	if err != nil {
-		return err
+		return false, err
 	}
+	// If neither a new run nor a retry, treat as a duplicate event (skipped)
 	if existingOperatorRun != nil && existingOperatorRun.Status != scheduler.StateRetry {
-		return nil
+		return false, nil
 	}
-	return s.createOperatorRun(ctx, event, operatorType)
+
+	isRetry := existingOperatorRun != nil && existingOperatorRun.Status == scheduler.StateRetry
+	if err = s.createOperatorRun(ctx, event, operatorType); err != nil {
+		return isRetry, err
+	}
+	return isRetry, nil
 }
 
 func (s *JobRunService) getOperatorRun(ctx context.Context, event *scheduler.Event, operatorType scheduler.OperatorType, jobRunID uuid.UUID) (*scheduler.OperatorRun, error) {
@@ -1217,24 +1224,17 @@ func (s *JobRunService) UpdateJobState(ctx context.Context, event *scheduler.Eve
 	case scheduler.JobSuccessEvent, scheduler.JobFailureEvent:
 		return s.updateJobRun(ctx, event)
 	case scheduler.SensorStartEvent:
-		return s.createOperatorRunIfAbsent(ctx, event, scheduler.OperatorSensor)
+		_, err := s.createOperatorRunIfAbsent(ctx, event, scheduler.OperatorSensor)
+		return err
 	case scheduler.SensorSuccessEvent, scheduler.SensorRetryEvent, scheduler.SensorFailEvent:
 		return s.updateOperatorRun(ctx, event, scheduler.OperatorSensor)
 	case scheduler.TaskStartEvent, scheduler.HookStartEvent:
 
-		existingOperatorRun, err := s.getExistingOperatorRun(ctx, event)
+		isRetry, err := s.createOperatorRunIfAbsent(ctx, event, event.EventContext.OperatorType)
 		if err != nil {
 			return err
 		}
-		// No row, or a retry-transitioned row, means a genuinely new try_number; anything else
-		// non-nil is a redelivered start event and must not create a duplicate row.
-		isNewAttempt := existingOperatorRun == nil || existingOperatorRun.Status == scheduler.StateRetry
-		if isNewAttempt {
-			if err := s.createOperatorRun(ctx, event, event.EventContext.OperatorType); err != nil {
-				return err
-			}
-		}
-		if existingOperatorRun != nil && existingOperatorRun.Status == scheduler.StateRetry {
+		if isRetry {
 			return nil
 		}
 		return s.registerConfiguredSLA(ctx, event)

--- a/core/scheduler/service/job_run_service_test.go
+++ b/core/scheduler/service/job_run_service_test.go
@@ -523,23 +523,30 @@ func TestJobRunService(t *testing.T) {
 					},
 				}
 
-				jobRun := scheduler.JobRun{
-					ID:        uuid.New(),
-					JobName:   jobName,
-					Tenant:    tnnt,
-					StartTime: time.Now(),
+				// each subtest gets its own jobRun/jobRunRepo -- createOperatorRun mutates
+				// jobRun.State in place, so a shared pointer would make subtests order-dependent
+				newJobRunFixture := func() (*scheduler.JobRun, *mockJobRunRepository) {
+					jobRun := &scheduler.JobRun{
+						ID:        uuid.New(),
+						JobName:   jobName,
+						Tenant:    tnnt,
+						StartTime: time.Now(),
+					}
+					jobRunRepo := new(mockJobRunRepository)
+					jobRunRepo.On("GetByScheduledAt", ctx, tnnt, jobName, scheduledAtTimeStamp).Return(jobRun, nil)
+					jobRunRepo.On("UpdateState", ctx, jobRun.ID, scheduler.StateInProgress).Return(nil)
+					return jobRun, jobRunRepo
 				}
 
-				jobRunRepo := new(mockJobRunRepository)
-				jobRunRepo.On("GetByScheduledAt", ctx, tnnt, jobName, scheduledAtTimeStamp).Return(&jobRun, nil)
-				jobRunRepo.On("UpdateState", ctx, jobRun.ID, scheduler.StateInProgress).Return(nil)
-				defer jobRunRepo.AssertExpectations(t)
+				t.Run("should create a new operator run when none exists yet", func(t *testing.T) {
+					jobRun, jobRunRepo := newJobRunFixture()
+					defer jobRunRepo.AssertExpectations(t)
 
-				t.Run("should pass creating new operator run ", func(t *testing.T) {
 					operatorRunRepository := new(mockOperatorRunRepository)
 					operatorRunRepository.On("CreateOperatorRun", ctx, event.OperatorName, scheduler.OperatorTask, jobRun.ID, eventTime).Return(nil)
 
-					operatorRunRepository.On("GetOperatorRun", ctx, event.OperatorName, scheduler.OperatorTask, jobRun.ID).Return(&scheduler.OperatorRun{}, nil)
+					operatorRunRepository.On("GetOperatorRun", ctx, event.OperatorName, scheduler.OperatorTask, jobRun.ID).
+						Return(nil, errors.NotFound(scheduler.EntityEvent, "operator not found in db"))
 
 					defer operatorRunRepository.AssertExpectations(t)
 
@@ -561,6 +568,67 @@ func TestJobRunService(t *testing.T) {
 
 					runService := service.NewJobRunService(logger,
 						jobRepo, jobRunRepo, nil, operatorRunRepository, nil, nil, nil, nil, eventHandler, nil, feats, nil, nil)
+
+					err := runService.UpdateJobState(ctx, event)
+					assert.Nil(t, err)
+				})
+
+				// no CreateOperatorRun/HandleEvent/UpdateState mock -- an unexpected call fails loudly
+				t.Run("should skip creating a duplicate operator run when one already exists", func(t *testing.T) {
+					jobRun := &scheduler.JobRun{
+						ID:        uuid.New(),
+						JobName:   jobName,
+						Tenant:    tnnt,
+						StartTime: time.Now(),
+					}
+					jobRunRepo := new(mockJobRunRepository)
+					jobRunRepo.On("GetByScheduledAt", ctx, tnnt, jobName, scheduledAtTimeStamp).Return(jobRun, nil)
+					defer jobRunRepo.AssertExpectations(t)
+
+					operatorRunRepository := new(mockOperatorRunRepository)
+					operatorRunRepository.On("GetOperatorRun", ctx, event.OperatorName, scheduler.OperatorTask, jobRun.ID).
+						Return(&scheduler.OperatorRun{Status: scheduler.StateRunning}, nil)
+					defer operatorRunRepository.AssertExpectations(t)
+
+					eventHandler := newEventHandler(t)
+
+					job := scheduler.Job{
+						Name:   jobName,
+						Tenant: tnnt,
+						Task: &scheduler.Task{
+							Config: map[string]string{},
+						},
+					}
+
+					jobRepo := new(JobRepository)
+					jobRepo.On("GetJob", ctx, projName, jobName).
+						Return(&job, nil)
+
+					runService := service.NewJobRunService(logger,
+						jobRepo, jobRunRepo, nil, operatorRunRepository, nil, nil, nil, nil, eventHandler, nil, feats, nil, nil)
+
+					err := runService.UpdateJobState(ctx, event)
+					assert.Nil(t, err)
+				})
+
+				// a StateRetry row means a genuinely new try_number, and must still get a new row
+				t.Run("should still create a new operator run for a genuine retry attempt", func(t *testing.T) {
+					jobRun, jobRunRepo := newJobRunFixture()
+					defer jobRunRepo.AssertExpectations(t)
+
+					operatorRunRepository := new(mockOperatorRunRepository)
+					operatorRunRepository.On("GetOperatorRun", ctx, event.OperatorName, scheduler.OperatorTask, jobRun.ID).
+						Return(&scheduler.OperatorRun{Status: scheduler.StateRetry}, nil)
+					operatorRunRepository.On("CreateOperatorRun", ctx, event.OperatorName, scheduler.OperatorTask, jobRun.ID, eventTime).Return(nil)
+					defer operatorRunRepository.AssertExpectations(t)
+
+					eventHandler := newEventHandler(t)
+					eventHandler.On("HandleEvent", mock.Anything).Times(1)
+					defer eventHandler.AssertExpectations(t)
+
+					// nil jobRepo: SLA registration is skipped for a retry, so GetJob must not be called
+					runService := service.NewJobRunService(logger,
+						nil, jobRunRepo, nil, operatorRunRepository, nil, nil, nil, nil, eventHandler, nil, feats, nil, nil)
 
 					err := runService.UpdateJobState(ctx, event)
 					assert.Nil(t, err)

--- a/ext/scheduler/airflow/__lib.py
+++ b/ext/scheduler/airflow/__lib.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, asdict
 
 import pendulum
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 from airflow.configuration import conf
 from airflow.hooks.base import BaseHook
 from airflow.models import (Variable, XCom, TaskReschedule )
@@ -40,6 +42,9 @@ TIMESTAMP_MS_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 SCHEDULER_ERR_MSG = "scheduler_error"
 STARTUP_TIMEOUT_IN_SECS = int(Variable.get("startup_timeout_in_secs", default_var=2 * 60))
 OPTIMUS_REQUEST_TIMEOUT_IN_SECS = int(Variable.get("optimus_request_timeout_in_secs", default_var=5 * 60))
+
+OPTIMUS_REQUEST_RETRY_TOTAL = int(Variable.get("optimus_request_retry_total", default_var=3))
+OPTIMUS_REQUEST_RETRY_BACKOFF_FACTOR = float(Variable.get("optimus_request_retry_backoff_factor", default_var=2))
 
 # --- EVENT TYPES -----------------------------------
 OPERATOR_START_EVENT      = "operator_start"
@@ -156,6 +161,20 @@ def _raise_error_if_request_failed(response=None, method=None, url=None, body=No
 class OptimusAPIClient:
     def __init__(self, optimus_host):
         self.host = self._add_connection_adapter_if_absent(optimus_host)
+        self._session = self._build_session()
+
+    def _build_session(self):
+        retry = Retry(
+            total=OPTIMUS_REQUEST_RETRY_TOTAL,
+            backoff_factor=OPTIMUS_REQUEST_RETRY_BACKOFF_FACTOR,
+            status_forcelist=list(range(500, 600)),
+            allowed_methods=frozenset(["GET", "POST", "PUT"]),
+        )
+        session = requests.Session()
+        adapter = HTTPAdapter(max_retries=retry)
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+        return session
 
     def _add_connection_adapter_if_absent(self, host):
         if host.startswith("http://") or host.startswith("https://"):
@@ -169,7 +188,7 @@ class OptimusAPIClient:
             optimus_host=self.host,
             optimus_project=project_name,
         )
-        response = requests.get(url, params={
+        response = self._session.get(url, params={
             'scheduled_at': scheduled_at_str,
             'job_names':    job_name,
             'status':       "in progress",
@@ -199,7 +218,7 @@ class OptimusAPIClient:
             optimus_project=project_name,
             optimus_job=job_name,
         )
-        response = requests.get(url, params={
+        response = self._session.get(url, params={
             'start_date': start_date,
             'end_date': end_date,
             'downstream_project_name': downstream_project_name,
@@ -225,7 +244,7 @@ class OptimusAPIClient:
             }
 
         try:
-            response = requests.put(url, json=payload,
+            response = self._session.put(url, json=payload,
                                     timeout=OPTIMUS_REQUEST_TIMEOUT_IN_SECS)
             _raise_error_if_request_failed(response)
             return response.json()
@@ -246,13 +265,13 @@ class OptimusAPIClient:
             job_name=job_name,
             reference_time=scheduled_at,
         )
-        response = requests.get(url, timeout=OPTIMUS_REQUEST_TIMEOUT_IN_SECS)
+        response = self._session.get(url, timeout=OPTIMUS_REQUEST_TIMEOUT_IN_SECS)
         _raise_error_if_request_failed(response)
         return response.json()
 
 
     def get_job_run_input(self, execution_date: str, project_name: str, job_name: str, job_type: str, instance_name: str) -> dict:
-        response = requests.post(url="{}/api/v1beta1/project/{}/job/{}/run_input".format(self.host, project_name, job_name),
+        response = self._session.post(url="{}/api/v1beta1/project/{}/job/{}/run_input".format(self.host, project_name, job_name),
                       json={'scheduled_at': execution_date,
                             'instance_name': instance_name,
                             'instance_type': "TYPE_" + job_type.upper()}, timeout=OPTIMUS_REQUEST_TIMEOUT_IN_SECS)
@@ -265,7 +284,7 @@ class OptimusAPIClient:
             optimus_host=self.host,
             project_name=project,
             job_name=job)
-        response = requests.get(url, timeout=OPTIMUS_REQUEST_TIMEOUT_IN_SECS)
+        response = self._session.get(url, timeout=OPTIMUS_REQUEST_TIMEOUT_IN_SECS)
         _raise_error_if_request_failed(response)
         return response.json()
 
@@ -275,7 +294,7 @@ class OptimusAPIClient:
             namespace_name=namespace,
             project_name=project,
             job_name=job)
-        response = requests.get(url, timeout=OPTIMUS_REQUEST_TIMEOUT_IN_SECS)
+        response = self._session.get(url, timeout=OPTIMUS_REQUEST_TIMEOUT_IN_SECS)
         _raise_error_if_request_failed(response)
         return response.json()
 
@@ -289,7 +308,7 @@ class OptimusAPIClient:
         request_data = {
             "event": event
         }
-        response = requests.post(url, data=json.dumps(request_data), timeout=OPTIMUS_REQUEST_TIMEOUT_IN_SECS)
+        response = self._session.post(url, data=json.dumps(request_data), timeout=OPTIMUS_REQUEST_TIMEOUT_IN_SECS)
         _raise_error_if_request_failed(response)
         return response.json()
 


### PR DESCRIPTION
## Summary

- Every Airflow callback wrapper (`operator_start_event`, `operator_success_event`,
  `operator_retry_event`, `operator_failure_event`, `job_success_event`, `job_failure_event`)
  catches all exceptions and only `print(e)`s them, with no retry. A transient failure
  calling Optimus (pod restart, network blip, slow response) silently drops that event
  forever, while the task itself continues and succeeds normally — leaving Optimus state
  permanently diverged from Airflow with no trace beyond a task's own stdout log.
- `OptimusAPIClient` now sends every request through a `requests.Session` backed by a
  `urllib3.Retry` adapter: 3 attempts by default, exponential backoff (~2s/4s/8s), covering
  connection errors and all 5xx responses. Both are tunable via Airflow Variables
  (`optimus_request_retry_total`, `optimus_request_retry_backoff_factor`) following the
  existing `optimus_request_timeout_in_secs` pattern. `POST` is explicitly added to
  `allowed_methods`, since urllib3 doesn't retry it by default.
- Retrying a start-event callback exposed a latent gap: `TaskStartEvent`/`HookStartEvent`/
  `SensorStartEvent` always called `createOperatorRun` unconditionally, with no check for
  whether a row already existed. Operator tables (`task_run`/`hook_run`/`sensor_run`) have no
  unique constraint on `(job_run_id, name)`, so a redelivered start callback (the first
  attempt actually succeeded, only its HTTP response was lost) would insert a second row for
  the same attempt. Fixed by checking the existing row's status first: create when none
  exists yet, or when the existing one already transitioned to `StateRetry` (a genuinely new
  `try_number`); skip when a row exists in any other state (a redelivery, not a new attempt).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `python3 -m py_compile ext/scheduler/airflow/__lib.py` / `ast.parse` clean
- [x] `go test -race ./core/scheduler/...` and `./server/...` pass
- [x] New/updated `TestJobRunService` cases cover: create-on-first-attempt, skip-on-redelivery
      (no `CreateOperatorRun`/`UpdateState`/`HandleEvent` mocked, so an unexpected call fails
      loudly), and create-on-genuine-retry (`StateRetry` row still gets a new row)
- [ ] Manual: deploy to a non-prod Airflow, kill the Optimus callback endpoint briefly during
      a task run, confirm the retry recovers and no duplicate `task_run` row appears
- [ ] Note for reviewers: `__lib.py` is `go:embed`ded — this needs a binary/image rebuild, a
      re-sync to the DAGs bucket, and a pod restart to actually take effect, not just a merge